### PR TITLE
feat(workexec): CAP-004 + CAP-005 workorder promotion and execution lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@ngx-translate/http-loader": "^17.0.0",
         "express": "^5.1.0",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0"
+        "tslib": "^2.3.0",
+        "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@angular/build": "^21.1.5",
@@ -28,6 +29,7 @@
         "@angular/compiler-cli": "^21.1.0",
         "@types/express": "^5.0.1",
         "@types/node": "^20.17.19",
+        "@types/uuid": "^10.0.0",
         "jsdom": "^27.1.0",
         "typescript": "~5.9.2",
         "vitest": "^4.0.8"
@@ -4065,6 +4067,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.4",
@@ -8124,6 +8133,19 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-name": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "@ngx-translate/http-loader": "^17.0.0",
     "express": "^5.1.0",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "uuid": "^13.0.0"
   },
   "devDependencies": {
     "@angular/build": "^21.1.5",
@@ -44,6 +45,7 @@
     "@angular/compiler-cli": "^21.1.0",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",
+    "@types/uuid": "^10.0.0",
     "jsdom": "^27.1.0",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"

--- a/src/app/core/services/api-base.service.ts
+++ b/src/app/core/services/api-base.service.ts
@@ -28,8 +28,8 @@ export class ApiBaseService {
 
   constructor(private readonly http: HttpClient) {}
 
-  get<T>(path: string, params?: HttpParams): Observable<T> {
-    return this.http.get<T>(this.url(path), { params });
+  get<T>(path: string, params?: HttpParams, options?: ApiRequestOptions): Observable<T> {
+    return this.http.get<T>(this.url(path), { params, headers: this.toHeaders(options?.headers) });
   }
 
   post<T>(path: string, body: unknown, options?: ApiRequestOptions): Observable<T> {

--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -125,6 +125,7 @@ export interface EstimateItemResponse {
   taxCode?: string;
   productId?: string;
   serviceId?: string;
+  lineItemApprovalStatus?: 'APPROVED' | 'DECLINED' | string;
   createdAt?: string;
   updatedAt?: string;
 }

--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -200,6 +200,262 @@ export interface ApproveEstimateRequest {
   purchaseOrderNumber?: string;
 }
 
+// ── CAP-004: Workorder types (Stories 231, 230, 229, 228, 227, 226) ──────────
+
+export type WorkorderStatus =
+  | 'DRAFT'
+  | 'PLANNED'
+  | 'PENDING_ASSIGNMENT'
+  | 'ASSIGNED'
+  | 'IN_PROGRESS'
+  | 'ON_HOLD'
+  | 'PENDING_REVIEW'
+  | 'COMPLETED'
+  | 'INVOICED'
+  | 'CANCELLED'
+  | 'ARCHIVED';
+
+export type ChangeRequestStatus =
+  | 'AWAITING_ADVISOR_REVIEW'
+  | 'APPROVED'
+  | 'DECLINED'
+  | 'CANCELLED';
+
+/** operationId: promoteEstimateToWorkorder — response (201 or 409 with existingWorkorderId) */
+export interface WorkorderResponse {
+  id: string;
+  estimateId?: string;
+  customerId?: string;
+  shopId?: string;
+  vehicleId?: string;
+  status?: WorkorderStatus;
+  primaryTechnicianId?: string;
+  primaryTechnicianName?: string;
+  startedAt?: string;
+  completedAt?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  version?: number;
+  /** Present on 409 — id of the existing work order */
+  existingWorkorderId?: string;
+}
+
+/** operationId: getWorkorderDetail — rich composite response */
+export interface WorkorderDetailResponse {
+  id: string;
+  estimateId?: string;
+  status?: WorkorderStatus;
+  customerId?: string;
+  vehicleId?: string;
+  shopId?: string;
+  primaryTechnicianId?: string;
+  primaryTechnicianName?: string;
+  isStarted?: boolean;
+  startedAt?: string;
+  isInProgress?: boolean;
+  inProgressReason?: string;
+  completedAt?: string;
+  createdAt?: string;
+  version?: number;
+  items?: WorkorderItemResponse[];
+  technician?: TechnicianAssignmentResponse;
+  operationalContext?: OperationalContextResponse;
+}
+
+/** Workorder line items promoted from estimate */
+export interface WorkorderItemResponse {
+  id: string;
+  workorderId: string;
+  sourceEstimateItemId?: string;
+  itemType?: 'PART' | 'LABOR';
+  description?: string;
+  quantity?: number;
+  unitPrice?: number;
+  lineTotal?: number;
+  status?: string;
+}
+
+/** operationId: getTransitionHistory */
+export interface WorkorderTransition {
+  id?: string;
+  workorderId?: string;
+  fromStatus?: WorkorderStatus;
+  toStatus?: WorkorderStatus;
+  reason?: string;
+  actorUserId?: string;
+  message?: string;
+  transitionedAt?: string;
+}
+
+/** operationId: getOperationalContext */
+export interface OperationalContextResponse {
+  workorderId?: string;
+  version?: string;
+  shopId?: string;
+  technicianId?: string;
+  authorities?: string[];
+  startedAt?: string;
+}
+
+// ── CAP-004/005: Technician assignment (Stories 225, 231) ────────────────────
+
+export interface TechnicianAssignmentResponse {
+  workorderId?: string;
+  technicianId?: string;
+  technicianName?: string;
+  assignedAt?: string;
+  assignedBy?: string;
+  unassignedAt?: string;
+  reason?: string;
+}
+
+export interface AssignTechnicianRequest {
+  /** Required */
+  technicianId: string;
+  assignedByUserId?: string;
+  notes?: string;
+}
+
+// ── CAP-005: Workorder start/status (Story 224) ───────────────────────────────
+
+export interface WorkorderStartResponse {
+  workorderId?: string;
+  operationalContextVersion?: string;
+  workStartedAt?: string;
+  previousStatus?: WorkorderStatus;
+  currentStatus?: WorkorderStatus;
+  transitionedAt?: string;
+  message?: string;
+}
+
+// ── CAP-005: Labor (Story 223) ────────────────────────────────────────────────
+
+export interface StartLaborRequest {
+  technicianId?: string;
+  /** Service line item ID on the workorder */
+  workorderServiceId?: string;
+  startTime?: string;
+}
+
+export interface StopLaborRequest {
+  stopTime?: string;
+  notes?: string;
+}
+
+export interface CreateLaborPerformedRequest {
+  workorderId: string;
+  workorderServiceId?: string;
+  technicianId?: string;
+  startTime?: string;
+  endTime?: string;
+  hoursWorked?: number;
+  laborCode?: string;
+  description?: string;
+  flatRate?: boolean;
+}
+
+export interface WorkorderLaborEntryResponse {
+  id?: string;
+  workorderId?: string;
+  workorderServiceId?: string;
+  technicianId?: string;
+  startTime?: string;
+  endTime?: string;
+  hoursWorked?: number;
+  laborCode?: string;
+  description?: string;
+  flatRate?: boolean;
+  createdAt?: string;
+}
+
+// ── CAP-005: Parts (Stories 222, 221) ────────────────────────────────────────
+
+export interface IssuePartsRequest {
+  partId: string;
+  quantity: number;
+  workorderServiceId?: string;
+  notes?: string;
+}
+
+export interface ConsumePartsRequest {
+  partId: string;
+  quantity: number;
+  workorderServiceId?: string;
+}
+
+export interface ReturnPartsRequest {
+  partId: string;
+  quantity: number;
+  reason?: string;
+}
+
+export interface SubstitutePartRequest {
+  originalPartId: string;
+  substitutePartId: string;
+  reason?: string;
+}
+
+export interface PartUsageResponse {
+  id?: string;
+  workorderId?: string;
+  partId?: string;
+  quantityIssued?: number;
+  quantityConsumed?: number;
+  quantityReturned?: number;
+  workorderServiceId?: string;
+  issuedAt?: string;
+  consumedAt?: string;
+}
+
+export interface SubstituteLinkResponse {
+  id?: string;
+  productId?: string;
+  substitutePartId?: string;
+  substituteType?: 'EQUIVALENT' | 'APPROVED_ALTERNATIVE' | 'UPGRADE' | 'DOWNGRADE';
+  priority?: number;
+  active?: boolean;
+}
+
+// ── CAP-005: Change Requests (Story 220) ─────────────────────────────────────
+
+export interface ChangeRequestItemRequest {
+  type: 'SERVICE' | 'PART';
+  serviceId?: string;
+  partId?: string;
+  quantity?: number;
+  isEmergency?: boolean;
+  emergencyReason?: string;
+}
+
+export interface CreateChangeRequestRequest {
+  description: string;
+  requestedItems: ChangeRequestItemRequest[];
+}
+
+export interface ChangeRequestResponse {
+  id: string;
+  workorderId?: string;
+  description?: string;
+  status?: ChangeRequestStatus;
+  createdAt?: string;
+  createdBy?: string;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  requestedItems?: ChangeRequestItemResponse[];
+}
+
+export interface ChangeRequestItemResponse {
+  id?: string;
+  changeRequestId?: string;
+  type?: 'SERVICE' | 'PART';
+  serviceId?: string;
+  partId?: string;
+  quantity?: number;
+  isEmergency?: boolean;
+  emergencyReason?: string;
+  status?: string;
+}
+
 // ── UI state types ────────────────────────────────────────────────────────────
 
 export type PageState = 'idle' | 'loading' | 'ready' | 'saving' | 'success' | 'error' | 'access-denied' | 'expired';

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.css
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.css
@@ -35,3 +35,14 @@
 .btn-link { background: none; border: none; cursor: pointer; color: var(--brand-primary); font-size: inherit; padding: 0; text-decoration: underline; }
 @media (max-width: 1023px) { .estimate-workspace { grid-template-columns: 1fr; } .workspace-sidebar { position: static; } }
 @media (max-width: 767px) { .estimate-detail { padding: var(--space-4, 1rem); } }
+/* CAP-004: Promotion CTA styles (Stories 231, 228, 227) */
+.btn--promote { background: linear-gradient(135deg,#006a62,#00897b); color: #fff; margin-top: var(--space-3, 0.75rem); border: none; }
+.btn--promote:disabled { opacity: 0.5; cursor: not-allowed; }
+.partial-scope-note { background: color-mix(in srgb, var(--functional-warning,#e6a540) 10%, transparent); border-radius: 0.125rem; padding: var(--space-3, 0.75rem); margin-top: var(--space-3, 0.75rem); font-size: 0.8125rem; }
+.partial-scope-note__title { font-weight: 700; margin: 0 0 var(--space-1); color: var(--functional-warning, #b46e00); }
+.partial-scope-note__body { margin: 0 0 var(--space-1); color: var(--currentTextColor); }
+.partial-scope-note__detail summary { cursor: pointer; color: var(--brand-primary); font-size: 0.8rem; }
+.partial-scope-note__item { margin: var(--space-1) 0 0 var(--space-3); font-size: 0.8rem; color: var(--handleColor); }
+.promote-conflict { margin-top: var(--space-3, 0.75rem); display: flex; flex-direction: column; gap: var(--space-1); }
+.promote-error { margin-top: var(--space-3, 0.75rem); }
+.promote-hint { margin-top: var(--space-3, 0.75rem); }

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.html
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.html
@@ -102,6 +102,66 @@
         >
           Submit for Approval
         </button>
+
+        <!-- CAP-004: Promote to Work Order (Stories 231, 228, 227) -->
+        @if (estimate()!.status === 'APPROVED') {
+
+          <!-- Story 227: Partial scope warning before promotion -->
+          @if (showPartialScope()) {
+            <div class="partial-scope-note" role="note" aria-label="Partial approval scope">
+              <p class="partial-scope-note__title">Partial Approval</p>
+              <p class="partial-scope-note__body">
+                {{ approvedItems().length }} item(s) approved for promotion.
+                {{ declinedItems().length }} item(s) were declined and will not be included in the work order.
+              </p>
+              <details class="partial-scope-note__detail">
+                <summary>Show excluded items</summary>
+                @for (item of declinedItems(); track item.id) {
+                  <p class="partial-scope-note__item">— {{ item.description }} ({{ item.itemType }})</p>
+                }
+              </details>
+            </div>
+          }
+
+          <!-- Story 228: 409 conflict state — existing workorder -->
+          @if (promoteState() === 'conflict') {
+            <div class="alert alert--warn promote-conflict" role="alert">
+              A work order already exists for this estimate.
+              @if (conflictWorkorderId()) {
+                <button class="btn-link" (click)="navigateToConflictWorkorder()">
+                  View existing work order →
+                </button>
+              }
+              <button class="btn-link" (click)="resetPromoteState()">Dismiss</button>
+            </div>
+          }
+
+          <!-- Story 228: 5xx / network error — safe-retry guidance -->
+          @if (promoteState() === 'error') {
+            <div class="alert alert--error promote-error" role="alert">
+              {{ promoteError() }}
+              <button class="btn-link" (click)="resetPromoteState()">Try again</button>
+            </div>
+          }
+
+          <!-- Story 231: Promote CTA — disabled during loading and after conflict/success -->
+          @if (promoteState() !== 'conflict' && promoteState() !== 'success') {
+            <button
+              class="btn btn--promote btn--full"
+              (click)="promoteToWorkorder()"
+              [disabled]="promoteState() === 'loading' || promoteState() === 'error'"
+              [attr.aria-busy]="promoteState() === 'loading'"
+              [attr.aria-disabled]="promoteState() !== 'idle'"
+            >
+              {{ promoteState() === 'loading' ? 'Creating Work Order…' : 'Promote to Work Order' }}
+            </button>
+          }
+
+        } @else if (estimate()!.status !== 'DRAFT') {
+          <p class="hint-text promote-hint">
+            Promotion requires customer approval. Current status: {{ estimate()!.status }}.
+          </p>
+        }
       </aside>
 
     </div>

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -149,8 +149,8 @@ export class EstimateDetailPageComponent implements OnInit {
   private buildApprovalScope(est: EstimateResponse): void {
     const allItems = est.items ?? [];
     if (est.status === 'APPROVED') {
-      const approved = allItems.filter(i => (i as any).lineItemApprovalStatus !== 'DECLINED');
-      const declined = allItems.filter(i => (i as any).lineItemApprovalStatus === 'DECLINED');
+      const approved = allItems.filter(i => i.lineItemApprovalStatus === 'APPROVED');
+      const declined = allItems.filter(i => i.lineItemApprovalStatus === 'DECLINED');
       this.approvedItems.set(approved);
       this.declinedItems.set(declined);
       this.showPartialScope.set(declined.length > 0);

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -4,17 +4,28 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
+import { v4 as uuidv4 } from 'uuid';
 import { WorkexecService } from '../../services/workexec.service';
-import { EstimateItemResponse, EstimateResponse, PageState, TotalsState } from '../../models/workexec.models';
+import {
+  EstimateItemResponse,
+  EstimateResponse,
+  PageState,
+  TotalsState,
+  WorkorderResponse,
+} from '../../models/workexec.models';
 
 /**
  * EstimateDetailPageComponent — Story 236 (CAP-002)
  * Route: /app/workexec/estimates/:estimateId
  * operationIds: calculateEstimateTotals, getEstimateById
  *
- * Displays the estimate workspace with inline totals panel.
- * Triggers calculateEstimateTotals on load and after item mutations.
- * Blocks Submit for Approval CTA when tax config is missing.
+ * CAP-004 additions:
+ *   Story 231 — Validate Promotion Preconditions: gate "Promote to Work Order" on
+ *               estimate status === 'APPROVED' and approved snapshot present.
+ *   Story 228 — Enforce Idempotent Promotion: Idempotency-Key header, disable on click,
+ *               409 → navigate to existing workorder, 5xx → safe-retry message.
+ *   Story 227 — Handle Partial Approval Promotion: display approved vs declined scope
+ *               before promotion confirm, show partialApproval summary post-promote.
  */
 @Component({
   selector: 'app-estimate-detail-page',
@@ -36,6 +47,17 @@ export class EstimateDetailPageComponent implements OnInit {
   readonly errorMessage = signal<string | null>(null);
   readonly taxBlocked   = signal(false);
 
+  // ── CAP-004: Promotion state (Stories 231, 228, 227) ─────────────────────
+  /** Promotion flow state machine */
+  readonly promoteState = signal<'idle' | 'loading' | 'conflict' | 'success' | 'error'>('idle');
+  readonly promoteError = signal<string | null>(null);
+  /** workorderId resolved on 409 conflict (Story 228) */
+  readonly conflictWorkorderId = signal<string | null>(null);
+  /** approved vs declined scope for partial promotion display (Story 227) */
+  readonly approvedItems = signal<EstimateItemResponse[]>([]);
+  readonly declinedItems = signal<EstimateItemResponse[]>([]);
+  readonly showPartialScope = signal(false);
+
   estimateId = '';
 
   private readonly recalcTrigger$ = new Subject<void>();
@@ -55,6 +77,7 @@ export class EstimateDetailPageComponent implements OnInit {
         this.items.set(est.items ?? []);
         this.totalsState.set('updated');
         this.taxBlocked.set(false);
+        this.buildApprovalScope(est);
       },
       error: err => {
         const code = err.error?.code ?? '';
@@ -80,6 +103,7 @@ export class EstimateDetailPageComponent implements OnInit {
           this.items.set(est.items ?? []);
           this.pageState.set('ready');
           this.recalcTrigger$.next();
+          this.buildApprovalScope(est);
         },
         error: err => {
           this.pageState.set('error');
@@ -108,5 +132,84 @@ export class EstimateDetailPageComponent implements OnInit {
   canSubmitForApproval(): boolean {
     const est = this.estimate();
     return est?.status === 'DRAFT' && !this.taxBlocked() && this.totalsState() !== 'blocked-config';
+  }
+
+  // ── CAP-004: Promotion logic ───────────────────────────────────────────────
+
+  /** Story 231: precondition check — APPROVED status required */
+  canPromote(): boolean {
+    const est = this.estimate();
+    return est?.status === 'APPROVED' && this.promoteState() === 'idle';
+  }
+
+  /**
+   * Story 227: Build approved vs declined item scope for partial-approval display.
+   * Items with lineItemApprovalStatus === 'APPROVED' are promoted; others are excluded.
+   */
+  private buildApprovalScope(est: EstimateResponse): void {
+    const allItems = est.items ?? [];
+    if (est.status === 'APPROVED') {
+      const approved = allItems.filter(i => (i as any).lineItemApprovalStatus !== 'DECLINED');
+      const declined = allItems.filter(i => (i as any).lineItemApprovalStatus === 'DECLINED');
+      this.approvedItems.set(approved);
+      this.declinedItems.set(declined);
+      this.showPartialScope.set(declined.length > 0);
+    }
+  }
+
+  /**
+   * Story 228 + 231: Promote to Work Order with Idempotency-Key.
+   * 409 → resolve existing workorderId and offer navigation.
+   * 5xx → safe-retry message.
+   */
+  promoteToWorkorder(): void {
+    if (!this.canPromote()) return;
+    this.promoteState.set('loading');
+    this.promoteError.set(null);
+    this.conflictWorkorderId.set(null);
+
+    const idempotencyKey = uuidv4();
+    this.workexec.promoteEstimateToWorkorder(this.estimateId, idempotencyKey)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result: WorkorderResponse) => {
+          this.promoteState.set('success');
+          this.router.navigate(['/app/workexec/workorders', result.id]);
+        },
+        error: (err) => {
+          const status = err?.status ?? 0;
+          if (status === 409) {
+            // Story 228: idempotent conflict — extract existing workorderId
+            const existingId: string | undefined =
+              err?.error?.existingWorkorderId ??
+              err?.error?.id ??
+              err?.error?.workorderId;
+            this.conflictWorkorderId.set(existingId ?? null);
+            this.promoteState.set('conflict');
+          } else if (status >= 500 || status === 0) {
+            // Story 228: safe-retry guidance for 5xx/network
+            this.promoteError.set(
+              'This action may have already succeeded. Check your work orders list before retrying to avoid creating a duplicate.',
+            );
+            this.promoteState.set('error');
+          } else {
+            this.promoteError.set(
+              err?.error?.message ?? 'Promotion failed. Please check the estimate status and try again.',
+            );
+            this.promoteState.set('error');
+          }
+        },
+      });
+  }
+
+  navigateToConflictWorkorder(): void {
+    const id = this.conflictWorkorderId();
+    if (id) this.router.navigate(['/app/workexec/workorders', id]);
+  }
+
+  resetPromoteState(): void {
+    this.promoteState.set('idle');
+    this.promoteError.set(null);
+    this.conflictWorkorderId.set(null);
   }
 }

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -154,6 +154,11 @@ export class EstimateDetailPageComponent implements OnInit {
       this.approvedItems.set(approved);
       this.declinedItems.set(declined);
       this.showPartialScope.set(declined.length > 0);
+    } else {
+      // Ensure no stale partial-approval UI state when estimate is not approved
+      this.approvedItems.set([]);
+      this.declinedItems.set([]);
+      this.showPartialScope.set(false);
     }
   }
 

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.css
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.css
@@ -1,0 +1,21 @@
+.workorder-assign {padding:var(--space-6) var(--space-5);}
+.back-btn {margin-bottom:var(--space-4);padding:var(--space-2) 0;font-size:0.875rem;}
+.page-header {margin-bottom:var(--space-5);}
+.page-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;opacity:0.55;margin:0 0 var(--space-1);}
+.page-header h1 {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.4rem;font-weight:700;margin:0;}
+.current-assignment {background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);padding:var(--space-4);margin-bottom:var(--space-5);}
+.section-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;margin:0 0 var(--space-2);}
+.assign-form {max-width:480px;display:flex;flex-direction:column;gap:var(--space-4);}
+.field {display:flex;flex-direction:column;gap:var(--space-1);}
+.field__label {font-size:0.8rem;font-weight:600;color:var(--currentTextColor,#1f2328);}
+.field__input {background:var(--cardBackground,#f6f8fa);border:none;border-bottom:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm) var(--radius-sm) 0 0;padding:var(--space-3);font-size:0.9rem;transition:border-color 0.15s;outline:none;}
+.field__input:focus {border-bottom:2px solid var(--brand-accent,#006a62);}
+.field__input--textarea {resize:vertical;min-height:80px;}
+.form-actions {display:flex;gap:var(--space-3);justify-content:flex-end;margin-top:var(--space-2);}
+.hint-text {font-size:0.875rem;opacity:0.55;font-style:italic;}
+.alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;}
+.alert--error {background:#ffebee;color:#c62828;}
+.btn {display:inline-flex;align-items:center;justify-content:center;padding:var(--space-2) var(--space-5);border-radius:var(--radius-md);font-size:0.875rem;font-weight:600;cursor:pointer;border:1px solid transparent;transition:opacity 0.15s;}
+.btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
+.btn--ghost {background:transparent;border:1px solid rgba(130,130,130,0.3);color:var(--currentTextColor,#1f2328);}

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
@@ -1,0 +1,65 @@
+<section class="workexec-page workorder-assign" aria-labelledby="assign-heading">
+
+  <button class="btn btn--ghost back-btn" (click)="cancel()">← Back to Work Order</button>
+
+  @if (pageState() === 'loading') { <p class="hint-text" aria-busy="true">Loading…</p> }
+  @if (pageState() === 'error') { <div class="alert alert--error" role="alert">{{ errorMessage() }}</div> }
+
+  @if (pageState() === 'ready') {
+    <header class="page-header">
+      <p class="page-overline">Work Order {{ workorderId() }}</p>
+      <h1 id="assign-heading">{{ formMode() === 'reassign' ? 'Reassign Technician' : 'Assign Technician' }}</h1>
+    </header>
+
+    @if (currentAssignment()) {
+      <div class="current-assignment" aria-label="Current technician assignment">
+        <p class="section-overline">Current Assignment</p>
+        <p><strong>{{ currentAssignment()!.technicianName ?? currentAssignment()!.technicianId }}</strong></p>
+        <p class="hint-text">Assigned {{ currentAssignment()!.assignedAt | date:'medium' }}</p>
+      </div>
+    }
+
+    <div class="assign-form">
+      <div class="field">
+        <label for="technicianId" class="field__label">Technician ID <span aria-hidden="true">*</span></label>
+        <input
+          id="technicianId"
+          class="field__input"
+          type="text"
+          [value]="technicianId()"
+          (input)="technicianId.set($any($event.target).value)"
+          placeholder="Enter technician UUID"
+          aria-required="true"
+        />
+      </div>
+      <div class="field">
+        <label for="assignNotes" class="field__label">Notes</label>
+        <textarea
+          id="assignNotes"
+          class="field__input field__input--textarea"
+          [value]="notes()"
+          (input)="notes.set($any($event.target).value)"
+          rows="3"
+          placeholder="Optional notes"
+        ></textarea>
+      </div>
+
+      @if (saveError()) {
+        <div class="alert alert--error" role="alert">{{ saveError() }}</div>
+      }
+
+      <div class="form-actions">
+        <button class="btn btn--ghost" (click)="cancel()" [disabled]="saveState() === 'loading'">Cancel</button>
+        <button
+          class="btn btn--accent"
+          (click)="save()"
+          [disabled]="saveState() === 'loading'"
+          [attr.aria-busy]="saveState() === 'loading'"
+        >
+          {{ saveState() === 'loading' ? 'Saving…' : (formMode() === 'reassign' ? 'Reassign' : 'Assign') }}
+        </button>
+      </div>
+    </div>
+  }
+
+</section>

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  AssignTechnicianRequest,
+  TechnicianAssignmentResponse,
+  WorkorderResponse,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+type FormMode = 'assign' | 'reassign';
+
+/**
+ * WorkorderAssignPageComponent — Story 225 (CAP-005)
+ * Route: /app/workexec/workorders/:workorderId/assign
+ * operationIds: assignTechnician, reassignTechnician, getTechnicianAssignment, getWorkorderById
+ */
+@Component({
+  selector: 'app-workorder-assign-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './workorder-assign-page.component.html',
+  styleUrl: './workorder-assign-page.component.css',
+})
+export class WorkorderAssignPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly workorder = signal<WorkorderResponse | null>(null);
+  readonly currentAssignment = signal<TechnicianAssignmentResponse | null>(null);
+  readonly errorMessage = signal<string | null>(null);
+  readonly saveState = signal<'idle' | 'loading' | 'success' | 'error'>('idle');
+  readonly saveError = signal<string | null>(null);
+
+  readonly technicianId = signal<string>('');
+  readonly notes = signal<string>('');
+
+  readonly formMode = signal<FormMode>('assign');
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadData(id);
+  }
+
+  private loadData(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getWorkorderById(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (wo) => {
+          this.workorder.set(wo);
+          if (wo.primaryTechnicianId) {
+            this.formMode.set('reassign');
+            this.loadCurrentAssignment(id);
+          } else {
+            this.pageState.set('ready');
+          }
+        },
+        error: () => {
+          this.errorMessage.set('Failed to load work order.');
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  private loadCurrentAssignment(id: string): void {
+    this.service
+      .getTechnicianAssignment(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (a) => {
+          this.currentAssignment.set(a);
+          this.pageState.set('ready');
+        },
+        error: () => this.pageState.set('ready'),
+      });
+  }
+
+  save(): void {
+    const id = this.workorderId();
+    const techId = this.technicianId().trim();
+    if (!techId) {
+      this.saveError.set('Technician ID is required.');
+      return;
+    }
+    const request: AssignTechnicianRequest = { technicianId: techId, notes: this.notes().trim() || undefined };
+    this.saveState.set('loading');
+    this.saveError.set(null);
+
+    const call$ =
+      this.formMode() === 'reassign'
+        ? this.service.reassignTechnician(id, request, uuidv4())
+        : this.service.assignTechnician(id, request, uuidv4());
+
+    call$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: () => {
+        this.saveState.set('success');
+        this.router.navigate(['/app/workexec/workorders', id]);
+      },
+      error: (err) => {
+        this.saveState.set('error');
+        this.saveError.set(
+          err?.error?.message ?? 'Failed to save technician assignment. Please try again.',
+        );
+      },
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId()]);
+  }
+}

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
@@ -1,0 +1,45 @@
+.workorder-change-requests {padding:var(--space-6) var(--space-5);}
+.back-btn {margin-bottom:var(--space-4);padding:var(--space-2) 0;font-size:0.875rem;}
+.page-header {margin-bottom:var(--space-5);}
+.page-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;opacity:0.55;margin:0 0 var(--space-1);}
+.page-header h1 {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.4rem;font-weight:700;margin:0;}
+.section-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;margin:0 0 var(--space-2);}
+.section-row {display:flex;align-items:center;justify-content:space-between;}
+.cr-header-row {display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-4);}
+.cr-form {background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-3);margin-bottom:var(--space-5);}
+.cr-items-section {display:flex;flex-direction:column;gap:var(--space-2);}
+.cr-item-row {display:flex;align-items:center;gap:var(--space-2);flex-wrap:wrap;}
+.cr-qty {width:70px;}
+.cr-emergency {display:flex;align-items:center;gap:var(--space-1);font-size:0.8rem;}
+.cr-card {padding:var(--space-4);border-radius:var(--radius-md);margin-bottom:var(--space-3);}
+.cr-card--alt {background:var(--cardBackground,#f6f8fa);}
+.cr-card__header {display:flex;align-items:center;gap:var(--space-3);flex-wrap:wrap;margin-bottom:var(--space-2);}
+.cr-id {font-size:0.75rem;font-family:monospace;opacity:0.6;word-break:break-all;}
+.cr-date {font-size:0.75rem;}
+.cr-card__description {font-size:0.9rem;margin:0 0 var(--space-2);}
+.cr-card__actions {margin-top:var(--space-3);display:flex;flex-direction:column;gap:var(--space-2);}
+.cr-notes {max-width:300px;}
+.action-btns {display:flex;gap:var(--space-2);}
+.field {display:flex;flex-direction:column;gap:var(--space-1);}
+.field__label {font-size:0.8rem;font-weight:600;}
+.field__input {background:rgba(255,255,255,0.8);border:none;border-bottom:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm) var(--radius-sm) 0 0;padding:var(--space-2) var(--space-3);font-size:0.875rem;outline:none;}
+.field__input:focus {border-bottom:2px solid var(--brand-accent,#006a62);}
+.field__input--textarea {resize:vertical;}
+.form-actions {display:flex;gap:var(--space-3);justify-content:flex-end;}
+.hint-text {font-size:0.875rem;opacity:0.55;font-style:italic;margin:0;}
+.alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;margin-bottom:var(--space-3);}
+.alert--error {background:#ffebee;color:#c62828;}
+.status-chip {display:inline-block;padding:2px 8px;border-radius:var(--radius-sm,4px);font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;}
+.status-chip--awaiting-advisor-review {background:#fff3e0;color:#e65100;}
+.status-chip--approved {background:#e8f5e9;color:#2e7d32;}
+.status-chip--declined {background:#ffebee;color:#c62828;}
+.status-chip--cancelled {background:#f5f5f5;color:#616161;}
+.btn {display:inline-flex;align-items:center;justify-content:center;padding:var(--space-2) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;font-weight:600;cursor:pointer;border:1px solid transparent;transition:opacity 0.15s;}
+.btn--sm {padding:var(--space-1) var(--space-3);font-size:0.8rem;}
+.btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
+.btn--ghost {background:transparent;border:1px solid rgba(130,130,130,0.3);color:var(--currentTextColor,#1f2328);}
+.btn--approve {background:#e8f5e9;color:#2e7d32;border:1px solid rgba(46,125,50,0.3);}
+.btn--decline {background:#ffebee;color:#c62828;border:1px solid rgba(198,40,40,0.3);}
+.btn--approve:disabled,.btn--decline:disabled {opacity:0.5;cursor:not-allowed;}
+.btn-icon {background:none;border:none;cursor:pointer;font-size:0.9rem;padding:var(--space-1);}

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
@@ -1,0 +1,104 @@
+<section class="workexec-page workorder-change-requests" aria-labelledby="cr-heading">
+
+  <button class="btn btn--ghost back-btn" (click)="back()">← Work Order</button>
+
+  @if (pageState() === 'loading') { <p class="hint-text" aria-busy="true">Loading change requests…</p> }
+  @if (pageState() === 'error') { <div class="alert alert--error" role="alert">{{ errorMessage() }}</div> }
+
+  @if (pageState() === 'ready') {
+    <header class="page-header">
+      <p class="page-overline">Work Order {{ workorderId() }}</p>
+      <h1 id="cr-heading">Change Requests</h1>
+    </header>
+
+    <div class="cr-header-row">
+      <p class="section-overline">Requests ({{ changeRequests().length }})</p>
+      <button class="btn btn--accent btn--sm" (click)="openCreateForm()">+ New Request</button>
+    </div>
+
+    <!-- Create form -->
+    @if (showCreateForm()) {
+      <div class="cr-form" role="form" aria-label="Create change request">
+        <div class="field">
+          <label class="field__label">Description <span aria-hidden="true">*</span></label>
+          <textarea class="field__input field__input--textarea" rows="3" [value]="crDescription()" (input)="crDescription.set($any($event.target).value)" placeholder="Describe the additional work needed…"></textarea>
+        </div>
+
+        <div class="cr-items-section">
+          <div class="section-row">
+            <p class="section-overline">Requested Items</p>
+            <button class="btn btn--ghost btn--sm" (click)="addItem()">+ Add Item</button>
+          </div>
+          @for (item of crItems(); track $index) {
+            <div class="cr-item-row">
+              <select class="field__input" [value]="item.type" (change)="updateItem($index, { type: $any($event.target).value })">
+                <option value="SERVICE">Service</option>
+                <option value="PART">Part</option>
+              </select>
+              <input class="field__input" type="text" [value]="item.serviceId ?? item.partId ?? ''" (input)="updateItem($index, item.type === 'SERVICE' ? { serviceId: $any($event.target).value } : { partId: $any($event.target).value })" placeholder="ID" />
+              <input class="field__input cr-qty" type="number" min="1" [value]="item.quantity" (input)="updateItem($index, { quantity: +$any($event.target).value })" />
+              <label class="cr-emergency">
+                <input type="checkbox" [checked]="item.isEmergency" (change)="updateItem($index, { isEmergency: $any($event.target).checked })" />
+                Emergency
+              </label>
+              <button class="btn-icon" (click)="removeItem($index)" aria-label="Remove item">✕</button>
+            </div>
+          }
+        </div>
+
+        @if (createError()) { <div class="alert alert--error" role="alert">{{ createError() }}</div> }
+        <div class="form-actions">
+          <button class="btn btn--ghost" (click)="showCreateForm.set(false)">Cancel</button>
+          <button class="btn btn--accent" (click)="submitCreate()" [attr.aria-busy]="createState() === 'loading'" [disabled]="createState() === 'loading'">
+            {{ createState() === 'loading' ? 'Submitting…' : 'Submit Request' }}
+          </button>
+        </div>
+      </div>
+    }
+
+    @if (resolveError()) {
+      <div class="alert alert--error" role="alert">{{ resolveError() }}</div>
+    }
+
+    <!-- Change request list -->
+    @if (changeRequests().length === 0) {
+      <p class="hint-text">No change requests for this work order.</p>
+    } @else {
+      @for (cr of changeRequests(); track cr.id; let even = $even) {
+        <div class="cr-card" [class.cr-card--alt]="even">
+          <div class="cr-card__header">
+            <span class="cr-id">{{ cr.id }}</span>
+            <span class="status-chip status-chip--{{ crStatusClass(cr.status) }}">{{ cr.status }}</span>
+            <span class="cr-date hint-text">{{ cr.createdAt | date:'shortDate' }}</span>
+          </div>
+          <p class="cr-card__description">{{ cr.description }}</p>
+          @if (cr.requestedItems && cr.requestedItems.length > 0) {
+            <p class="hint-text">{{ cr.requestedItems.length }} item(s) requested</p>
+          }
+          <!-- Approve/decline only for AWAITING_ADVISOR_REVIEW -->
+          @if (cr.status === 'AWAITING_ADVISOR_REVIEW') {
+            <div class="cr-card__actions">
+              <div class="field">
+                <label class="field__label">Notes</label>
+                <input class="field__input cr-notes" type="text" [value]="resolveNotes()" (input)="resolveNotes.set($any($event.target).value)" placeholder="Optional" />
+              </div>
+              <div class="action-btns">
+                <button
+                  class="btn btn--approve"
+                  (click)="approve(cr.id)"
+                  [disabled]="resolveState() === 'loading' && resolveId() === cr.id"
+                >Approve</button>
+                <button
+                  class="btn btn--decline"
+                  (click)="decline(cr.id)"
+                  [disabled]="resolveState() === 'loading' && resolveId() === cr.id"
+                >Decline</button>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    }
+  }
+
+</section>

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
@@ -31,7 +31,10 @@
           </div>
           @for (item of crItems(); track $index) {
             <div class="cr-item-row">
-              <select class="field__input" [value]="item.type" (change)="updateItem($index, { type: $any($event.target).value })">
+              <select
+                class="field__input"
+                [value]="item.type"
+                (change)="updateItem($index, $any($event.target).value === 'SERVICE' ? { type: 'SERVICE', partId: null } : { type: 'PART', serviceId: null })">
                 <option value="SERVICE">Service</option>
                 <option value="PART">Part</option>
               </select>

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.ts
@@ -1,0 +1,173 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  ChangeRequestItemRequest,
+  ChangeRequestResponse,
+  CreateChangeRequestRequest,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+
+/**
+ * WorkorderChangeRequestsPageComponent — Story 220 (CAP-005)
+ * Route: /app/workexec/workorders/:workorderId/change-requests
+ * operationIds: createChangeRequest, approveChangeRequest, declineChangeRequest,
+ *               getChangeRequestsByWorkorder, getChangeRequestById
+ */
+@Component({
+  selector: 'app-workorder-change-requests-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './workorder-change-requests-page.component.html',
+  styleUrl: './workorder-change-requests-page.component.css',
+})
+export class WorkorderChangeRequestsPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly changeRequests = signal<ChangeRequestResponse[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Create form */
+  readonly showCreateForm = signal(false);
+  readonly crDescription = signal<string>('');
+  readonly crItems = signal<ChangeRequestItemRequest[]>([]);
+  readonly createState = signal<'idle' | 'loading' | 'error'>('idle');
+  readonly createError = signal<string | null>(null);
+
+  /** Resolve (approve/decline) state */
+  readonly resolveId = signal<string | null>(null);
+  readonly resolveNotes = signal<string>('');
+  readonly resolveState = signal<'idle' | 'loading' | 'error'>('idle');
+  readonly resolveError = signal<string | null>(null);
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadChangeRequests(id);
+  }
+
+  loadChangeRequests(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getChangeRequestsByWorkorder(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (crs) => {
+          this.changeRequests.set(crs ?? []);
+          this.pageState.set('ready');
+        },
+        error: () => {
+          this.errorMessage.set('Failed to load change requests.');
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  openCreateForm(): void {
+    this.crDescription.set('');
+    this.crItems.set([]);
+    this.createError.set(null);
+    this.createState.set('idle');
+    this.showCreateForm.set(true);
+  }
+
+  addItem(): void {
+    this.crItems.update(items => [
+      ...items,
+      { type: 'SERVICE', serviceId: '', quantity: 1, isEmergency: false },
+    ]);
+  }
+
+  removeItem(index: number): void {
+    this.crItems.update(items => items.filter((_, i) => i !== index));
+  }
+
+  updateItem(index: number, partial: Partial<ChangeRequestItemRequest>): void {
+    this.crItems.update(items =>
+      items.map((item, i) => (i === index ? { ...item, ...partial } : item)),
+    );
+  }
+
+  submitCreate(): void {
+    const desc = this.crDescription().trim();
+    if (!desc) { this.createError.set('Description is required.'); return; }
+    this.createState.set('loading');
+    this.createError.set(null);
+    const request: CreateChangeRequestRequest = {
+      description: desc,
+      requestedItems: this.crItems(),
+    };
+    this.service
+      .createChangeRequest(this.workorderId(), request, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (cr) => {
+          this.changeRequests.update(list => [cr, ...list]);
+          this.createState.set('idle');
+          this.showCreateForm.set(false);
+        },
+        error: (err) => {
+          this.createState.set('error');
+          this.createError.set(err?.error?.message ?? 'Failed to create change request.');
+        },
+      });
+  }
+
+  approve(changeId: string): void {
+    this.resolveId.set(changeId);
+    this.resolveState.set('loading');
+    this.resolveError.set(null);
+    this.service
+      .approveChangeRequest(changeId, this.resolveNotes() || undefined, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.changeRequests.update(list => list.map(cr => (cr.id === changeId ? updated : cr)));
+          this.resolveState.set('idle');
+          this.resolveId.set(null);
+        },
+        error: (err) => {
+          this.resolveState.set('error');
+          this.resolveError.set(err?.error?.message ?? 'Failed to approve change request.');
+        },
+      });
+  }
+
+  decline(changeId: string): void {
+    this.resolveId.set(changeId);
+    this.resolveState.set('loading');
+    this.resolveError.set(null);
+    this.service
+      .declineChangeRequest(changeId, this.resolveNotes() || undefined, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (updated) => {
+          this.changeRequests.update(list => list.map(cr => (cr.id === changeId ? updated : cr)));
+          this.resolveState.set('idle');
+          this.resolveId.set(null);
+        },
+        error: (err) => {
+          this.resolveState.set('error');
+          this.resolveError.set(err?.error?.message ?? 'Failed to decline change request.');
+        },
+      });
+  }
+
+  back(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId()]);
+  }
+
+  crStatusClass(status?: string): string {
+    return (status ?? '').toLowerCase().replace(/_/g, '-');
+  }
+}

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.css
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.css
@@ -1,0 +1,79 @@
+/* WorkorderDetailPageComponent — design authority compliance */
+/* Blueprint-blue gradient header, Electric Teal CTAs, ledger tables, glassmorphism modal */
+
+.workorder-detail {padding:var(--space-6) var(--space-5);}
+
+/* Header — gradient per design authority: 135deg #0f3560 → #2b4c78, white text */
+.wo-header {background:linear-gradient(135deg,#0f3560,#2b4c78);border-radius:var(--radius-lg);padding:var(--space-5) var(--space-6);margin-bottom:var(--space-5);color:#fff;}
+.wo-header__inner {display:flex;flex-wrap:wrap;align-items:flex-start;gap:var(--space-4);}
+.wo-header__identity {flex:1 1 200px;display:flex;flex-direction:column;gap:var(--space-1);}
+.wo-header__overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;opacity:0.7;margin:0;}
+.wo-header__id {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.4rem;font-weight:700;margin:0;line-height:1.2;word-break:break-all;}
+.wo-header__meta {display:flex;flex-direction:column;gap:var(--space-2);flex:1 1 160px;}
+.wo-header__meta-item {display:flex;flex-direction:column;gap:2px;}
+.wo-header__meta-label {font-size:0.7rem;opacity:0.7;text-transform:uppercase;letter-spacing:0.05em;}
+.wo-header__meta-value {font-size:0.9rem;font-weight:600;}
+.wo-header__meta-value--empty {opacity:0.5;font-weight:400;font-style:italic;}
+.wo-header__actions {display:flex;flex-wrap:wrap;gap:var(--space-2);align-items:center;margin-left:auto;}
+.wo-header__actions .btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.wo-header__actions .btn--ghost {border:1px solid rgba(255,255,255,0.35);color:#fff;background:transparent;}
+.wo-header__actions .btn--ghost:hover {background:rgba(255,255,255,0.1);}
+
+/* Tab bar — 2px secondary bottom border indicator only, no box */
+.wo-tabs {display:flex;gap:0;border-bottom:1px solid rgba(var(--outline-variant-rgb,130,130,130),0.15);margin-bottom:var(--space-4);}
+.wo-tab {background:none;border:none;border-bottom:2px solid transparent;padding:var(--space-3) var(--space-4);font-size:0.875rem;font-weight:500;color:var(--currentTextColor,#1f2328);cursor:pointer;opacity:0.65;transition:opacity 0.15s,border-color 0.15s;}
+.wo-tab:hover {opacity:0.9;}
+.wo-tab--active {border-bottom:2px solid var(--brand-accent,#006a62);opacity:1;color:var(--brand-accent,#006a62);}
+
+/* Section container */
+.wo-section {padding:var(--space-4) 0;}
+.section-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;color:var(--currentTextColor,#1f2328);opacity:0.55;margin:0 0 var(--space-3);}
+
+/* Ledger — tonal alternation, no dividers per design authority */
+.ledger {width:100%;}
+.ledger__header {display:grid;grid-template-columns:3fr 1fr 1fr 1fr;gap:var(--space-3);padding:var(--space-2) var(--space-3);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;font-weight:600;}
+.ledger--audit .ledger__header {grid-template-columns:1fr 1fr 1fr 1fr 2fr;}
+.ledger__row {display:grid;grid-template-columns:3fr 1fr 1fr 1fr;gap:var(--space-3);padding:var(--space-3) var(--space-3);border-radius:var(--radius-sm);align-items:center;}
+.ledger--audit .ledger__row {grid-template-columns:1fr 1fr 1fr 1fr 2fr;}
+.ledger__row--alt {background:var(--cardBackground,#f6f8fa);}
+.ledger__cell {font-size:0.875rem;}
+.ledger__cell--desc {display:flex;align-items:center;gap:var(--space-2);}
+.ledger__cell--total {font-weight:600;}
+.ledger__type-badge {font-size:0.65rem;text-transform:uppercase;padding:2px 5px;border-radius:var(--radius-sm);background:var(--themeBackground,#eef1f5);opacity:0.7;}
+.ledger__type-badge--part {background:#e3f2fd;color:#0277bd;}
+.ledger__type-badge--labor {background:#e8f5e9;color:#2e7d32;}
+
+/* Audit section */
+.audit-origin {margin-bottom:var(--space-5);padding:var(--space-4);background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);}
+.audit-link {color:var(--brand-accent,#006a62);text-decoration:underline;}
+.audit-transitions {margin-top:var(--space-3);}
+.audit-toggle {font-size:0.875rem;cursor:pointer;color:var(--brand-accent,#006a62);background:none;border:none;padding:0;text-decoration:underline;}
+
+/* Status chips */
+.status-chip {display:inline-block;padding:2px 8px;border-radius:var(--radius-sm,4px);font-size:0.7rem;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;}
+.status-chip--in_progress {background:#e8f5e9;color:#2e7d32;}
+.status-chip--assigned {background:#e3f2fd;color:#0277bd;}
+.status-chip--pending_assignment {background:#fff3e0;color:#e65100;}
+.status-chip--draft {background:#f5f5f5;color:#616161;}
+.status-chip--completed {background:#e8f5e9;color:#1b5e20;}
+.status-chip--cancelled {background:#ffebee;color:#c62828;}
+.status-chip--on_hold {background:#fff8e1;color:#f57f17;}
+
+/* Glassmorphism modal — design authority spec */
+.modal-backdrop {position:fixed;inset:0;background:rgba(15,53,96,0.4);display:flex;align-items:center;justify-content:center;z-index:300;padding:var(--space-4);}
+.modal-glass {background:rgba(255,255,255,0.75);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-radius:var(--radius-xl,16px);padding:var(--space-7);max-width:480px;width:100%;box-shadow:0 8px 40px rgba(0,0,0,0.18);}
+.modal-glass__title {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.15rem;font-weight:700;margin:0 0 var(--space-3);}
+.modal-glass__body {font-size:0.9rem;line-height:1.5;margin:0 0 var(--space-5);}
+.modal-glass__actions {display:flex;gap:var(--space-3);justify-content:flex-end;}
+
+/* Shared utilities */
+.hint-text {opacity:0.55;font-size:0.875rem;font-style:italic;}
+.btn-link {background:none;border:none;cursor:pointer;padding:0;color:var(--brand-accent,#006a62);text-decoration:underline;font-size:inherit;}
+.alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);margin-bottom:var(--space-3);font-size:0.875rem;}
+.alert--error {background:#ffebee;color:#c62828;}
+.alert--warn {background:#fff8e1;color:#f57f17;}
+.btn {display:inline-flex;align-items:center;justify-content:center;gap:var(--space-2);padding:var(--space-2) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;font-weight:600;cursor:pointer;border:1px solid transparent;transition:opacity 0.15s,background 0.15s;}
+.btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
+.btn--ghost {background:transparent;border:1px solid rgba(var(--outline-variant-rgb,130,130,130),0.35);color:var(--currentTextColor,#1f2328);}
+.btn--full {width:100%;}

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
@@ -1,0 +1,215 @@
+<section class="workexec-page workorder-detail" aria-labelledby="wo-heading">
+
+  @if (pageState() === 'loading') {
+    <p class="hint-text" aria-busy="true">Loading work order…</p>
+  }
+
+  @if (pageState() === 'error') {
+    <div class="alert alert--error" role="alert">
+      {{ errorMessage() }}
+      <button class="btn-link" (click)="refresh()">Retry</button>
+    </div>
+  }
+
+  @if (pageState() === 'ready' && workorder()) {
+
+    <!-- Blueprint-blue gradient header per design authority -->
+    <header class="wo-header" aria-labelledby="wo-heading">
+      <div class="wo-header__inner">
+        <div class="wo-header__identity">
+          <p class="wo-header__overline">Work Order</p>
+          <h1 id="wo-heading" class="wo-header__id">{{ workorderId() }}</h1>
+          <span
+            class="status-chip status-chip--{{ workorder()!.status?.toLowerCase() }}"
+            aria-label="Status: {{ workorder()!.status }}"
+          >{{ workorder()!.status }}</span>
+        </div>
+
+        <div class="wo-header__meta">
+          @if (technicianName()) {
+            <p class="wo-header__meta-item">
+              <span class="wo-header__meta-label">Technician</span>
+              <span class="wo-header__meta-value">{{ technicianName() }}</span>
+            </p>
+          } @else {
+            <p class="wo-header__meta-item">
+              <span class="wo-header__meta-label">Technician</span>
+              <span class="wo-header__meta-value wo-header__meta-value--empty">Unassigned</span>
+            </p>
+          }
+          @if (workorder()!.startedAt) {
+            <p class="wo-header__meta-item">
+              <span class="wo-header__meta-label">Started</span>
+              <span class="wo-header__meta-value">{{ workorder()!.startedAt | date:'medium' }}</span>
+            </p>
+          }
+        </div>
+
+        <!-- Primary CTAs — Electric Teal only for positive primary action -->
+        <div class="wo-header__actions">
+          @if (canStartWork()) {
+            <button class="btn btn--accent" (click)="openStartWorkModal()">Start Work</button>
+          }
+          @if (isInProgress()) {
+            <button class="btn btn--ghost" (click)="navigateToLabor()">Record Labor</button>
+            <button class="btn btn--ghost" (click)="navigateToParts()">Manage Parts</button>
+            <button class="btn btn--ghost" (click)="navigateToChangeRequests()">Change Requests</button>
+          }
+          <button class="btn btn--ghost" (click)="navigateToAssign()">
+            {{ technicianName() ? 'Reassign' : 'Assign Technician' }}
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <!-- Tab bar — 2px secondary bottom indicator only, no box shadow -->
+    <nav class="wo-tabs" aria-label="Work order sections">
+      <button
+        class="wo-tab"
+        [class.wo-tab--active]="activeTab() === 'items'"
+        (click)="selectTab('items')"
+        aria-selected="{{ activeTab() === 'items' }}"
+      >Scope</button>
+      <button
+        class="wo-tab"
+        [class.wo-tab--active]="activeTab() === 'labor'"
+        (click)="navigateToLabor()"
+      >Labor</button>
+      <button
+        class="wo-tab"
+        [class.wo-tab--active]="activeTab() === 'parts'"
+        (click)="navigateToParts()"
+      >Parts</button>
+      <button
+        class="wo-tab"
+        [class.wo-tab--active]="activeTab() === 'change-requests'"
+        (click)="navigateToChangeRequests()"
+      >Change Requests</button>
+      <button
+        class="wo-tab"
+        [class.wo-tab--active]="activeTab() === 'audit'"
+        (click)="selectTab('audit')"
+      >Audit Trail</button>
+    </nav>
+
+    <!-- Scope/Items tab — Story 229 -->
+    @if (activeTab() === 'items') {
+      <div class="wo-section" aria-label="Work order scope">
+        @if (items().length === 0) {
+          <p class="hint-text">No items were promoted from the estimate.</p>
+        } @else {
+          <div class="ledger">
+            <div class="ledger__header">
+              <span>Description</span>
+              <span>Qty</span>
+              <span>Unit Price</span>
+              <span>Line Total</span>
+            </div>
+            @for (item of items(); track item.id; let even = $even) {
+              <div class="ledger__row" [class.ledger__row--alt]="even" [attr.aria-label]="item.description">
+                <span class="ledger__cell ledger__cell--desc">
+                  <span class="ledger__type-badge ledger__type-badge--{{ item.itemType?.toLowerCase() }}">{{ item.itemType }}</span>
+                  {{ item.description }}
+                </span>
+                <span class="ledger__cell">{{ item.quantity }}</span>
+                <span class="ledger__cell">{{ item.unitPrice | currency }}</span>
+                <span class="ledger__cell ledger__cell--total">{{ item.lineTotal | currency }}</span>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Audit trail tab — Story 226 -->
+    @if (activeTab() === 'audit') {
+      <div class="wo-section" aria-label="Promotion and transition audit trail">
+        @if (workorder()!.estimateId) {
+          <div class="audit-origin">
+            <p class="section-overline">Promoted From</p>
+            <p>
+              Estimate
+              <a [routerLink]="['/app/workexec/estimates', workorder()!.estimateId]" class="audit-link">
+                {{ workorder()!.estimateId }}
+              </a>
+            </p>
+          </div>
+        }
+
+        <div class="audit-transitions">
+          <button
+            class="audit-toggle btn-link"
+            (click)="auditExpanded.set(!auditExpanded())"
+            [attr.aria-expanded]="auditExpanded()"
+          >
+            {{ auditExpanded() ? 'Hide' : 'Show' }} Transition History ({{ transitions().length }})
+          </button>
+
+          @if (auditExpanded()) {
+            @if (transitions().length === 0) {
+              <p class="hint-text">No transitions recorded yet.</p>
+            } @else {
+              <div class="ledger ledger--audit">
+                <div class="ledger__header">
+                  <span>From</span>
+                  <span>To</span>
+                  <span>Actor</span>
+                  <span>When</span>
+                  <span>Reason</span>
+                </div>
+                @for (t of transitions(); track t.id; let even = $even) {
+                  <div class="ledger__row" [class.ledger__row--alt]="even">
+                    <span class="ledger__cell">
+                      <span class="status-chip status-chip--{{ t.fromStatus?.toLowerCase() }}">{{ t.fromStatus }}</span>
+                    </span>
+                    <span class="ledger__cell">
+                      <span class="status-chip status-chip--{{ t.toStatus?.toLowerCase() }}">{{ t.toStatus }}</span>
+                    </span>
+                    <span class="ledger__cell">{{ t.actorUserId }}</span>
+                    <span class="ledger__cell">{{ t.transitionedAt | date:'short' }}</span>
+                    <span class="ledger__cell">{{ t.reason ?? t.message ?? '—' }}</span>
+                  </div>
+                }
+              </div>
+            }
+          }
+        </div>
+      </div>
+    }
+
+  }
+
+</section>
+
+<!-- Start Work confirmation modal — glassmorphism per design authority -->
+@if (showStartWorkModal()) {
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-work-modal-title">
+    <div class="modal-glass">
+      <h2 id="start-work-modal-title" class="modal-glass__title">Start Work on {{ workorderId() }}?</h2>
+      <p class="modal-glass__body">
+        This will move the work order to <strong>IN PROGRESS</strong> and allow labor and parts recording.
+        This action cannot be undone from this screen.
+      </p>
+
+      @if (startWorkError()) {
+        <div class="alert alert--error" role="alert">{{ startWorkError() }}</div>
+      }
+
+      <div class="modal-glass__actions">
+        <button
+          class="btn btn--ghost"
+          (click)="cancelStartWork()"
+          [disabled]="startWorkLoading()"
+        >Cancel</button>
+        <button
+          class="btn btn--accent"
+          (click)="confirmStartWork()"
+          [disabled]="startWorkLoading()"
+          [attr.aria-busy]="startWorkLoading()"
+        >
+          {{ startWorkLoading() ? 'Starting…' : 'Confirm — Start Work' }}
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
@@ -1,0 +1,190 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  WorkorderDetailResponse,
+  WorkorderItemResponse,
+  WorkorderStartResponse,
+  WorkorderTransition,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+type WorkorderTab = 'items' | 'labor' | 'parts' | 'change-requests' | 'audit';
+
+/**
+ * WorkorderDetailPageComponent — Story 230 (hub scaffold),
+ * Stories 229 (items), 226 (audit trail), 224 (status CTAs), 219 (role visibility).
+ *
+ * Route: /app/workexec/workorders/:workorderId
+ *
+ * Design Authority directives applied:
+ *   - Blueprint-blue gradient header (135deg #0f3560 → #2b4c78) with white text
+ *   - Electric Teal CTAs (--brand-accent, btn btn--accent) for "Start Work" only
+ *   - Tab indicator: 2px secondary bottom-border, no box
+ *   - No dividers in item lists — tonal alternation via surface/surface-container-low
+ *   - Glassmorphism confirmation modal for Start Work (rgba + backdrop-filter blur)
+ *   - Status chip classes: status-chip status-chip--{status|lowercase}
+ */
+@Component({
+  selector: 'app-workorder-detail-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './workorder-detail-page.component.html',
+  styleUrl: './workorder-detail-page.component.css',
+})
+export class WorkorderDetailPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly workorder = signal<WorkorderDetailResponse | null>(null);
+  readonly transitions = signal<WorkorderTransition[]>([]);
+  readonly activeTab = signal<WorkorderTab>('items');
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Start Work confirmation modal */
+  readonly showStartWorkModal = signal(false);
+  readonly startWorkLoading = signal(false);
+  readonly startWorkError = signal<string | null>(null);
+  readonly startWorkResult = signal<WorkorderStartResponse | null>(null);
+
+  /** Audit trail expand/collapse */
+  readonly auditExpanded = signal(false);
+
+  readonly canStartWork = computed(() => {
+    const wo = this.workorder();
+    return wo?.status === 'ASSIGNED' || wo?.status === 'PENDING_ASSIGNMENT';
+  });
+
+  readonly isInProgress = computed(() => this.workorder()?.status === 'IN_PROGRESS');
+
+  readonly items = computed((): WorkorderItemResponse[] => this.workorder()?.items ?? []);
+
+  readonly technicianName = computed(() =>
+    this.workorder()?.primaryTechnicianName ??
+    this.workorder()?.technician?.technicianName ??
+    null,
+  );
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadWorkorder(id);
+  }
+
+  loadWorkorder(id: string): void {
+    this.pageState.set('loading');
+    this.errorMessage.set(null);
+    this.service
+      .getWorkorderDetail(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (detail) => {
+          this.workorder.set(detail);
+          this.pageState.set('ready');
+          if (this.activeTab() === 'audit') {
+            this.loadTransitions(id);
+          }
+        },
+        error: (err) => {
+          const status = err?.status ?? 0;
+          this.errorMessage.set(
+            status === 404
+              ? 'Work order not found.'
+              : status === 403
+                ? 'You do not have permission to view this work order.'
+                : 'Failed to load work order. Please try again.',
+          );
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  selectTab(tab: WorkorderTab): void {
+    this.activeTab.set(tab);
+    if (tab === 'audit' && this.transitions().length === 0) {
+      this.loadTransitions(this.workorderId());
+    }
+  }
+
+  private loadTransitions(id: string): void {
+    this.service
+      .getTransitionHistory(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (t) => this.transitions.set(t),
+        error: () => {
+          /* non-blocking: audit trail load failure is silent */
+        },
+      });
+  }
+
+  openStartWorkModal(): void {
+    this.startWorkError.set(null);
+    this.showStartWorkModal.set(true);
+  }
+
+  confirmStartWork(): void {
+    const id = this.workorderId();
+    this.startWorkLoading.set(true);
+    this.startWorkError.set(null);
+    this.service
+      .startWork(id, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.startWorkResult.set(result);
+          this.startWorkLoading.set(false);
+          this.showStartWorkModal.set(false);
+          this.loadWorkorder(id);
+        },
+        error: (err) => {
+          this.startWorkLoading.set(false);
+          const status = err?.status ?? 0;
+          this.startWorkError.set(
+            status === 409
+              ? 'Work has already been started for this work order.'
+              : 'Failed to start work. Please try again.',
+          );
+        },
+      });
+  }
+
+  cancelStartWork(): void {
+    this.showStartWorkModal.set(false);
+    this.startWorkError.set(null);
+  }
+
+  navigateToAssign(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'assign']);
+  }
+
+  navigateToLabor(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'labor']);
+  }
+
+  navigateToParts(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'parts']);
+  }
+
+  navigateToChangeRequests(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'change-requests']);
+  }
+
+  refresh(): void {
+    this.loadWorkorder(this.workorderId());
+  }
+}

--- a/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.css
+++ b/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.css
@@ -1,0 +1,34 @@
+.workorder-labor {padding:var(--space-6) var(--space-5);}
+.back-btn {margin-bottom:var(--space-4);padding:var(--space-2) 0;font-size:0.875rem;}
+.page-header {margin-bottom:var(--space-5);}
+.page-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;opacity:0.55;margin:0 0 var(--space-1);}
+.page-header h1 {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.4rem;font-weight:700;margin:0;}
+.section-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;margin:0 0 var(--space-2);}
+.session-panel {background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);padding:var(--space-4);margin-bottom:var(--space-5);}
+.session-active {display:flex;flex-direction:column;gap:var(--space-2);}
+.session-badge {display:inline-block;padding:2px 10px;border-radius:var(--radius-sm);background:#e8f5e9;color:#2e7d32;font-size:0.75rem;font-weight:700;}
+.session-start {display:flex;flex-wrap:wrap;gap:var(--space-3);align-items:flex-end;}
+.manual-entry-header {display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3);}
+.manual-form {background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-3);margin-bottom:var(--space-5);}
+.field-row {display:grid;grid-template-columns:1fr 1fr;gap:var(--space-3);}
+.field {display:flex;flex-direction:column;gap:var(--space-1);}
+.field--inline {flex-direction:row;align-items:center;gap:var(--space-2);}
+.field__label {font-size:0.8rem;font-weight:600;}
+.field__input {background:rgba(255,255,255,0.7);border:none;border-bottom:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm) var(--radius-sm) 0 0;padding:var(--space-2) var(--space-3);font-size:0.875rem;outline:none;}
+.field__input:focus {border-bottom:2px solid var(--brand-accent,#006a62);}
+.labor-history {margin-top:var(--space-5);}
+.ledger {}
+.ledger__header {display:grid;grid-template-columns:1fr 2fr 1fr 1fr 1fr;gap:var(--space-2);padding:var(--space-2) var(--space-3);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;font-weight:600;}
+.ledger__row {display:grid;grid-template-columns:1fr 2fr 1fr 1fr 1fr;gap:var(--space-2);padding:var(--space-3);border-radius:var(--radius-sm);align-items:center;}
+.ledger__row--alt {background:var(--cardBackground,#f6f8fa);}
+.ledger__cell {font-size:0.875rem;}
+.form-actions {display:flex;gap:var(--space-3);justify-content:flex-end;}
+.hint-text {font-size:0.875rem;opacity:0.55;font-style:italic;}
+.alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;}
+.alert--error {background:#ffebee;color:#c62828;}
+.btn {display:inline-flex;align-items:center;justify-content:center;padding:var(--space-2) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;font-weight:600;cursor:pointer;border:1px solid transparent;transition:opacity 0.15s;}
+.btn--sm {padding:var(--space-1) var(--space-3);font-size:0.8rem;}
+.btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
+.btn--ghost {background:transparent;border:1px solid rgba(130,130,130,0.3);color:var(--currentTextColor,#1f2328);}
+.btn--warn {background:#ffebee;color:#c62828;border:1px solid rgba(198,40,40,0.3);}

--- a/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.html
+++ b/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.html
@@ -1,0 +1,133 @@
+<section class="workexec-page workorder-labor" aria-labelledby="labor-heading">
+
+  <button class="btn btn--ghost back-btn" (click)="back()">← Work Order</button>
+
+  @if (pageState() === 'loading') { <p class="hint-text" aria-busy="true">Loading labor…</p> }
+  @if (pageState() === 'error') { <div class="alert alert--error" role="alert">{{ errorMessage() }}</div> }
+
+  @if (pageState() === 'ready') {
+    <header class="page-header">
+      <p class="page-overline">Work Order {{ workorderId() }}</p>
+      <h1 id="labor-heading">Labor</h1>
+    </header>
+
+    <!-- Session control -->
+    <div class="session-panel">
+      <p class="section-overline">Labor Session</p>
+
+      @if (sessionState() === 'active' && activeSession()) {
+        <div class="session-active" role="status" aria-live="polite">
+          <span class="session-badge">● Session Active</span>
+          <p class="hint-text">Started: {{ activeSession()!.startTime | date:'medium' }}</p>
+          <button
+            class="btn btn--warn"
+            (click)="stopSession()"
+            [attr.aria-busy]="sessionState() === 'stopping'"
+          >
+            {{ sessionState() === 'stopping' ? 'Stopping…' : 'Stop Session' }}
+          </button>
+        </div>
+      } @else {
+        <div class="session-start">
+          @if (serviceItems().length > 0) {
+            <select
+              class="field__input"
+              [value]="selectedServiceId()"
+              (change)="selectedServiceId.set($any($event.target).value)"
+              aria-label="Select service line"
+            >
+              <option value="">— Select service line —</option>
+              @for (item of serviceItems(); track item.id) {
+                <option [value]="item.id">{{ item.description }}</option>
+              }
+            </select>
+          }
+          <button
+            class="btn btn--accent"
+            (click)="startSession()"
+            [disabled]="sessionState() === 'starting'"
+            [attr.aria-busy]="sessionState() === 'starting'"
+          >
+            {{ sessionState() === 'starting' ? 'Starting…' : 'Start Session' }}
+          </button>
+        </div>
+        @if (sessionError()) {
+          <div class="alert alert--error" role="alert">{{ sessionError() }}</div>
+        }
+      }
+    </div>
+
+    <!-- Manual entry toggle -->
+    <div class="manual-entry-header">
+      <p class="section-overline">Manual Entry</p>
+      <button class="btn btn--ghost btn--sm" (click)="showManualForm.set(!showManualForm())">
+        {{ showManualForm() ? 'Close' : '+ Add Manual Entry' }}
+      </button>
+    </div>
+
+    @if (showManualForm()) {
+      <div class="manual-form">
+        <div class="field-row">
+          <div class="field">
+            <label class="field__label">Service Line</label>
+            <select class="field__input" [value]="manualServiceId()" (change)="manualServiceId.set($any($event.target).value)">
+              <option value="">— Optional —</option>
+              @for (item of serviceItems(); track item.id) {
+                <option [value]="item.id">{{ item.description }}</option>
+              }
+            </select>
+          </div>
+          <div class="field">
+            <label class="field__label">Labor Code</label>
+            <input class="field__input" type="text" [value]="manualLaborCode()" (input)="manualLaborCode.set($any($event.target).value)" placeholder="e.g. OIL-CHG" />
+          </div>
+        </div>
+        <div class="field">
+          <label class="field__label">Description</label>
+          <input class="field__input" type="text" [value]="manualDescription()" (input)="manualDescription.set($any($event.target).value)" />
+        </div>
+        <div class="field-row">
+          <div class="field">
+            <label class="field__label">Hours</label>
+            <input class="field__input" type="number" min="0.1" step="0.25" [value]="manualHours()" (input)="manualHours.set(+$any($event.target).value)" />
+          </div>
+          <div class="field field--inline">
+            <label class="field__label">Flat Rate</label>
+            <input type="checkbox" [checked]="manualFlatRate()" (change)="manualFlatRate.set($any($event.target).checked)" />
+          </div>
+        </div>
+        @if (manualError()) { <div class="alert alert--error" role="alert">{{ manualError() }}</div> }
+        <div class="form-actions">
+          <button class="btn btn--ghost" (click)="showManualForm.set(false)">Cancel</button>
+          <button class="btn btn--accent" (click)="submitManualEntry()" [attr.aria-busy]="manualState() === 'loading'" [disabled]="manualState() === 'loading'">
+            {{ manualState() === 'loading' ? 'Saving…' : 'Save Entry' }}
+          </button>
+        </div>
+      </div>
+    }
+
+    <!-- Labor history ledger -->
+    <div class="labor-history">
+      <p class="section-overline">History ({{ laborHistory().length }})</p>
+      @if (laborHistory().length === 0) {
+        <p class="hint-text">No labor recorded yet.</p>
+      } @else {
+        <div class="ledger">
+          <div class="ledger__header">
+            <span>Code</span><span>Description</span><span>Hours</span><span>Type</span><span>Recorded</span>
+          </div>
+          @for (entry of laborHistory(); track entry.id; let even = $even) {
+            <div class="ledger__row" [class.ledger__row--alt]="even">
+              <span class="ledger__cell">{{ entry.laborCode ?? '—' }}</span>
+              <span class="ledger__cell">{{ entry.description ?? '—' }}</span>
+              <span class="ledger__cell">{{ entry.hoursWorked ?? '—' }}</span>
+              <span class="ledger__cell">{{ entry.flatRate ? 'Flat' : 'Time' }}</span>
+              <span class="ledger__cell">{{ (entry.endTime ?? entry.startTime) | date:'short' }}</span>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+
+</section>

--- a/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.ts
@@ -1,0 +1,189 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  CreateLaborPerformedRequest,
+  StartLaborRequest,
+  WorkorderDetailResponse,
+  WorkorderItemResponse,
+  WorkorderLaborEntryResponse,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+
+/**
+ * WorkorderLaborPageComponent — Story 223 (CAP-005)
+ * Route: /app/workexec/workorders/:workorderId/labor
+ * operationIds: startLaborSession, stopLaborSession, createLaborPerformed, getLaborHistory
+ */
+@Component({
+  selector: 'app-workorder-labor-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './workorder-labor-page.component.html',
+  styleUrl: './workorder-labor-page.component.css',
+})
+export class WorkorderLaborPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly workorder = signal<WorkorderDetailResponse | null>(null);
+  readonly laborHistory = signal<WorkorderLaborEntryResponse[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Active labor session tracking */
+  readonly activeSession = signal<WorkorderLaborEntryResponse | null>(null);
+  readonly sessionState = signal<'idle' | 'starting' | 'active' | 'stopping' | 'error'>('idle');
+  readonly sessionError = signal<string | null>(null);
+
+  /** Manual labor entry form */
+  readonly showManualForm = signal(false);
+  readonly manualServiceId = signal<string>('');
+  readonly manualDescription = signal<string>('');
+  readonly manualHours = signal<number>(0);
+  readonly manualLaborCode = signal<string>('');
+  readonly manualFlatRate = signal<boolean>(false);
+  readonly manualState = signal<'idle' | 'loading' | 'error'>('idle');
+  readonly manualError = signal<string | null>(null);
+
+  /** Selected service line for session start */
+  readonly selectedServiceId = signal<string>('');
+
+  readonly serviceItems = computed(() =>
+    this.workorder()?.items?.filter(i => i.itemType === 'LABOR') ?? [],
+  );
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadData(id);
+  }
+
+  private loadData(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getWorkorderDetail(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (detail) => {
+          this.workorder.set(detail);
+          this.loadHistory(id);
+        },
+        error: () => {
+          this.errorMessage.set('Failed to load work order.');
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  private loadHistory(id: string): void {
+    this.service
+      .getLaborHistory(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (entries) => {
+          this.laborHistory.set(entries ?? []);
+          this.pageState.set('ready');
+        },
+        error: () => this.pageState.set('ready'),
+      });
+  }
+
+  startSession(): void {
+    const id = this.workorderId();
+    const serviceId = this.selectedServiceId();
+    if (!serviceId) {
+      this.sessionError.set('Select a labor service line to start a session.');
+      return;
+    }
+    this.sessionState.set('starting');
+    this.sessionError.set(null);
+    const request: StartLaborRequest = { workorderServiceId: serviceId };
+    this.service
+      .startLaborSession(id, serviceId, request, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (entry) => {
+          this.activeSession.set(entry);
+          this.sessionState.set('active');
+        },
+        error: (err) => {
+          this.sessionState.set('error');
+          this.sessionError.set(err?.error?.message ?? 'Failed to start labor session.');
+        },
+      });
+  }
+
+  stopSession(): void {
+    const session = this.activeSession();
+    if (!session?.id) return;
+    this.sessionState.set('stopping');
+    this.service
+      .stopLaborSession(this.workorderId(), session.id, { stopTime: new Date().toISOString() }, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (entry) => {
+          this.activeSession.set(null);
+          this.sessionState.set('idle');
+          this.laborHistory.update(h => [entry, ...h]);
+        },
+        error: (err) => {
+          this.sessionState.set('error');
+          this.sessionError.set(err?.error?.message ?? 'Failed to stop labor session.');
+        },
+      });
+  }
+
+  submitManualEntry(): void {
+    const id = this.workorderId();
+    if (this.manualHours() <= 0) {
+      this.manualError.set('Hours must be greater than 0.');
+      return;
+    }
+    this.manualState.set('loading');
+    this.manualError.set(null);
+    const request: CreateLaborPerformedRequest = {
+      workorderId: id,
+      workorderServiceId: this.manualServiceId() || undefined,
+      hoursWorked: this.manualHours(),
+      laborCode: this.manualLaborCode() || undefined,
+      description: this.manualDescription() || undefined,
+      flatRate: this.manualFlatRate(),
+    };
+    this.service
+      .createLaborPerformed(request, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (entry) => {
+          this.laborHistory.update(h => [entry, ...h]);
+          this.manualState.set('idle');
+          this.showManualForm.set(false);
+          this.resetManualForm();
+        },
+        error: (err) => {
+          this.manualState.set('error');
+          this.manualError.set(err?.error?.message ?? 'Failed to save labor entry.');
+        },
+      });
+  }
+
+  private resetManualForm(): void {
+    this.manualServiceId.set('');
+    this.manualDescription.set('');
+    this.manualHours.set(0);
+    this.manualLaborCode.set('');
+    this.manualFlatRate.set(false);
+  }
+
+  back(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId()]);
+  }
+}

--- a/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.css
+++ b/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.css
@@ -1,0 +1,46 @@
+.workorder-parts {padding:var(--space-6) var(--space-5);}
+.back-btn {margin-bottom:var(--space-4);padding:var(--space-2) 0;font-size:0.875rem;}
+.page-header {margin-bottom:var(--space-5);}
+.page-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.06em;opacity:0.55;margin:0 0 var(--space-1);}
+.page-header h1 {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.4rem;font-weight:700;margin:0;}
+.section-overline {font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;margin:0 0 var(--space-2);}
+.section-row {display:flex;align-items:center;justify-content:space-between;margin-bottom:var(--space-3);}
+.action-btns {display:flex;gap:var(--space-2);}
+.parts-scope {margin-bottom:var(--space-5);}
+.usage-history {margin-top:var(--space-5);}
+.ledger {}
+.ledger__header {display:grid;grid-template-columns:3fr 1fr 1fr 1fr;gap:var(--space-2);padding:var(--space-2) var(--space-3);font-size:0.7rem;text-transform:uppercase;letter-spacing:0.05em;opacity:0.55;font-weight:600;}
+.ledger__row {display:grid;grid-template-columns:3fr 1fr 1fr 1fr;gap:var(--space-2);padding:var(--space-3);border-radius:var(--radius-sm);align-items:center;}
+.ledger__row--alt {background:var(--cardBackground,#f6f8fa);}
+.ledger__cell {font-size:0.875rem;}
+.ledger__cell--actions {display:flex;gap:var(--space-2);}
+.usage-part-id {font-size:0.75rem;font-family:monospace;word-break:break-all;opacity:0.7;}
+.action-form {background:var(--cardBackground,#f6f8fa);border-radius:var(--radius-md);padding:var(--space-4);display:flex;flex-direction:column;gap:var(--space-3);margin-bottom:var(--space-5);}
+.field {display:flex;flex-direction:column;gap:var(--space-1);}
+.field__label {font-size:0.8rem;font-weight:600;}
+.field__input {background:rgba(255,255,255,0.7);border:none;border-bottom:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm) var(--radius-sm) 0 0;padding:var(--space-2) var(--space-3);font-size:0.875rem;outline:none;}
+.field__input:focus {border-bottom:2px solid var(--brand-accent,#006a62);}
+.form-actions {display:flex;gap:var(--space-3);justify-content:flex-end;}
+.hint-text {font-size:0.875rem;opacity:0.55;font-style:italic;}
+.btn-link {background:none;border:none;cursor:pointer;color:var(--brand-accent,#006a62);text-decoration:underline;font-size:0.8rem;padding:0;}
+.alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;}
+.alert--error {background:#ffebee;color:#c62828;}
+.btn {display:inline-flex;align-items:center;justify-content:center;padding:var(--space-2) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;font-weight:600;cursor:pointer;border:1px solid transparent;transition:opacity 0.15s;}
+.btn--sm {padding:var(--space-1) var(--space-3);font-size:0.8rem;}
+.btn--accent {background:linear-gradient(135deg,#006a62,#00897b);color:#fff;border:none;}
+.btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
+.btn--ghost {background:transparent;border:1px solid rgba(130,130,130,0.3);color:var(--currentTextColor,#1f2328);}
+/* Substitution panel */
+.subst-backdrop {position:fixed;inset:0;background:rgba(15,53,96,0.35);display:flex;align-items:flex-end;justify-content:flex-end;z-index:200;}
+.subst-panel {background:#fff;width:min(460px,100vw);height:100%;padding:var(--space-6);display:flex;flex-direction:column;gap:var(--space-4);overflow-y:auto;}
+.subst-panel__header {display:flex;align-items:center;justify-content:space-between;}
+.subst-panel__title {font-family:var(--font-display,'Public Sans',sans-serif);font-size:1.1rem;font-weight:700;margin:0;}
+.subst-panel__actions {display:flex;gap:var(--space-3);justify-content:flex-end;margin-top:auto;padding-top:var(--space-4);}
+.subst-part-id {font-family:monospace;font-size:0.75rem;margin-top:calc(-1 * var(--space-2));}
+.subst-list {display:flex;flex-direction:column;gap:var(--space-2);}
+.subst-option {display:flex;align-items:center;gap:var(--space-2);padding:var(--space-3);border-radius:var(--radius-sm);cursor:pointer;background:var(--cardBackground,#f6f8fa);}
+.subst-option--selected {background:#e0f2f1;outline:2px solid var(--brand-accent,#006a62);}
+.subst-option__id {font-size:0.8rem;font-family:monospace;flex:1;word-break:break-all;}
+.subst-type-badge {font-size:0.65rem;text-transform:uppercase;padding:2px 6px;border-radius:var(--radius-sm);background:#e3f2fd;color:#0277bd;}
+.subst-priority {font-size:0.75rem;opacity:0.6;}
+.btn-icon {background:none;border:none;cursor:pointer;font-size:1rem;padding:var(--space-1);color:var(--currentTextColor,#1f2328);}

--- a/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.html
+++ b/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.html
@@ -134,7 +134,7 @@
         </div>
 
         <div class="field">
-          <label class="field__label">Reason (required)</label>
+          <label class="field__label">Reason <span aria-hidden="true">*</span></label>
           <input class="field__input" type="text" [value]="substReason()" (input)="substReason.set($any($event.target).value)" placeholder="Why substituting?" />
         </div>
       }
@@ -147,7 +147,7 @@
           <button
             class="btn btn--accent"
             (click)="confirmSubstitution()"
-            [disabled]="substSaveState() === 'loading' || !substSelectedId()"
+            [disabled]="substSaveState() === 'loading' || !substSelectedId() || !substReason().trim()"
             [attr.aria-busy]="substSaveState() === 'loading'"
           >
             {{ substSaveState() === 'loading' ? 'Substituting…' : 'Confirm Substitution' }}

--- a/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.html
+++ b/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.html
@@ -1,0 +1,159 @@
+<section class="workexec-page workorder-parts" aria-labelledby="parts-heading">
+
+  <button class="btn btn--ghost back-btn" (click)="back()">← Work Order</button>
+
+  @if (pageState() === 'loading') { <p class="hint-text" aria-busy="true">Loading parts…</p> }
+  @if (pageState() === 'error') { <div class="alert alert--error" role="alert">{{ errorMessage() }}</div> }
+
+  @if (pageState() === 'ready') {
+    <header class="page-header">
+      <p class="page-overline">Work Order {{ workorderId() }}</p>
+      <h1 id="parts-heading">Parts</h1>
+    </header>
+
+    <!-- Scope parts list with actions -->
+    <div class="parts-scope">
+      <div class="section-row">
+        <p class="section-overline">Scope Parts</p>
+        <div class="action-btns">
+          <button class="btn btn--ghost btn--sm" (click)="openAction('issue')">Issue Parts</button>
+          <button class="btn btn--ghost btn--sm" (click)="openAction('consume')">Consume</button>
+          <button class="btn btn--ghost btn--sm" (click)="openAction('return')">Return</button>
+        </div>
+      </div>
+
+      @if (partItems().length === 0) {
+        <p class="hint-text">No parts in this work order scope.</p>
+      } @else {
+        <div class="ledger">
+          <div class="ledger__header">
+            <span>Part / Description</span><span>Qty</span><span>Unit Price</span><span>Actions</span>
+          </div>
+          @for (item of partItems(); track item.id; let even = $even) {
+            <div class="ledger__row" [class.ledger__row--alt]="even">
+              <span class="ledger__cell">{{ item.description }}</span>
+              <span class="ledger__cell">{{ item.quantity }}</span>
+              <span class="ledger__cell">{{ item.unitPrice | currency }}</span>
+              <span class="ledger__cell ledger__cell--actions">
+                <button class="btn-link" (click)="openAction('issue', item.id)">Issue</button>
+                <button class="btn-link" (click)="openSubstPanel(item.id)">Substitute</button>
+              </span>
+            </div>
+          }
+        </div>
+      }
+    </div>
+
+    <!-- Part action inline form -->
+    @if (activeAction()) {
+      <div class="action-form" role="dialog" aria-label="Part action form">
+        <p class="section-overline">{{ activeAction() | titlecase }} Parts</p>
+        <div class="field">
+          <label class="field__label">Part ID <span aria-hidden="true">*</span></label>
+          <input class="field__input" type="text" [value]="actionPartId()" (input)="actionPartId.set($any($event.target).value)" placeholder="Part UUID" />
+        </div>
+        <div class="field">
+          <label class="field__label">Quantity</label>
+          <input class="field__input" type="number" min="1" [value]="actionQuantity()" (input)="actionQuantity.set(+$any($event.target).value)" />
+        </div>
+        @if (activeAction() === 'issue' || activeAction() === 'return') {
+          <div class="field">
+            <label class="field__label">Notes</label>
+            <input class="field__input" type="text" [value]="actionNotes()" (input)="actionNotes.set($any($event.target).value)" placeholder="Optional" />
+          </div>
+        }
+        @if (actionError()) { <div class="alert alert--error" role="alert">{{ actionError() }}</div> }
+        <div class="form-actions">
+          <button class="btn btn--ghost" (click)="closeAction()">Cancel</button>
+          <button class="btn btn--accent" (click)="submitAction()" [attr.aria-busy]="actionState() === 'loading'" [disabled]="actionState() === 'loading'">
+            {{ actionState() === 'loading' ? 'Saving…' : 'Confirm' }}
+          </button>
+        </div>
+      </div>
+    }
+
+    <!-- Usage history ledger -->
+    <div class="usage-history">
+      <p class="section-overline">Usage History ({{ usageHistory().length }})</p>
+      @if (usageHistory().length === 0) {
+        <p class="hint-text">No usage recorded yet.</p>
+      } @else {
+        <div class="ledger">
+          <div class="ledger__header">
+            <span>Part ID</span><span>Issued</span><span>Consumed</span><span>Returned</span><span>When</span>
+          </div>
+          @for (entry of usageHistory(); track entry.id; let even = $even) {
+            <div class="ledger__row" [class.ledger__row--alt]="even">
+              <span class="ledger__cell usage-part-id">{{ entry.partId }}</span>
+              <span class="ledger__cell">{{ entry.quantityIssued }}</span>
+              <span class="ledger__cell">{{ entry.quantityConsumed }}</span>
+              <span class="ledger__cell">{{ entry.quantityReturned }}</span>
+              <span class="ledger__cell">{{ (entry.consumedAt ?? entry.issuedAt) | date:'short' }}</span>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  }
+
+</section>
+
+<!-- Story 221: Substitution slide-out panel -->
+@if (showSubstPanel()) {
+  <div class="subst-backdrop" role="dialog" aria-modal="true" aria-labelledby="subst-panel-title">
+    <div class="subst-panel">
+      <div class="subst-panel__header">
+        <h2 id="subst-panel-title" class="subst-panel__title">Find Substitute for Part</h2>
+        <button class="btn-icon" (click)="closeSubstPanel()" aria-label="Close substitution panel">✕</button>
+      </div>
+      <p class="hint-text subst-part-id">Part: {{ substSourcePartId() }}</p>
+
+      @if (substLoadState() === 'loading') { <p class="hint-text" aria-busy="true">Loading suggestions…</p> }
+      @if (substLoadState() === 'error') { <div class="alert alert--error">Failed to load suggestions.</div> }
+
+      @if (substSuggestions().length === 0 && substLoadState() === 'idle') {
+        <p class="hint-text">No substitutes found for this part.</p>
+      }
+
+      @if (substSuggestions().length > 0) {
+        <div class="subst-list">
+          @for (sub of substSuggestions(); track sub.id) {
+            <label class="subst-option" [class.subst-option--selected]="substSelectedId() === sub.substitutePartId">
+              <input
+                type="radio"
+                name="substChoice"
+                [value]="sub.substitutePartId"
+                [checked]="substSelectedId() === sub.substitutePartId"
+                (change)="substSelectedId.set(sub.substitutePartId ?? '')"
+              />
+              <span class="subst-option__id">{{ sub.substitutePartId }}</span>
+              <span class="subst-type-badge subst-type-badge--{{ sub.substituteType?.toLowerCase() }}">{{ sub.substituteType }}</span>
+              <span class="subst-priority">Priority {{ sub.priority }}</span>
+            </label>
+          }
+        </div>
+
+        <div class="field">
+          <label class="field__label">Reason (required)</label>
+          <input class="field__input" type="text" [value]="substReason()" (input)="substReason.set($any($event.target).value)" placeholder="Why substituting?" />
+        </div>
+      }
+
+      @if (substError()) { <div class="alert alert--error" role="alert">{{ substError() }}</div> }
+
+      <div class="subst-panel__actions">
+        <button class="btn btn--ghost" (click)="closeSubstPanel()">Cancel</button>
+        @if (substSuggestions().length > 0) {
+          <button
+            class="btn btn--accent"
+            (click)="confirmSubstitution()"
+            [disabled]="substSaveState() === 'loading' || !substSelectedId()"
+            [attr.aria-busy]="substSaveState() === 'loading'"
+          >
+            {{ substSaveState() === 'loading' ? 'Substituting…' : 'Confirm Substitution' }}
+          </button>
+        }
+      </div>
+    </div>
+  </div>
+}

--- a/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.ts
@@ -197,10 +197,12 @@ export class WorkorderPartsPageComponent implements OnInit {
   confirmSubstitution(): void {
     const substituteId = this.substSelectedId().trim();
     if (!substituteId) { this.substError.set('Select a substitute part.'); return; }
+    const reason = this.substReason().trim();
+    if (!reason) { this.substError.set('Reason is required.'); return; }
     const request: SubstitutePartRequest = {
       originalPartId: this.substSourcePartId(),
       substitutePartId: substituteId,
-      reason: this.substReason() || undefined,
+      reason,
     };
     this.substSaveState.set('loading');
     this.substError.set(null);

--- a/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-parts/workorder-parts-page.component.ts
@@ -1,0 +1,226 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  ConsumePartsRequest,
+  IssuePartsRequest,
+  PartUsageResponse,
+  ReturnPartsRequest,
+  SubstituteLinkResponse,
+  SubstitutePartRequest,
+  WorkorderDetailResponse,
+  WorkorderItemResponse,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+type PartAction = 'issue' | 'consume' | 'return';
+
+/**
+ * WorkorderPartsPageComponent — Story 222 (issue/consume/return) + Story 221 (substitutions)
+ * Route: /app/workexec/workorders/:workorderId/parts
+ * operationIds: issueParts, consumeParts, returnParts, returnUnusedQuantity, correctPartQuantity,
+ *               getUsageHistory, substitutePart, suggestSubstitutes
+ *
+ * Story 221 substitution flow implemented as an inline slide-out panel — no separate route.
+ */
+@Component({
+  selector: 'app-workorder-parts-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './workorder-parts-page.component.html',
+  styleUrl: './workorder-parts-page.component.css',
+})
+export class WorkorderPartsPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly workorder = signal<WorkorderDetailResponse | null>(null);
+  readonly usageHistory = signal<PartUsageResponse[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Part action form */
+  readonly activeAction = signal<PartAction | null>(null);
+  readonly actionPartId = signal<string>('');
+  readonly actionQuantity = signal<number>(1);
+  readonly actionNotes = signal<string>('');
+  readonly actionState = signal<'idle' | 'loading' | 'error'>('idle');
+  readonly actionError = signal<string | null>(null);
+
+  /** Story 221: substitution panel */
+  readonly showSubstPanel = signal(false);
+  readonly substSourcePartId = signal<string>('');
+  readonly substSuggestions = signal<SubstituteLinkResponse[]>([]);
+  readonly substLoadState = signal<'idle' | 'loading' | 'error'>('idle');
+  readonly substSelectedId = signal<string>('');
+  readonly substReason = signal<string>('');
+  readonly substSaveState = signal<'idle' | 'loading' | 'success' | 'error'>('idle');
+  readonly substError = signal<string | null>(null);
+
+  readonly partItems = computed((): WorkorderItemResponse[] =>
+    this.workorder()?.items?.filter(i => i.itemType === 'PART') ?? [],
+  );
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadData(id);
+  }
+
+  private loadData(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getWorkorderDetail(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (detail) => {
+          this.workorder.set(detail);
+          this.loadUsageHistory(id);
+        },
+        error: () => {
+          this.errorMessage.set('Failed to load work order.');
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  private loadUsageHistory(id: string): void {
+    this.service
+      .getUsageHistory(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (h) => {
+          this.usageHistory.set(h ?? []);
+          this.pageState.set('ready');
+        },
+        error: () => this.pageState.set('ready'),
+      });
+  }
+
+  openAction(action: PartAction, partId?: string): void {
+    this.activeAction.set(action);
+    this.actionPartId.set(partId ?? '');
+    this.actionQuantity.set(1);
+    this.actionNotes.set('');
+    this.actionError.set(null);
+    this.actionState.set('idle');
+  }
+
+  closeAction(): void {
+    this.activeAction.set(null);
+  }
+
+  submitAction(): void {
+    const id = this.workorderId();
+    const partId = this.actionPartId().trim();
+    const qty = this.actionQuantity();
+    if (!partId) { this.actionError.set('Part ID is required.'); return; }
+    if (qty <= 0) { this.actionError.set('Quantity must be greater than 0.'); return; }
+
+    this.actionState.set('loading');
+    this.actionError.set(null);
+
+    let call$;
+    switch (this.activeAction()) {
+      case 'issue': {
+        const req: IssuePartsRequest = { partId, quantity: qty, notes: this.actionNotes() || undefined };
+        call$ = this.service.issueParts(id, req, uuidv4());
+        break;
+      }
+      case 'consume': {
+        const req: ConsumePartsRequest = { partId, quantity: qty };
+        call$ = this.service.consumeParts(id, req, uuidv4());
+        break;
+      }
+      case 'return': {
+        const req: ReturnPartsRequest = { partId, quantity: qty, reason: this.actionNotes() || undefined };
+        call$ = this.service.returnParts(id, req, uuidv4());
+        break;
+      }
+      default:
+        return;
+    }
+
+    call$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (result) => {
+        this.usageHistory.update(h => [result, ...h]);
+        this.actionState.set('idle');
+        this.activeAction.set(null);
+      },
+      error: (err) => {
+        this.actionState.set('error');
+        this.actionError.set(err?.error?.message ?? 'Action failed. Please try again.');
+      },
+    });
+  }
+
+  // ── Story 221: Substitution panel ─────────────────────────────────────────
+
+  openSubstPanel(partId: string): void {
+    this.substSourcePartId.set(partId);
+    this.substSuggestions.set([]);
+    this.substSelectedId.set('');
+    this.substReason.set('');
+    this.substError.set(null);
+    this.substSaveState.set('idle');
+    this.showSubstPanel.set(true);
+    this.loadSuggestions(partId);
+  }
+
+  closeSubstPanel(): void {
+    this.showSubstPanel.set(false);
+  }
+
+  private loadSuggestions(partId: string): void {
+    this.substLoadState.set('loading');
+    this.service
+      .suggestSubstitutes(this.workorderId(), partId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (suggestions) => {
+          this.substSuggestions.set(suggestions ?? []);
+          this.substLoadState.set('idle');
+        },
+        error: () => {
+          this.substLoadState.set('error');
+        },
+      });
+  }
+
+  confirmSubstitution(): void {
+    const substituteId = this.substSelectedId().trim();
+    if (!substituteId) { this.substError.set('Select a substitute part.'); return; }
+    const request: SubstitutePartRequest = {
+      originalPartId: this.substSourcePartId(),
+      substitutePartId: substituteId,
+      reason: this.substReason() || undefined,
+    };
+    this.substSaveState.set('loading');
+    this.substError.set(null);
+    this.service
+      .substitutePart(this.workorderId(), request, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.substSaveState.set('success');
+          this.showSubstPanel.set(false);
+          this.loadData(this.workorderId());
+        },
+        error: (err) => {
+          this.substSaveState.set('error');
+          this.substError.set(err?.error?.message ?? 'Substitution failed.');
+        },
+      });
+  }
+
+  back(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId()]);
+  }
+}

--- a/src/app/features/workexec/services/workexec.service.spec.ts
+++ b/src/app/features/workexec/services/workexec.service.spec.ts
@@ -254,4 +254,20 @@ describe('WorkexecService', () => {
     expect(r.request.headers.get('Idempotency-Key')).toBe('add-item-idem-key');
     r.flush({ id: 'item-1', estimateId: 'est-1', itemType: 'PART', quantity: 1, unitPrice: 10 });
   });
+
+  it('getWorkorderDetail — forwards X-Authorities header when authorities provided', () => {
+    service.getWorkorderDetail('wo-1', 'ROLE_MANAGER').subscribe();
+    const r = http.expectOne(`${BASE}/v1/workorders/wo-1/detail`);
+    expect(r.request.method).toBe('GET');
+    expect(r.request.headers.get('X-Authorities')).toBe('ROLE_MANAGER');
+    r.flush({ id: 'wo-1' });
+  });
+
+  it('getWorkorderDetail — does not set X-Authorities header when authorities omitted', () => {
+    service.getWorkorderDetail('wo-1').subscribe();
+    const r = http.expectOne(`${BASE}/v1/workorders/wo-1/detail`);
+    expect(r.request.method).toBe('GET');
+    expect(r.request.headers.has('X-Authorities')).toBeFalsy();
+    r.flush({ id: 'wo-1' });
+  });
 });

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -4,13 +4,32 @@ import { ApiBaseService } from '../../../core/services/api-base.service';
 import {
   AddEstimateItemRequest,
   ApproveEstimateRequest,
+  AssignTechnicianRequest,
   CalculateEstimateTotalsResponse,
+  ChangeRequestResponse,
+  ConsumePartsRequest,
+  CreateChangeRequestRequest,
   CreateEstimateRequest,
+  CreateLaborPerformedRequest,
   EstimateItemResponse,
   EstimateResponse,
   EstimateSnapshotResponse,
   EstimateSummaryResponse,
+  IssuePartsRequest,
+  OperationalContextResponse,
+  PartUsageResponse,
+  ReturnPartsRequest,
+  StartLaborRequest,
+  StopLaborRequest,
+  SubstitutePartRequest,
+  SubstituteLinkResponse,
+  TechnicianAssignmentResponse,
   UpdateEstimateItemRequest,
+  WorkorderDetailResponse,
+  WorkorderLaborEntryResponse,
+  WorkorderResponse,
+  WorkorderStartResponse,
+  WorkorderTransition,
 } from '../models/workexec.models';
 
 /**
@@ -32,6 +51,36 @@ import {
  *
  * Idempotency-Key header is forwarded for mutating operations per
  * DECISION-INVENTORY-012 via ApiBaseService options.
+ *
+ * CAP-004 (Promotion) operationId mapping:
+ *   promoteEstimateToWorkorder → POST /v1/workorders/estimates/{estimateId}/promote
+ *   getWorkorderById           → GET  /v1/workorders/{workorderId}
+ *   getWorkorderDetail         → GET  /v1/workorders/{workorderId}/detail
+ *   getTransitionHistory       → GET  /v1/workorders/{workorderId}/transitions
+ *
+ * CAP-005 (Execution) operationId mapping:
+ *   assignTechnician           → POST   /v1/workorders/{workorderId}/technician
+ *   reassignTechnician         → PUT    /v1/workorders/{workorderId}/technician
+ *   getTechnicianAssignment    → GET    /v1/workorders/{workorderId}/technician
+ *   startWork                  → POST   /v1/workorders/{workorderId}/start
+ *   startLaborSession          → POST   /v1/workorders/{workorderId}/services/{serviceId}/labor/start
+ *   stopLaborSession           → POST   /v1/workorders/{workorderId}/labor/{entryId}/stop
+ *   createLaborPerformed       → POST   /v1/workexec/labor-performed
+ *   getLaborHistory            → GET    /v1/workorders/{workorderId}/labor
+ *   issueParts                 → POST   /v1/workorders/{workorderId}/parts/issue
+ *   consumeParts               → POST   /v1/workorders/{workorderId}/parts/consume
+ *   returnParts                → POST   /v1/workorders/{workorderId}/parts/return
+ *   returnUnusedQuantity       → POST   /v1/workorders/{workorderId}/parts/returnUnused
+ *   substitutePart             → POST   /v1/workorders/{workorderId}/parts/substitute
+ *   suggestSubstitutes         → POST   /v1/workorders/{workorderId}/suggestSubstitutes
+ *   correctPartQuantity        → POST   /v1/workorders/{workorderId}/parts/correct
+ *   getUsageHistory            → GET    /v1/workorders/{workorderId}/parts/usageHistory
+ *   getOperationalContext      → GET    /v1/workorders/{workorderId}/operationalContext
+ *   getChangeRequestsByWorkorder → GET  /v1/workorders/{workorderId}/changeRequests
+ *   createChangeRequest        → POST   /v1/workorders/{workorderId}/changeRequests
+ *   approveChangeRequest       → POST   /v1/workorders/changeRequests/{changeId}/approve
+ *   declineChangeRequest       → POST   /v1/workorders/changeRequests/{changeId}/decline
+ *   getChangeRequestById       → GET    /v1/workorders/changeRequests/{changeId}
  */
 @Injectable({ providedIn: 'root' })
 export class WorkexecService {
@@ -235,6 +284,335 @@ export class WorkexecService {
     return this.api.post<EstimateResponse>(
       `/v1/workorders/estimates/${estimateId}/approval`,
       request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  // ── CAP-004: Workorder Promotion ──────────────────────────────────────────
+
+  /**
+   * operationId: promoteEstimateToWorkorder
+   * POST /v1/workorders/estimates/{estimateId}/promote
+   * Stories 231, 230, 228, 227
+   *
+   * Contract normalization: empty in AGENT_WORKSET. OpenAPI path verified:
+   * POST /v1/workorders/estimates/{estimateId}/promote with optional Idempotency-Key header.
+   * Returns WorkorderResponse (201) or 409 Conflict with existingWorkorderId.
+   */
+  promoteEstimateToWorkorder(estimateId: string, idempotencyKey?: string): Observable<WorkorderResponse> {
+    return this.api.post<WorkorderResponse>(
+      `/v1/workorders/estimates/${estimateId}/promote`,
+      {},
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getWorkorderById
+   * GET /v1/workorders/{workorderId}
+   * Stories 230, 228
+   */
+  getWorkorderById(workorderId: string): Observable<WorkorderResponse> {
+    return this.api.get<WorkorderResponse>(`/v1/workorders/${workorderId}`);
+  }
+
+  /**
+   * operationId: getWorkorderDetail
+   * GET /v1/workorders/{workorderId}/detail
+   * Stories 229, 226, 224
+   *
+   * Accepts X-Authorities header for role-gated field exposure.
+   * Contract normalization: empty in AGENT_WORKSET. Path verified from OpenAPI.
+   */
+  getWorkorderDetail(workorderId: string, authorities?: string): Observable<WorkorderDetailResponse> {
+    const opts = authorities ? { headers: { 'X-Authorities': authorities } } : undefined;
+    return this.api.get<WorkorderDetailResponse>(`/v1/workorders/${workorderId}/detail`, undefined);
+  }
+
+  /**
+   * operationId: getTransitionHistory
+   * GET /v1/workorders/{workorderId}/transitions
+   * Stories 226, 224
+   */
+  getTransitionHistory(workorderId: string): Observable<WorkorderTransition[]> {
+    return this.api.get<WorkorderTransition[]>(`/v1/workorders/${workorderId}/transitions`);
+  }
+
+  /**
+   * operationId: getOperationalContext
+   * GET /v1/workorders/{workorderId}/operationalContext
+   * Story 219 — role-based visibility flags
+   */
+  getOperationalContext(workorderId: string): Observable<OperationalContextResponse> {
+    return this.api.get<OperationalContextResponse>(`/v1/workorders/${workorderId}/operationalContext`);
+  }
+
+  // ── CAP-005: Technician Assignment (Story 225) ────────────────────────────
+
+  /**
+   * operationId: assignTechnician
+   * POST /v1/workorders/{workorderId}/technician
+   */
+  assignTechnician(
+    workorderId: string,
+    request: AssignTechnicianRequest,
+    idempotencyKey?: string,
+  ): Observable<TechnicianAssignmentResponse> {
+    return this.api.post<TechnicianAssignmentResponse>(
+      `/v1/workorders/${workorderId}/technician`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: reassignTechnician
+   * PUT /v1/workorders/{workorderId}/technician
+   */
+  reassignTechnician(
+    workorderId: string,
+    request: AssignTechnicianRequest,
+    idempotencyKey?: string,
+  ): Observable<TechnicianAssignmentResponse> {
+    return this.api.put<TechnicianAssignmentResponse>(
+      `/v1/workorders/${workorderId}/technician`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getTechnicianAssignment
+   * GET /v1/workorders/{workorderId}/technician
+   */
+  getTechnicianAssignment(workorderId: string): Observable<TechnicianAssignmentResponse> {
+    return this.api.get<TechnicianAssignmentResponse>(`/v1/workorders/${workorderId}/technician`);
+  }
+
+  // ── CAP-005: Start Work (Story 224) ──────────────────────────────────────
+
+  /**
+   * operationId: startWork
+   * POST /v1/workorders/{workorderId}/start
+   */
+  startWork(workorderId: string, idempotencyKey?: string): Observable<WorkorderStartResponse> {
+    return this.api.post<WorkorderStartResponse>(
+      `/v1/workorders/${workorderId}/start`,
+      {},
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  // ── CAP-005: Labor Sessions (Story 223) ──────────────────────────────────
+
+  /**
+   * operationId: startLaborSession
+   * POST /v1/workorders/{workorderId}/services/{serviceId}/labor/start
+   */
+  startLaborSession(
+    workorderId: string,
+    serviceId: string,
+    request: StartLaborRequest,
+    idempotencyKey?: string,
+  ): Observable<WorkorderLaborEntryResponse> {
+    return this.api.post<WorkorderLaborEntryResponse>(
+      `/v1/workorders/${workorderId}/services/${serviceId}/labor/start`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: stopLaborSession
+   * POST /v1/workorders/{workorderId}/labor/{entryId}/stop
+   */
+  stopLaborSession(
+    workorderId: string,
+    entryId: string,
+    request: StopLaborRequest,
+    idempotencyKey?: string,
+  ): Observable<WorkorderLaborEntryResponse> {
+    return this.api.post<WorkorderLaborEntryResponse>(
+      `/v1/workorders/${workorderId}/labor/${entryId}/stop`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: createLaborPerformed
+   * POST /v1/workexec/labor-performed
+   * Manual labor entry (no session)
+   */
+  createLaborPerformed(
+    request: CreateLaborPerformedRequest,
+    idempotencyKey?: string,
+  ): Observable<WorkorderLaborEntryResponse> {
+    return this.api.post<WorkorderLaborEntryResponse>(
+      `/v1/workexec/labor-performed`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getLaborHistory
+   * GET /v1/workorders/{workorderId}/labor
+   */
+  getLaborHistory(workorderId: string): Observable<WorkorderLaborEntryResponse[]> {
+    return this.api.get<WorkorderLaborEntryResponse[]>(`/v1/workorders/${workorderId}/labor`);
+  }
+
+  // ── CAP-005: Parts (Stories 222, 221) ─────────────────────────────────────
+
+  /**
+   * operationId: issueParts
+   * POST /v1/workorders/{workorderId}/parts/issue
+   */
+  issueParts(workorderId: string, request: IssuePartsRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/issue`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: consumeParts
+   * POST /v1/workorders/{workorderId}/parts/consume
+   */
+  consumeParts(workorderId: string, request: ConsumePartsRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/consume`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: returnParts
+   * POST /v1/workorders/{workorderId}/parts/return
+   */
+  returnParts(workorderId: string, request: ReturnPartsRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/return`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: returnUnusedQuantity
+   * POST /v1/workorders/{workorderId}/parts/returnUnused
+   */
+  returnUnusedQuantity(workorderId: string, request: ReturnPartsRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/returnUnused`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: substitutePart
+   * POST /v1/workorders/{workorderId}/parts/substitute
+   * Story 221
+   */
+  substitutePart(workorderId: string, request: SubstitutePartRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/substitute`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: suggestSubstitutes
+   * POST /v1/workorders/{workorderId}/suggestSubstitutes
+   * Story 221
+   */
+  suggestSubstitutes(workorderId: string, partId: string): Observable<SubstituteLinkResponse[]> {
+    return this.api.post<SubstituteLinkResponse[]>(
+      `/v1/workorders/${workorderId}/suggestSubstitutes`,
+      { partId },
+    );
+  }
+
+  /**
+   * operationId: correctPartQuantity
+   * POST /v1/workorders/{workorderId}/parts/correct
+   */
+  correctPartQuantity(workorderId: string, request: ConsumePartsRequest, idempotencyKey?: string): Observable<PartUsageResponse> {
+    return this.api.post<PartUsageResponse>(
+      `/v1/workorders/${workorderId}/parts/correct`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getUsageHistory
+   * GET /v1/workorders/{workorderId}/parts/usageHistory
+   */
+  getUsageHistory(workorderId: string): Observable<PartUsageResponse[]> {
+    return this.api.get<PartUsageResponse[]>(`/v1/workorders/${workorderId}/parts/usageHistory`);
+  }
+
+  // ── CAP-005: Change Requests (Story 220) ──────────────────────────────────
+
+  /**
+   * operationId: getChangeRequestsByWorkorder
+   * GET /v1/workorders/{workorderId}/changeRequests
+   */
+  getChangeRequestsByWorkorder(workorderId: string): Observable<ChangeRequestResponse[]> {
+    return this.api.get<ChangeRequestResponse[]>(`/v1/workorders/${workorderId}/changeRequests`);
+  }
+
+  /**
+   * operationId: createChangeRequest
+   * POST /v1/workorders/{workorderId}/changeRequests
+   */
+  createChangeRequest(
+    workorderId: string,
+    request: CreateChangeRequestRequest,
+    idempotencyKey?: string,
+  ): Observable<ChangeRequestResponse> {
+    return this.api.post<ChangeRequestResponse>(
+      `/v1/workorders/${workorderId}/changeRequests`,
+      request,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getChangeRequestById
+   * GET /v1/workorders/changeRequests/{changeId}
+   */
+  getChangeRequestById(changeId: string): Observable<ChangeRequestResponse> {
+    return this.api.get<ChangeRequestResponse>(`/v1/workorders/changeRequests/${changeId}`);
+  }
+
+  /**
+   * operationId: approveChangeRequest
+   * POST /v1/workorders/changeRequests/{changeId}/approve
+   * Story 220 (manager flow)
+   */
+  approveChangeRequest(changeId: string, notes?: string, idempotencyKey?: string): Observable<ChangeRequestResponse> {
+    return this.api.post<ChangeRequestResponse>(
+      `/v1/workorders/changeRequests/${changeId}/approve`,
+      { notes },
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: declineChangeRequest
+   * POST /v1/workorders/changeRequests/{changeId}/decline
+   */
+  declineChangeRequest(changeId: string, reason?: string, idempotencyKey?: string): Observable<ChangeRequestResponse> {
+    return this.api.post<ChangeRequestResponse>(
+      `/v1/workorders/changeRequests/${changeId}/decline`,
+      { reason },
       this.idempotencyOptions(idempotencyKey),
     );
   }

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -326,7 +326,7 @@ export class WorkexecService {
    */
   getWorkorderDetail(workorderId: string, authorities?: string): Observable<WorkorderDetailResponse> {
     const opts = authorities ? { headers: { 'X-Authorities': authorities } } : undefined;
-    return this.api.get<WorkorderDetailResponse>(`/v1/workorders/${workorderId}/detail`, undefined);
+    return this.api.get<WorkorderDetailResponse>(`/v1/workorders/${workorderId}/detail`, undefined, opts);
   }
 
   /**

--- a/src/app/features/workexec/workexec.routes.ts
+++ b/src/app/features/workexec/workexec.routes.ts
@@ -116,8 +116,6 @@ export const WORKEXEC_ROUTES: Routes = [
           ),
       },
 
-      { path: '**', redirectTo: 'estimates/new' },
-
       // ── CAP-004: Workorder Promotion + Hub ────────────────────────────────
 
       /** Stories 230, 229, 226, 224, 219: Workorder hub (detail, scope, audit, start, roles) */
@@ -166,6 +164,8 @@ export const WORKEXEC_ROUTES: Routes = [
             m => m.WorkorderChangeRequestsPageComponent,
           ),
       },
+
+      { path: '**', redirectTo: 'estimates/new' },
     ],
   },
 ];

--- a/src/app/features/workexec/workexec.routes.ts
+++ b/src/app/features/workexec/workexec.routes.ts
@@ -3,8 +3,10 @@ import { WorkexecComponent } from './workexec.component';
 
 /**
  * Workexec feature routes
- * Capabilities: CAP-002 (Estimates), CAP-003 (Customer Approval Workflow)
- * Wave B — stories 239, 238, 237, 236, 235, 234, 233, 271, 270, 269, 268
+ * Capabilities: CAP-002 (Estimates), CAP-003 (Customer Approval Workflow),
+ *               CAP-004 (Workorder Promotion), CAP-005 (Workorder Execution)
+ * Wave B — stories 239, 238, 237, 236, 235, 234, 233, 271, 270, 269, 268,
+ *           231, 230, 229, 228, 227, 226 (CAP-004), 225, 224, 223, 222, 221, 220, 219 (CAP-005)
  */
 export const WORKEXEC_ROUTES: Routes = [
   {
@@ -115,6 +117,55 @@ export const WORKEXEC_ROUTES: Routes = [
       },
 
       { path: '**', redirectTo: 'estimates/new' },
+
+      // ── CAP-004: Workorder Promotion + Hub ────────────────────────────────
+
+      /** Stories 230, 229, 226, 224, 219: Workorder hub (detail, scope, audit, start, roles) */
+      {
+        path: 'workorders/:workorderId',
+        loadComponent: () =>
+          import('./pages/workorder-detail/workorder-detail-page.component').then(
+            m => m.WorkorderDetailPageComponent,
+          ),
+      },
+
+      // ── CAP-005: Workorder Execution sub-pages ───────────────────────────
+
+      /** Story 225: Assign/Reassign Technician */
+      {
+        path: 'workorders/:workorderId/assign',
+        loadComponent: () =>
+          import('./pages/workorder-assign/workorder-assign-page.component').then(
+            m => m.WorkorderAssignPageComponent,
+          ),
+      },
+
+      /** Story 223: Record Labor (sessions + manual entries) */
+      {
+        path: 'workorders/:workorderId/labor',
+        loadComponent: () =>
+          import('./pages/workorder-labor/workorder-labor-page.component').then(
+            m => m.WorkorderLaborPageComponent,
+          ),
+      },
+
+      /** Stories 222 + 221: Issue/Consume/Return Parts + Substitutions */
+      {
+        path: 'workorders/:workorderId/parts',
+        loadComponent: () =>
+          import('./pages/workorder-parts/workorder-parts-page.component').then(
+            m => m.WorkorderPartsPageComponent,
+          ),
+      },
+
+      /** Story 220: Change Requests (create, approve, decline) */
+      {
+        path: 'workorders/:workorderId/change-requests',
+        loadComponent: () =>
+          import('./pages/workorder-change-requests/workorder-change-requests-page.component').then(
+            m => m.WorkorderChangeRequestsPageComponent,
+          ),
+      },
     ],
   },
 ];


### PR DESCRIPTION
- [x] Extend `ApiBaseService.get()` to accept optional `ApiRequestOptions` (headers)
- [x] Fix `getWorkorderDetail` in `WorkexecService` to pass `opts`
- [x] Add two tests verifying `X-Authorities` header forwarding in `getWorkorderDetail`
- [x] Enforce non-empty reason in `confirmSubstitution()` — validates trimmed reason, returns early with error if blank
- [x] Disable "Confirm Substitution" button when `substReason` is empty (in addition to missing selection)
- [x] Updated label to use standard asterisk pattern instead of "(required)" text
- [x] Move `{ path: '**', redirectTo: 'estimates/new' }` catch-all to the end of the `children` array so all CAP-004/CAP-005 workorder routes are reachable
- [x] Add typed `lineItemApprovalStatus?: 'APPROVED' | 'DECLINED' | string` field to `EstimateItemResponse`; update `buildApprovalScope` to filter explicitly on `=== 'APPROVED'` (removes `as any` cast and fixes silent bug where items with no approval status were incorrectly counted as approved)
- [x] All 66 tests pass

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
