### PR TITLE
feat(workexec+billing): Wave C — Complete Workorder + Convert to Invoice (CAP-006, CAP-007)

### DIFF
--- a/src/app/features/billing/billing.routes.ts
+++ b/src/app/features/billing/billing.routes.ts
@@ -1,10 +1,25 @@
 import { Routes } from '@angular/router';
 import { BillingComponent } from './billing.component';
 
+/**
+ * Billing feature routes
+ * Capability: CAP-007 (Convert Workorder to Invoice)
+ * Wave C — stories 213, 212, 211, 210, 209
+ */
 export const BILLING_ROUTES: Routes = [
   {
     path: '',
     component: BillingComponent,
-    children: [],
+    children: [
+      /** Stories 209–213 (CAP-007): Invoice detail, totals, traceability, adjustments, issue */
+      {
+        path: 'invoices/:invoiceId',
+        loadComponent: () =>
+          import('./pages/invoice-detail/invoice-detail-page.component').then(
+            m => m.InvoiceDetailPageComponent,
+          ),
+      },
+    ],
   },
 ];
+

--- a/src/app/features/billing/models/billing.models.ts
+++ b/src/app/features/billing/models/billing.models.ts
@@ -1,0 +1,136 @@
+/**
+ * Billing domain models.
+ * Service contracts: CAP-007 (Stories 213–209)
+ * Base URL: /billing (billing microservice)
+ */
+
+// ── Invoice status ────────────────────────────────────────────────────────────
+
+export type InvoiceStatus = 'DRAFT' | 'PENDING_REVIEW' | 'ISSUED' | 'VOID' | 'CANCELLED';
+
+// ── Invoice line items ────────────────────────────────────────────────────────
+
+export interface InvoiceLineItem {
+  id: string;
+  description?: string;
+  quantity?: number;
+  unitPrice?: number;
+  lineTotal?: number;
+  type?: 'PART' | 'LABOR' | 'FEE' | 'TAX';
+  itemType?: 'PART' | 'LABOR' | 'FEE' | 'TAX';
+  taxCode?: string;
+}
+
+// ── Traceability links (Story 211) ───────────────────────────────────────────
+
+export interface InvoiceTraceability {
+  estimateId?: string;
+  estimateNumber?: string;
+  workorderId?: string;
+  workorderNumber?: string;
+  approvalId?: string;
+  snapshotId?: string;
+  snapshotVersion?: number;
+  snapshotCapturedAt?: string;
+  workorderCompletedAt?: string;
+  generatedById?: string;
+}
+
+// ── Invoice adjustment (Story 210) ───────────────────────────────────────────
+
+export interface InvoiceAdjustment {
+  id: string;
+  reasonCode: string;
+  reason?: string;
+  justification?: string;
+  adjustmentType?: string;
+  amount: number;
+  appliedAt?: string;
+  appliedBy?: string;
+  adjustedAt?: string;
+  adjustedBy?: string;
+}
+
+// ── Issuance policy (Story 209) ──────────────────────────────────────────────
+
+export interface IssuanceBlocker {
+  blockerId: string;
+  description: string;
+  severity: 'BLOCKING' | 'WARNING';
+}
+
+export interface IssuancePolicy {
+  requiresElevation?: boolean;
+  blockers?: IssuanceBlocker[];
+  issuableNow?: boolean;
+}
+
+// ── Artifact (Story 209) ─────────────────────────────────────────────────────
+
+export interface InvoiceArtifact {
+  artifactRefId: string;
+  fileName?: string;
+  filename?: string;
+  mimeType?: string;
+  contentType?: string;
+  createdAt?: string;
+}
+
+export interface ArtifactDownloadToken {
+  downloadToken: string;
+  downloadUrl?: string;
+  expiresAt?: string;
+}
+
+// ── Invoice detail (Stories 212, 211, 210, 209) ───────────────────────────────
+
+export interface InvoiceDetail {
+  invoiceId: string;
+  invoiceNumber?: string;
+  workOrderId?: string;
+  poNumber?: string;
+  status: InvoiceStatus;
+  subtotal?: number;
+  taxTotal?: number;
+  taxAmount?: number;
+  feeTotal?: number;
+  discountAmount?: number;
+  adjustmentTotal?: number;
+  grandTotal?: number;
+  currencyCode?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  issuedAt?: string;
+  issuedBy?: string;
+  lineItems?: InvoiceLineItem[];
+  adjustments?: InvoiceAdjustment[];
+  traceability?: InvoiceTraceability;
+  issuancePolicy?: IssuancePolicy;
+}
+
+// ── Create invoice draft (Story 213) ─────────────────────────────────────────
+
+export interface CreateInvoiceDraftRequest {
+  workOrderId: string;
+}
+
+export interface CreateInvoiceDraftResponse {
+  invoiceId: string;
+  status?: InvoiceStatus;
+  workOrderId?: string;
+}
+
+// ── Issue invoice (Story 209) ─────────────────────────────────────────────────
+
+export interface IssueInvoiceRequest {
+  elevationToken?: string;
+}
+
+export interface ElevateRequest {
+  password: string;
+}
+
+export interface ElevateResponse {
+  elevationToken: string;
+  expiresAt?: string;
+}

--- a/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.css
+++ b/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.css
@@ -1,0 +1,224 @@
+.invoice-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ── Totals grid ────────────────────────────────────────────────────────── */
+
+.totals-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.totals-grid__label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-on-surface-muted, #57606a);
+  margin-bottom: 0.15rem;
+}
+
+.totals-grid__value {
+  font-size: 0.9rem;
+  color: var(--color-on-surface, #1f2328);
+  word-break: break-word;
+}
+
+/* ── Line items table ───────────────────────────────────────────────────── */
+
+.line-items {
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+}
+
+.line-items__header,
+.line-items__row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 0.5fr 1fr 1fr;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.875rem;
+  align-items: center;
+}
+
+.line-items__header {
+  background: var(--color-surface-container, #f1f5f9);
+  font-weight: 600;
+  color: var(--color-on-surface, #1f2328);
+  border-bottom: 1px solid var(--color-outline-variant, #d0d7de);
+}
+
+.line-items__row { border-bottom: 1px solid var(--color-outline-variant, #d0d7de); }
+.line-items__row:last-child { border-bottom: none; }
+.line-items__row--alt { background: var(--color-surface-container-low, #f8fafb); }
+
+.line-total { text-align: right; font-weight: 500; }
+
+/* ── Type chip ──────────────────────────────────────────────────────────── */
+
+.type-chip {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 100px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: var(--color-surface-container, #f1f5f9);
+  color: var(--color-on-surface-muted, #57606a);
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+}
+.type-chip--part { background: #dbeafe; color: #1e40af; border-color: #1e40af; }
+.type-chip--service { background: #dcfce7; color: #166534; border-color: #166534; }
+.type-chip--labor { background: #f0fdf4; color: #166534; border-color: #166534; }
+
+/* ── Totals breakdown ───────────────────────────────────────────────────── */
+
+.totals-breakdown {
+  background: var(--color-surface-container, #f1f5f9);
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.75rem 1rem;
+  max-width: 28rem;
+  margin-left: auto;
+}
+
+.totals-breakdown__row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  padding: 0.3rem 0;
+  color: var(--color-on-surface, #1f2328);
+}
+
+.totals-breakdown__row--discount .totals-breakdown__value { color: var(--color-success, #16a34a); }
+
+.totals-breakdown__row--grand {
+  border-top: 1px solid var(--color-outline-variant, #d0d7de);
+  margin-top: 0.35rem;
+  padding-top: 0.5rem;
+}
+
+.totals-breakdown__value--grand {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-on-surface, #1f2328);
+}
+
+/* ── Adjustment cards ───────────────────────────────────────────────────── */
+
+.adjustment-card {
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  margin-bottom: 0.5rem;
+  background: var(--color-surface, #fff);
+}
+
+.adjustment-card--alt { background: var(--color-surface-container-low, #f8fafb); }
+
+.adjustment-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.adj-reason {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-on-surface, #1f2328);
+  flex: 1;
+}
+
+.adjustment-card__meta { font-size: 0.8rem; margin-bottom: 0.4rem; }
+
+.adjustment-card__amount {
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: right;
+}
+
+.adjustment-card__amount--debit { color: var(--color-error, #dc2626); }
+.adjustment-card__amount--credit { color: var(--color-success, #16a34a); }
+
+/* ── Traceability grid ──────────────────────────────────────────────────── */
+
+.trace-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+  gap: 0.75rem 1.5rem;
+}
+
+.trace-grid__label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-on-surface-muted, #57606a);
+  margin-bottom: 0.15rem;
+}
+
+.trace-grid__value {
+  font-size: 0.875rem;
+  color: var(--color-on-surface, #1f2328);
+}
+
+.trace-grid__value--mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+}
+
+/* ── Artifacts ──────────────────────────────────────────────────────────── */
+
+.artifact-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--color-outline-variant, #d0d7de);
+  font-size: 0.875rem;
+}
+
+.artifact-row:last-child { border-bottom: none; }
+
+.artifact-row__name {
+  flex: 1;
+  font-weight: 500;
+  color: var(--color-on-surface, #1f2328);
+}
+
+/* ── Form ───────────────────────────────────────────────────────────────── */
+
+.form-field { margin-bottom: 0.75rem; }
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.35rem;
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: var(--color-surface, #fff);
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-input:focus {
+  outline: 2px solid var(--brand-accent, #14c8b4);
+  outline-offset: 1px;
+  border-color: var(--brand-accent, #14c8b4);
+}

--- a/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.html
+++ b/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.html
@@ -1,0 +1,246 @@
+<section class="billing-page invoice-detail" aria-labelledby="invoice-heading">
+
+  <header class="wo-header" aria-labelledby="invoice-heading">
+    <div class="wo-header__inner">
+      <div class="wo-header__identity">
+        <p class="wo-header__overline">Invoice</p>
+        <h1 id="invoice-heading" class="wo-header__id">{{ invoiceId() }}</h1>
+        @if (invoice()) {
+          <span class="status-chip status-chip--{{ statusClass(invoice()!.status) }}">{{ invoice()!.status }}</span>
+        }
+      </div>
+      <div class="wo-header__actions">
+        <button class="btn btn--ghost" (click)="goBack()">← Back to Work Order</button>
+        @if (canIssue()) {
+          <button
+            class="btn btn--accent"
+            (click)="initiateIssue()"
+            [attr.aria-busy]="issueState() === 'issuing'"
+          >
+            {{ issueState() === 'issuing' ? 'Issuing…' : 'Issue Invoice' }}
+          </button>
+        }
+      </div>
+    </div>
+  </header>
+
+  @if (pageState() === 'loading') {
+    <p class="hint-text" aria-busy="true">Loading invoice…</p>
+  }
+
+  @if (pageState() === 'error') {
+    <div class="alert alert--error" role="alert">{{ errorMessage() }}</div>
+  }
+
+  @if (issueError()) {
+    <div class="alert alert--error" role="alert">{{ issueError() }}</div>
+  }
+
+  @if (issueSuccess()) {
+    <div class="alert alert--success" role="status">
+      Invoice issued successfully. Documents available below.
+    </div>
+  }
+
+  @if (pageState() === 'ready' && invoice()) {
+
+    <!-- Story 212: Totals summary ─────────────────────────────────────── -->
+    <div class="wo-section invoice-totals" aria-labelledby="totals-heading">
+      <h2 id="totals-heading" class="section-heading">Invoice Summary</h2>
+      <div class="totals-grid">
+        <div class="totals-grid__item">
+          <span class="totals-grid__label">Work Order</span>
+          <span class="totals-grid__value">{{ invoice()!.workOrderId }}</span>
+        </div>
+        @if (invoice()!.poNumber) {
+          <div class="totals-grid__item">
+            <span class="totals-grid__label">PO Number</span>
+            <span class="totals-grid__value">{{ invoice()!.poNumber }}</span>
+          </div>
+        }
+        <div class="totals-grid__item">
+          <span class="totals-grid__label">Created</span>
+          <span class="totals-grid__value">{{ invoice()!.createdAt | date:'medium' }}</span>
+        </div>
+        @if (invoice()!.issuedAt) {
+          <div class="totals-grid__item">
+            <span class="totals-grid__label">Issued</span>
+            <span class="totals-grid__value">{{ invoice()!.issuedAt | date:'medium' }}</span>
+          </div>
+        }
+      </div>
+
+      <!-- Line items -->
+      @if ((invoice()!.lineItems?.length ?? 0) > 0) {
+        <div class="line-items" aria-label="Invoice line items">
+          <div class="line-items__header">
+            <span>Description</span>
+            <span>Type</span>
+            <span>Qty</span>
+            <span>Unit</span>
+            <span>Total</span>
+          </div>
+          @for (item of invoice()!.lineItems; track item.id; let even = $even) {
+            <div class="line-items__row" [class.line-items__row--alt]="even">
+              <span>{{ item.description }}</span>
+              <span>
+                <span class="type-chip type-chip--{{ item.type?.toLowerCase() }}">{{ item.type }}</span>
+              </span>
+              <span>{{ item.quantity }}</span>
+              <span>{{ item.unitPrice | currency }}</span>
+              <span class="line-total">{{ item.lineTotal | currency }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- Totals breakdown -->
+      <div class="totals-breakdown" role="complementary" aria-label="Invoice totals">
+        <div class="totals-breakdown__row">
+          <span class="totals-breakdown__label">Subtotal</span>
+          <span class="totals-breakdown__value">{{ invoice()!.subtotal | currency }}</span>
+        </div>
+        @if ((invoice()!.taxAmount ?? 0) > 0) {
+          <div class="totals-breakdown__row">
+            <span class="totals-breakdown__label">Tax</span>
+            <span class="totals-breakdown__value">{{ invoice()!.taxAmount | currency }}</span>
+          </div>
+        }
+        @if ((invoice()!.discountAmount ?? 0) > 0) {
+          <div class="totals-breakdown__row totals-breakdown__row--discount">
+            <span class="totals-breakdown__label">Discount</span>
+            <span class="totals-breakdown__value">−{{ invoice()!.discountAmount | currency }}</span>
+          </div>
+        }
+        <div class="totals-breakdown__row totals-breakdown__row--grand">
+          <span class="totals-breakdown__label">Grand Total</span>
+          <span class="totals-breakdown__value totals-breakdown__value--grand">{{ invoice()!.grandTotal | currency }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Story 210: Adjustments ─────────────────────────────────────────── -->
+    @if (invoice()!.adjustments && invoice()!.adjustments!.length > 0) {
+      <div class="wo-section" aria-labelledby="adjustments-heading">
+        <h2 id="adjustments-heading" class="section-heading">Adjustments</h2>
+        @for (adj of invoice()!.adjustments!; track adj.id; let even = $even) {
+          <div class="adjustment-card" [class.adjustment-card--alt]="even">
+            <div class="adjustment-card__header">
+              <span class="adj-reason">{{ adj.reason }}</span>
+              <span class="adj-type status-chip status-chip--{{ adj.adjustmentType?.toLowerCase() }}">{{ adj.adjustmentType }}</span>
+            </div>
+            <div class="adjustment-card__meta hint-text">
+              {{ adj.adjustedAt | date:'medium' }} · by {{ adj.adjustedBy }}
+            </div>
+            <div class="adjustment-card__amount"
+              [class.adjustment-card__amount--debit]="(adj.amount ?? 0) > 0"
+              [class.adjustment-card__amount--credit]="(adj.amount ?? 0) < 0"
+            >
+              {{ (adj.amount ?? 0) >= 0 ? '+' : '' }}{{ adj.amount | currency }}
+            </div>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Story 211: Traceability ────────────────────────────────────────── -->
+    @if (invoice()!.traceability) {
+      <div class="wo-section" aria-labelledby="trace-heading">
+        <h2 id="trace-heading" class="section-heading">Traceability</h2>
+        <div class="trace-grid">
+          @if (invoice()!.traceability!.snapshotId) {
+            <div class="trace-grid__item">
+              <span class="trace-grid__label">Snapshot</span>
+              <span class="trace-grid__value trace-grid__value--mono">{{ invoice()!.traceability!.snapshotId | slice:0:8 }}…</span>
+            </div>
+          }
+          @if (invoice()!.traceability!.snapshotCapturedAt) {
+            <div class="trace-grid__item">
+              <span class="trace-grid__label">Captured</span>
+              <span class="trace-grid__value">{{ invoice()!.traceability!.snapshotCapturedAt | date:'medium' }}</span>
+            </div>
+          }
+          @if (invoice()!.traceability!.workorderCompletedAt) {
+            <div class="trace-grid__item">
+              <span class="trace-grid__label">Work Order Completed</span>
+              <span class="trace-grid__value">{{ invoice()!.traceability!.workorderCompletedAt | date:'medium' }}</span>
+            </div>
+          }
+          @if (invoice()!.traceability!.snapshotVersion) {
+            <div class="trace-grid__item">
+              <span class="trace-grid__label">Snapshot Version</span>
+              <span class="trace-grid__value">{{ invoice()!.traceability!.snapshotVersion }}</span>
+            </div>
+          }
+          @if (invoice()!.traceability!.generatedById) {
+            <div class="trace-grid__item">
+              <span class="trace-grid__label">Generated By</span>
+              <span class="trace-grid__value">{{ invoice()!.traceability!.generatedById }}</span>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Artifacts ──────────────────────────────────────────────────────── -->
+    @if (artifacts().length > 0) {
+      <div class="wo-section" aria-labelledby="artifacts-heading">
+        <h2 id="artifacts-heading" class="section-heading">Documents</h2>
+        @for (art of artifacts(); track art.artifactRefId) {
+          <div class="artifact-row">
+            <span class="artifact-row__name">{{ art.fileName ?? art.filename }}</span>
+            <span class="artifact-row__type hint-text">{{ art.contentType ?? art.mimeType }}</span>
+            <button class="btn btn--ghost btn--sm" (click)="downloadArtifact(art.artifactRefId, art.fileName ?? art.filename ?? 'invoice')">
+              Download
+            </button>
+          </div>
+        }
+      </div>
+    }
+
+  }
+
+</section>
+
+<!-- Story 209: Elevation modal ─────────────────────────────────────────── -->
+@if (showElevationModal()) {
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="elevation-heading">
+    <div class="modal" aria-label="Manager elevation required">
+      <div class="modal__header">
+        <h2 id="elevation-heading" class="modal__title">Manager Authorisation Required</h2>
+      </div>
+      <div class="modal__body">
+        <p class="modal__desc">
+          Issuing this invoice requires manager-level authorisation.
+          Enter the manager password to proceed.
+        </p>
+        <div class="form-field">
+          <label for="elevation-password" class="form-label">Manager Password</label>
+          <input
+            id="elevation-password"
+            type="password"
+            class="form-input"
+            [value]="elevationPassword()"
+            (input)="elevationPassword.set($any($event.target).value)"
+            placeholder="Enter password"
+            autocomplete="current-password"
+          />
+        </div>
+        @if (elevationError()) {
+          <div class="alert alert--error" role="alert">{{ elevationError() }}</div>
+        }
+      </div>
+      <div class="modal__footer">
+        <button class="btn btn--ghost" (click)="dismissElevationModal()">Cancel</button>
+        <button
+          class="btn btn--accent"
+          (click)="elevate()"
+          [attr.aria-busy]="issueState() === 'elevating'"
+          [disabled]="issueState() === 'elevating'"
+        >
+          {{ issueState() === 'elevating' ? 'Verifying…' : 'Authorise' }}
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.ts
+++ b/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.ts
@@ -1,0 +1,216 @@
+import { CurrencyPipe, DatePipe, SlicePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  InvoiceDetail,
+  InvoiceArtifact,
+  IssueInvoiceRequest,
+} from '../../models/billing.models';
+import { BillingService } from '../../services/billing.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+type IssueState = 'idle' | 'elevating' | 'issuing' | 'success' | 'error';
+
+/**
+ * InvoiceDetailPageComponent — CAP-007 Stories 209–212.
+ *
+ * Story 209: Issue Invoice (with optional elevation)
+ * Story 210: Adjustments display
+ * Story 211: Traceability breakdown
+ * Story 212: Invoice totals summary
+ *
+ * Route: /app/billing/invoices/:invoiceId
+ */
+@Component({
+  selector: 'app-invoice-detail-page',
+  standalone: true,
+  imports: [CurrencyPipe, DatePipe, SlicePipe, FormsModule],
+  templateUrl: './invoice-detail-page.component.html',
+  styleUrl: './invoice-detail-page.component.css',
+})
+export class InvoiceDetailPageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(BillingService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly invoiceId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly invoice = signal<InvoiceDetail | null>(null);
+  readonly artifacts = signal<InvoiceArtifact[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Issue flow */
+  readonly issueState = signal<IssueState>('idle');
+  readonly issueError = signal<string | null>(null);
+  readonly issueSuccess = signal(false);
+  /** Elevation modal */
+  readonly showElevationModal = signal(false);
+  readonly elevationPassword = signal('');
+  readonly elevationToken = signal<string | null>(null);
+  readonly elevationError = signal<string | null>(null);
+
+  readonly requiresElevation = computed(
+    () => this.invoice()?.issuancePolicy?.requiresElevation ?? false,
+  );
+
+  readonly canIssue = computed(() => {
+    const inv = this.invoice();
+    if (!inv) return false;
+    const status = inv.status?.toUpperCase();
+    return (status === 'DRAFT' || status === 'FINALIZED') &&
+      this.issueState() === 'idle' &&
+      !this.issueSuccess();
+  });
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('invoiceId') ?? '';
+    this.invoiceId.set(id);
+    this.loadInvoice(id);
+  }
+
+  private loadInvoice(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getInvoiceDetail(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (inv) => {
+          this.invoice.set(inv);
+          this.pageState.set('ready');
+          this.loadArtifacts(id);
+        },
+        error: (err) => {
+          this.errorMessage.set(
+            err?.status === 404
+              ? 'Invoice not found.'
+              : 'Failed to load invoice. Please try again.',
+          );
+          this.pageState.set('error');
+        },
+      });
+  }
+
+  private loadArtifacts(id: string): void {
+    this.service
+      .getInvoiceArtifacts(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (arts) => this.artifacts.set(arts ?? []),
+        error: () => this.artifacts.set([]),
+      });
+  }
+
+  /** Issue flow entry point. */
+  initiateIssue(): void {
+    if (!this.canIssue()) return;
+    if (this.requiresElevation() && !this.elevationToken()) {
+      this.elevationError.set(null);
+      this.elevationPassword.set('');
+      this.showElevationModal.set(true);
+    } else {
+      this.performIssue();
+    }
+  }
+
+  elevate(): void {
+    const pw = this.elevationPassword().trim();
+    if (!pw) {
+      this.elevationError.set('Password is required.');
+      return;
+    }
+    this.issueState.set('elevating');
+    this.elevationError.set(null);
+    this.service
+      .elevate({ password: pw })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.elevationToken.set(res.elevationToken);
+          this.showElevationModal.set(false);
+          this.issueState.set('idle');
+          this.performIssue();
+        },
+        error: (err) => {
+          this.issueState.set('idle');
+          this.elevationError.set(
+            err?.status === 401
+              ? 'Incorrect password. Please try again.'
+              : 'Elevation failed. Please contact your manager.',
+          );
+        },
+      });
+  }
+
+  dismissElevationModal(): void {
+    this.showElevationModal.set(false);
+    this.issueState.set('idle');
+  }
+
+  private performIssue(): void {
+    this.issueState.set('issuing');
+    this.issueError.set(null);
+    const body: IssueInvoiceRequest = {};
+    const token = this.elevationToken();
+    if (token) body.elevationToken = token;
+    this.service
+      .issueInvoice(this.invoiceId(), body)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.issueState.set('success');
+          this.issueSuccess.set(true);
+          this.invoice.update(inv => inv ? { ...inv, status: 'ISSUED' } : inv);
+          this.loadArtifacts(this.invoiceId());
+        },
+        error: (err) => {
+          this.issueState.set('error');
+          this.issueError.set(
+            err?.status === 409
+              ? 'Invoice has already been issued.'
+              : err?.error?.message ?? 'Failed to issue invoice. Please try again.',
+          );
+        },
+      });
+  }
+
+  downloadArtifact(artifactRefId: string, filename: string): void {
+    this.service
+      .getArtifactDownloadToken(artifactRefId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          const url = res.downloadUrl ?? `/billing/artifacts/${artifactRefId}/download?token=${res.downloadToken}`;
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = filename;
+          a.target = '_blank';
+          a.rel = 'noopener noreferrer';
+          a.click();
+        },
+        error: () => {},
+      });
+  }
+
+  goBack(): void {
+    const workorderId = this.invoice()?.workOrderId;
+    if (workorderId) {
+      this.router.navigate(['/app/workexec/workorders', workorderId]);
+    } else {
+      this.router.navigate(['/app/billing']);
+    }
+  }
+
+  statusClass(status?: string): string {
+    return (status ?? '').toLowerCase().replace(/_/g, '-');
+  }
+}

--- a/src/app/features/billing/services/billing.service.ts
+++ b/src/app/features/billing/services/billing.service.ts
@@ -1,0 +1,100 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiBaseService } from '../../../core/services/api-base.service';
+import {
+  ArtifactDownloadToken,
+  CreateInvoiceDraftRequest,
+  CreateInvoiceDraftResponse,
+  ElevateRequest,
+  ElevateResponse,
+  InvoiceArtifact,
+  InvoiceDetail,
+  IssueInvoiceRequest,
+} from '../models/billing.models';
+
+/**
+ * BillingService — CAP-007 (Stories 213–209)
+ * Base path: /billing (billing microservice)
+ */
+@Injectable({ providedIn: 'root' })
+export class BillingService {
+  constructor(private readonly api: ApiBaseService) {}
+
+  // ── Invoice draft ─────────────────────────────────────────────────────────
+
+  /**
+   * POST /billing/invoices/draft
+   * Creates an invoice draft from a completed workorder (Story 213).
+   * Idempotent by workOrderId.
+   */
+  createInvoiceDraft(
+    body: CreateInvoiceDraftRequest,
+    idempotencyKey?: string,
+  ): Observable<CreateInvoiceDraftResponse> {
+    return this.api.post<CreateInvoiceDraftResponse>(
+      '/billing/invoices/draft',
+      body,
+      idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : undefined,
+    );
+  }
+
+  // ── Invoice detail ────────────────────────────────────────────────────────
+
+  /**
+   * GET /billing/invoices/{invoiceId}
+   * Returns full invoice detail with line items, totals, traceability,
+   * issuance policy (Stories 212, 211, 210, 209).
+   */
+  getInvoiceDetail(invoiceId: string): Observable<InvoiceDetail> {
+    return this.api.get<InvoiceDetail>(`/billing/invoices/${invoiceId}`);
+  }
+
+  /**
+   * GET /billing/invoices/by-work-order/{workOrderId}
+   * Look up invoice by work order (optional alternate entry point).
+   */
+  getInvoiceByWorkOrder(workOrderId: string): Observable<InvoiceDetail> {
+    return this.api.get<InvoiceDetail>(`/billing/invoices/by-work-order/${workOrderId}`);
+  }
+
+  // ── Artifacts ─────────────────────────────────────────────────────────────
+
+  /**
+   * GET /billing/invoices/{invoiceId}/artifacts
+   * Returns artifact list for the invoice (Story 209).
+   */
+  getInvoiceArtifacts(invoiceId: string): Observable<InvoiceArtifact[]> {
+    return this.api.get<InvoiceArtifact[]>(`/billing/invoices/${invoiceId}/artifacts`);
+  }
+
+  /**
+   * POST /billing/artifacts/{artifactRefId}/download-token
+   * Obtains a short-lived download token for an artifact (Story 209).
+   */
+  getArtifactDownloadToken(artifactRefId: string): Observable<ArtifactDownloadToken> {
+    return this.api.post<ArtifactDownloadToken>(
+      `/billing/artifacts/${artifactRefId}/download-token`,
+      {},
+    );
+  }
+
+  // ── Issue invoice ─────────────────────────────────────────────────────────
+
+  /**
+   * POST /billing/invoices/{invoiceId}/issue
+   * Issues the invoice. Requires elevationToken when policy demands it (Story 209).
+   */
+  issueInvoice(invoiceId: string, body: IssueInvoiceRequest): Observable<InvoiceDetail> {
+    return this.api.post<InvoiceDetail>(`/billing/invoices/${invoiceId}/issue`, body);
+  }
+
+  // ── Step-up authentication ────────────────────────────────────────────────
+
+  /**
+   * POST /billing/auth/elevate
+   * Returns a short-lived elevationToken for privileged actions (Story 209).
+   */
+  elevate(body: ElevateRequest): Observable<ElevateResponse> {
+    return this.api.post<ElevateResponse>('/billing/auth/elevate', body);
+  }
+}

--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -463,3 +463,96 @@ export type PageState = 'idle' | 'loading' | 'ready' | 'saving' | 'success' | 'e
 
 /** Totals panel state machine (Story 236) */
 export type TotalsState = 'idle' | 'recalculating' | 'updated' | 'blocked-config' | 'error';
+
+// ── CAP-006: Completion + Reopen (Stories 218, 215, 214) ─────────────────────
+
+/**
+ * operationId: completeWorkorder
+ * POST /v1/workorders/{workorderId}/complete
+ */
+export interface CompleteWorkorderRequest {
+  completionNotes?: string;
+}
+
+export interface CompletionFailedCheck {
+  checkId: string;
+  description: string;
+  severity: 'BLOCKING' | 'WARNING';
+}
+
+export interface CompleteWorkorderResponse {
+  workorderId: string;
+  status: WorkorderStatus;
+  completedAt?: string;
+  completedBy?: string;
+  completionNotes?: string;
+  failedChecks?: CompletionFailedCheck[];
+}
+
+/**
+ * operationId: reopenWorkorder
+ * POST /v1/workorders/{workorderId}/reopen
+ */
+export interface ReopenWorkorderRequest {
+  reopenReason: string;
+}
+
+export interface ReopenWorkorderResponse {
+  workorderId: string;
+  status: WorkorderStatus;
+  reopenedAt?: string;
+  reopenedBy?: string;
+  reopenReason?: string;
+}
+
+// ── CAP-006: Finalize Billable Scope Snapshot (Story 216) ────────────────────
+
+/**
+ * POST /v1/workorders/{workorderId}/finalize
+ */
+export interface FinalizeWorkorderRequest {
+  snapshotType?: string;
+  poNumber?: string;
+}
+
+export interface BillableScopeSnapshotItem {
+  id: string;
+  description?: string;
+  quantity?: number;
+  unitPrice?: number;
+  lineTotal?: number;
+  itemType?: 'PART' | 'LABOR';
+}
+
+export interface BillableScopeSnapshot {
+  snapshotId: string;
+  workorderId: string;
+  snapshotVersion: number;
+  snapshotStatus: string;
+  partsTotal?: number;
+  laborTotal?: number;
+  taxTotal?: number;
+  grandTotal?: number;
+  poNumber?: string;
+  finalizedAt?: string;
+  finalizedBy?: string;
+  items?: BillableScopeSnapshotItem[];
+}
+
+export interface FinalizeWorkorderResponse extends BillableScopeSnapshot {
+  message?: string;
+}
+
+/**
+ * operationId: getSnapshotHistory
+ * GET /v1/workorders/{workorderId}/snapshots
+ */
+export interface WorkorderSnapshotHistoryEntry {
+  id: string;
+  workorderId?: string;
+  status?: string;
+  snapshotData?: string;
+  capturedAt?: string;
+  capturedById?: string;
+  notes?: string;
+}

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
@@ -43,3 +43,25 @@
 .btn--decline {background:#ffebee;color:#c62828;border:1px solid rgba(198,40,40,0.3);}
 .btn--approve:disabled,.btn--decline:disabled {opacity:0.5;cursor:not-allowed;}
 .btn-icon {background:none;border:none;cursor:pointer;font-size:0.9rem;padding:var(--space-1);}
+
+/* ── Story 217: Blocker banner ──────────────────────────────────────────── */
+
+.blocker-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin: 1rem 1.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm, 4px);
+  background: var(--color-warning-surface, #fef3c7);
+  border: 1px solid var(--color-warning, #d97706);
+  color: var(--color-warning-on, #92400e);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.blocker-banner__icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.html
@@ -11,6 +11,23 @@
       <h1 id="cr-heading">Change Requests</h1>
     </header>
 
+    <!-- Story 217: Blocker banner -->
+    @if (blockers().length > 0) {
+      <div class="blocker-banner" role="alert" aria-label="Approval blockers">
+        <span class="blocker-banner__icon" aria-hidden="true">⚠</span>
+        <span>
+          <strong>{{ blockers().length }} {{ blockers().length === 1 ? 'change request requires' : 'change requests require' }} your approval</strong>
+          before this work order can be completed. Resolve all items below.
+        </span>
+      </div>
+    }
+
+    @if (resolvedCount() > 0 && blockers().length === 0) {
+      <div class="alert alert--success" role="status">
+        All change requests resolved. Work order is clear to complete.
+      </div>
+    }
+
     <div class="cr-header-row">
       <p class="section-overline">Requests ({{ changeRequests().length }})</p>
       <button class="btn btn--accent btn--sm" (click)="openCreateForm()">+ New Request</button>
@@ -34,7 +51,7 @@
               <select
                 class="field__input"
                 [value]="item.type"
-                (change)="updateItem($index, $any($event.target).value === 'SERVICE' ? { type: 'SERVICE', partId: null } : { type: 'PART', serviceId: null })">
+                (change)="updateItem($index, $any($event.target).value === 'SERVICE' ? { type: 'SERVICE', partId: undefined } : { type: 'PART', serviceId: undefined })">
                 <option value="SERVICE">Service</option>
                 <option value="PART">Part</option>
               </select>

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -14,10 +14,12 @@ import { WorkexecService } from '../../services/workexec.service';
 type PageState = 'loading' | 'ready' | 'error';
 
 /**
- * WorkorderChangeRequestsPageComponent — Story 220 (CAP-005)
+ * WorkorderChangeRequestsPageComponent — Story 220 (CAP-005) + Story 217 (CAP-006)
  * Route: /app/workexec/workorders/:workorderId/change-requests
  * operationIds: createChangeRequest, approveChangeRequest, declineChangeRequest,
  *               getChangeRequestsByWorkorder, getChangeRequestById
+ *
+ * Story 217 adds: blockers computed list, blocker banner, resolved-count summary.
  */
 @Component({
   selector: 'app-workorder-change-requests-page',
@@ -162,6 +164,15 @@ export class WorkorderChangeRequestsPageComponent implements OnInit {
         },
       });
   }
+
+  /** Story 217 — approval-gated blockers */
+  readonly blockers = computed(() =>
+    this.changeRequests().filter(cr => cr.status === 'AWAITING_ADVISOR_REVIEW'),
+  );
+
+  readonly resolvedCount = computed(() =>
+    this.changeRequests().filter(cr => cr.status === 'APPROVED' || cr.status === 'DECLINED').length,
+  );
 
   back(): void {
     this.router.navigate(['/app/workexec/workorders', this.workorderId()]);

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.css
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.css
@@ -77,3 +77,139 @@
 .btn--accent:disabled {opacity:0.5;cursor:not-allowed;}
 .btn--ghost {background:transparent;border:1px solid rgba(var(--outline-variant-rgb,130,130,130),0.35);color:var(--currentTextColor,#1f2328);}
 .btn--full {width:100%;}
+
+/* ── Tab badge (Story 218 — Story 217) ──────────────────────────────────── */
+
+.tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 9999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0 0.3rem;
+  margin-left: 0.4rem;
+  line-height: 1;
+}
+
+.tab-badge--warning {
+  background: var(--color-warning, #f59e0b);
+  color: var(--color-on-warning, #1f2328);
+}
+
+/* ── Inline error beside CTA ────────────────────────────────────────────── */
+
+.inline-error {
+  font-size: 0.8rem;
+  color: var(--color-error, #dc2626);
+  margin-left: 0.5rem;
+}
+
+/* ── Completion checklist panel (Story 218) ─────────────────────────────── */
+
+.checklist-panel {
+  margin: 1.25rem 1.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface-container-low, #f8fafc);
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+}
+
+.checklist-panel__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-on-surface, #1f2328);
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.checklist-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  font-size: 0.875rem;
+  border-bottom: 1px solid var(--color-outline-variant, #d0d7de);
+}
+
+.checklist-item:last-child {
+  border-bottom: none;
+}
+
+.checklist-item__icon {
+  flex-shrink: 0;
+  font-weight: 700;
+  width: 1.25rem;
+  text-align: center;
+}
+
+.checklist-item--ok .checklist-item__icon { color: var(--color-success, #16a34a); }
+.checklist-item--blocking .checklist-item__icon { color: var(--color-error, #dc2626); }
+.checklist-item--warning .checklist-item__icon { color: var(--color-warning, #f59e0b); }
+
+.checklist-item__label { flex: 1; }
+
+/* ── Form fields (modals) ───────────────────────────────────────────────── */
+
+.form-field { margin-bottom: 1rem; }
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.35rem;
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-textarea {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.875rem;
+  font-family: inherit;
+  resize: vertical;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-textarea:focus {
+  outline: 2px solid var(--brand-accent, #14c8b4);
+  outline-offset: 1px;
+  border-color: var(--brand-accent, #14c8b4);
+}
+
+.required-mark { color: var(--color-error, #dc2626); }
+
+/* ── Failed checks list ─────────────────────────────────────────────────── */
+
+.failed-checks {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 1rem;
+}
+
+.failed-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.4rem 0;
+  font-size: 0.875rem;
+}
+
+.failed-check__icon { flex-shrink: 0; font-weight: 700; }
+.failed-check--blocking .failed-check__icon { color: var(--color-error, #dc2626); }
+.failed-check--warning .failed-check__icon { color: var(--color-warning, #f59e0b); }
+
+/* ── Success alert ──────────────────────────────────────────────────────── */
+
+.alert--success {
+  background: var(--color-success-surface, #dcfce7);
+  color: var(--color-success, #16a34a);
+  border: 1px solid var(--color-success, #16a34a);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+}

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
@@ -54,6 +54,24 @@
             <button class="btn btn--ghost" (click)="navigateToLabor()">Record Labor</button>
             <button class="btn btn--ghost" (click)="navigateToParts()">Manage Parts</button>
             <button class="btn btn--ghost" (click)="navigateToChangeRequests()">Change Requests</button>
+            <button class="btn btn--ghost" (click)="navigateToFinalize()">Finalize for Billing</button>
+          }
+          @if (canComplete()) {
+            <button class="btn btn--accent" (click)="openCompleteModal()">Complete Work Order</button>
+          }
+          @if (canReopen()) {
+            <button class="btn btn--ghost" (click)="openReopenModal()">Reopen</button>
+          }
+          @if (canCreateInvoice()) {
+            <button
+              class="btn btn--accent"
+              (click)="generateInvoice()"
+              [disabled]="invoiceLoading()"
+              [attr.aria-busy]="invoiceLoading()"
+            >{{ invoiceLoading() ? 'Creating Invoice…' : 'Create Invoice' }}</button>
+          }
+          @if (invoiceError()) {
+            <span class="inline-error" role="alert">{{ invoiceError() }}</span>
           }
           <button class="btn btn--ghost" (click)="navigateToAssign()">
             {{ technicianName() ? 'Reassign' : 'Assign Technician' }}
@@ -84,7 +102,12 @@
         class="wo-tab"
         [class.wo-tab--active]="activeTab() === 'change-requests'"
         (click)="navigateToChangeRequests()"
-      >Change Requests</button>
+      >
+        Change Requests
+        @if (pendingCrCount() > 0) {
+          <span class="tab-badge tab-badge--warning" aria-label="{{ pendingCrCount() }} pending">{{ pendingCrCount() }}</span>
+        }
+      </button>
       <button
         class="wo-tab"
         [class.wo-tab--active]="activeTab() === 'audit'"
@@ -181,6 +204,39 @@
 
 </section>
 
+<!-- Completion Checklist Panel (Story 218) — shown when canComplete -->
+@if (pageState() === 'ready' && canComplete()) {
+  <aside class="checklist-panel" aria-label="Completion readiness checklist">
+    <h3 class="checklist-panel__title">Completion Checklist</h3>
+    @if (checklistLoading()) {
+      <p class="hint-text" aria-busy="true">Checking prerequisites…</p>
+    } @else {
+      @if (pendingCrCount() > 0) {
+        <div class="checklist-item checklist-item--blocking" role="listitem">
+          <span class="checklist-item__icon" aria-hidden="true">✗</span>
+          <span class="checklist-item__label">
+            {{ pendingCrCount() }} change request(s) pending advisor review — resolve before completing.
+          </span>
+          <button class="btn-link" (click)="navigateToChangeRequests()">View Change Requests</button>
+        </div>
+      } @else {
+        <div class="checklist-item checklist-item--ok" role="listitem">
+          <span class="checklist-item__icon" aria-hidden="true">✓</span>
+          <span class="checklist-item__label">No pending change requests.</span>
+        </div>
+      }
+      @if (failedChecks().length > 0) {
+        @for (check of failedChecks(); track check.checkId) {
+          <div class="checklist-item checklist-item--{{ check.severity === 'BLOCKING' ? 'blocking' : 'warning' }}" role="listitem">
+            <span class="checklist-item__icon" aria-hidden="true">{{ check.severity === 'BLOCKING' ? '✗' : '!' }}</span>
+            <span class="checklist-item__label">{{ check.description }}</span>
+          </div>
+        }
+      }
+    }
+  </aside>
+}
+
 <!-- Start Work confirmation modal — glassmorphism per design authority -->
 @if (showStartWorkModal()) {
   <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-work-modal-title">
@@ -210,6 +266,118 @@
           {{ startWorkLoading() ? 'Starting…' : 'Confirm — Start Work' }}
         </button>
       </div>
+    </div>
+  </div>
+}
+
+<!-- Complete Work Order modal (Story 215) — glassmorphism -->
+@if (showCompleteModal()) {
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="complete-modal-title">
+    <div class="modal-glass">
+      <h2 id="complete-modal-title" class="modal-glass__title">Complete Work Order</h2>
+
+      @if (completeModalState() === 'success') {
+        <div class="alert alert--success" role="status">Work order completed successfully.</div>
+      } @else {
+        <p class="modal-glass__body">
+          Mark this work order as <strong>COMPLETED</strong>. Ensure all labor and parts have been recorded.
+        </p>
+
+        <div class="form-field">
+          <label for="completion-notes" class="form-label">Completion Notes <span class="hint-text">(optional)</span></label>
+          <textarea
+            id="completion-notes"
+            class="form-textarea"
+            rows="3"
+            [value]="completionNotes()"
+            (input)="completionNotes.set($any($event.target).value)"
+            placeholder="Describe any final notes or observations…"
+          ></textarea>
+        </div>
+
+        @if (completeError()) {
+          <div class="alert alert--error" role="alert">{{ completeError() }}</div>
+        }
+
+        @if (failedChecks().length > 0) {
+          <ul class="failed-checks" aria-label="Completion blockers">
+            @for (check of failedChecks(); track check.checkId) {
+              <li class="failed-check failed-check--{{ check.severity.toLowerCase() }}">
+                <span class="failed-check__icon" aria-hidden="true">{{ check.severity === 'BLOCKING' ? '✗' : '!' }}</span>
+                {{ check.description }}
+              </li>
+            }
+          </ul>
+        }
+
+        <div class="modal-glass__actions">
+          <button
+            class="btn btn--ghost"
+            (click)="cancelComplete()"
+            [disabled]="completeModalState() === 'loading'"
+          >Cancel</button>
+          <button
+            class="btn btn--accent"
+            (click)="confirmComplete()"
+            [disabled]="completeModalState() === 'loading' || pendingCrCount() > 0"
+            [attr.aria-busy]="completeModalState() === 'loading'"
+          >
+            {{ completeModalState() === 'loading' ? 'Completing…' : 'Confirm — Complete Work Order' }}
+          </button>
+        </div>
+      }
+    </div>
+  </div>
+}
+
+<!-- Reopen Work Order modal (Story 214) — glassmorphism -->
+@if (showReopenModal()) {
+  <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="reopen-modal-title">
+    <div class="modal-glass">
+      <h2 id="reopen-modal-title" class="modal-glass__title">Reopen Work Order</h2>
+
+      @if (reopenModalState() === 'success') {
+        <div class="alert alert--success" role="status">Work order reopened successfully.</div>
+      } @else {
+        <p class="modal-glass__body">
+          This will move the work order back to <strong>IN PROGRESS</strong>.
+          A reason is required.
+        </p>
+
+        <div class="form-field">
+          <label for="reopen-reason" class="form-label">Reopen Reason <span class="required-mark" aria-hidden="true">*</span></label>
+          <textarea
+            id="reopen-reason"
+            class="form-textarea"
+            rows="3"
+            [value]="reopenReason()"
+            (input)="reopenReason.set($any($event.target).value)"
+            placeholder="Explain why this work order is being reopened…"
+            required
+            aria-required="true"
+          ></textarea>
+        </div>
+
+        @if (reopenError()) {
+          <div class="alert alert--error" role="alert">{{ reopenError() }}</div>
+        }
+
+        <div class="modal-glass__actions">
+          <button
+            class="btn btn--ghost"
+            (click)="cancelReopen()"
+            [disabled]="reopenModalState() === 'loading'"
+          >Cancel</button>
+          <button
+            class="btn btn--accent"
+            (click)="confirmReopen()"
+            [disabled]="reopenModalState() === 'loading' || !reopenReason().trim()"
+            [attr.aria-busy]="reopenModalState() === 'loading'"
+          >
+            {{ reopenModalState() === 'loading' ? 'Reopening…' : 'Confirm — Reopen Work Order' }}
+          </button>
+        </div>
+      }
     </div>
   </div>
 }

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import {
   Component,
   DestroyRef,
@@ -11,6 +12,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { v4 as uuidv4 } from 'uuid';
 import {
+  ChangeRequestResponse,
+  CompleteWorkorderRequest,
+  CompleteWorkorderResponse,
+  CompletionFailedCheck,
+  ReopenWorkorderRequest,
   WorkorderDetailResponse,
   WorkorderItemResponse,
   WorkorderStartResponse,
@@ -20,25 +26,19 @@ import { WorkexecService } from '../../services/workexec.service';
 
 type PageState = 'loading' | 'ready' | 'error';
 type WorkorderTab = 'items' | 'labor' | 'parts' | 'change-requests' | 'audit';
+type ModalState = 'idle' | 'confirming' | 'loading' | 'success' | 'error';
 
 /**
- * WorkorderDetailPageComponent — Story 230 (hub scaffold),
- * Stories 229 (items), 226 (audit trail), 224 (status CTAs), 219 (role visibility).
+ * WorkorderDetailPageComponent — CAP-004 (Story 230), CAP-005 (Stories 229, 226, 224, 219),
+ * CAP-006 (Stories 218 completion checklist, 215 complete, 214 reopen),
+ * CAP-007 (Story 213 — "Create Invoice" CTA).
  *
  * Route: /app/workexec/workorders/:workorderId
- *
- * Design Authority directives applied:
- *   - Blueprint-blue gradient header (135deg #0f3560 → #2b4c78) with white text
- *   - Electric Teal CTAs (--brand-accent, btn btn--accent) for "Start Work" only
- *   - Tab indicator: 2px secondary bottom-border, no box
- *   - No dividers in item lists — tonal alternation via surface/surface-container-low
- *   - Glassmorphism confirmation modal for Start Work (rgba + backdrop-filter blur)
- *   - Status chip classes: status-chip status-chip--{status|lowercase}
  */
 @Component({
   selector: 'app-workorder-detail-page',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink],
   templateUrl: './workorder-detail-page.component.html',
   styleUrl: './workorder-detail-page.component.css',
 })
@@ -55,14 +55,43 @@ export class WorkorderDetailPageComponent implements OnInit {
   readonly activeTab = signal<WorkorderTab>('items');
   readonly errorMessage = signal<string | null>(null);
 
-  /** Start Work confirmation modal */
+  // ── Start Work modal ──────────────────────────────────────────────────────
+
   readonly showStartWorkModal = signal(false);
   readonly startWorkLoading = signal(false);
   readonly startWorkError = signal<string | null>(null);
   readonly startWorkResult = signal<WorkorderStartResponse | null>(null);
 
-  /** Audit trail expand/collapse */
+  // ── Complete Work Order (Story 215) ───────────────────────────────────────
+
+  readonly showCompleteModal = signal(false);
+  readonly completeModalState = signal<ModalState>('idle');
+  readonly completionNotes = signal('');
+  readonly completeError = signal<string | null>(null);
+  readonly failedChecks = signal<CompletionFailedCheck[]>([]);
+
+  // ── Reopen Work Order (Story 214) ────────────────────────────────────────
+
+  readonly showReopenModal = signal(false);
+  readonly reopenModalState = signal<ModalState>('idle');
+  readonly reopenReason = signal('');
+  readonly reopenError = signal<string | null>(null);
+
+  // ── Completion checklist / blockers (Story 218) ──────────────────────────
+
+  readonly changeRequests = signal<ChangeRequestResponse[]>([]);
+  readonly checklistLoading = signal(false);
+
+  // ── Generate Invoice (Story 213 — CAP-007 entry) ─────────────────────────
+
+  readonly invoiceLoading = signal(false);
+  readonly invoiceError = signal<string | null>(null);
+
+  // ── Audit trail expand/collapse ───────────────────────────────────────────
+
   readonly auditExpanded = signal(false);
+
+  // ── Computed guards ───────────────────────────────────────────────────────
 
   readonly canStartWork = computed(() => {
     const wo = this.workorder();
@@ -70,6 +99,23 @@ export class WorkorderDetailPageComponent implements OnInit {
   });
 
   readonly isInProgress = computed(() => this.workorder()?.status === 'IN_PROGRESS');
+
+  readonly isCompleted = computed(() => this.workorder()?.status === 'COMPLETED');
+
+  readonly canComplete = computed(() => {
+    const wo = this.workorder();
+    return wo?.status === 'IN_PROGRESS' || wo?.status === 'PENDING_REVIEW';
+  });
+
+  readonly canReopen = computed(() => this.workorder()?.status === 'COMPLETED');
+
+  readonly canCreateInvoice = computed(() =>
+    this.workorder()?.status === 'COMPLETED' || this.workorder()?.status === 'INVOICED',
+  );
+
+  readonly pendingCrCount = computed(
+    () => this.changeRequests().filter(cr => cr.status === 'AWAITING_ADVISOR_REVIEW').length,
+  );
 
   readonly items = computed((): WorkorderItemResponse[] => this.workorder()?.items ?? []);
 
@@ -98,6 +144,7 @@ export class WorkorderDetailPageComponent implements OnInit {
           if (this.activeTab() === 'audit') {
             this.loadTransitions(id);
           }
+          this.loadChangeRequests(id);
         },
         error: (err) => {
           const status = err?.status ?? 0;
@@ -110,6 +157,20 @@ export class WorkorderDetailPageComponent implements OnInit {
           );
           this.pageState.set('error');
         },
+      });
+  }
+
+  private loadChangeRequests(id: string): void {
+    this.checklistLoading.set(true);
+    this.service
+      .getChangeRequestsByWorkorder(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (crs) => {
+          this.changeRequests.set(crs);
+          this.checklistLoading.set(false);
+        },
+        error: () => this.checklistLoading.set(false),
       });
   }
 
@@ -126,11 +187,11 @@ export class WorkorderDetailPageComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (t) => this.transitions.set(t),
-        error: () => {
-          /* non-blocking: audit trail load failure is silent */
-        },
+        error: () => { /* non-blocking */ },
       });
   }
+
+  // ── Start Work ────────────────────────────────────────────────────────────
 
   openStartWorkModal(): void {
     this.startWorkError.set(null);
@@ -168,6 +229,150 @@ export class WorkorderDetailPageComponent implements OnInit {
     this.startWorkError.set(null);
   }
 
+  // ── Complete Work Order (Story 215) ───────────────────────────────────────
+
+  openCompleteModal(): void {
+    this.completeModalState.set('confirming');
+    this.completeError.set(null);
+    this.failedChecks.set([]);
+    this.completionNotes.set('');
+    this.showCompleteModal.set(true);
+  }
+
+  confirmComplete(): void {
+    const id = this.workorderId();
+    this.completeModalState.set('loading');
+    this.completeError.set(null);
+    const body: CompleteWorkorderRequest = {
+      completionNotes: this.completionNotes() || undefined,
+    };
+    this.service
+      .completeWorkorder(id, body, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res: CompleteWorkorderResponse) => {
+          if (res.failedChecks && res.failedChecks.length > 0) {
+            this.failedChecks.set(res.failedChecks);
+            this.completeModalState.set('error');
+            this.completeError.set('Completion blocked. Please resolve all issues below.');
+          } else {
+            this.completeModalState.set('success');
+            setTimeout(() => {
+              this.showCompleteModal.set(false);
+              this.completeModalState.set('idle');
+              this.loadWorkorder(id);
+            }, 1200);
+          }
+        },
+        error: (err) => {
+          this.completeModalState.set('error');
+          const apiError = err?.error;
+          if (apiError?.failedChecks?.length) {
+            this.failedChecks.set(apiError.failedChecks);
+            this.completeError.set('Completion blocked. Please resolve all issues below.');
+          } else {
+            const status = err?.status ?? 0;
+            this.completeError.set(
+              status === 409
+                ? 'Work order cannot be completed in its current state.'
+                : status === 422
+                  ? apiError?.message ?? 'Completion requirements not met.'
+                  : 'Failed to complete work order. Please try again.',
+            );
+          }
+        },
+      });
+  }
+
+  cancelComplete(): void {
+    this.showCompleteModal.set(false);
+    this.completeModalState.set('idle');
+    this.failedChecks.set([]);
+    this.completeError.set(null);
+  }
+
+  // ── Reopen Work Order (Story 214) ────────────────────────────────────────
+
+  openReopenModal(): void {
+    this.reopenModalState.set('confirming');
+    this.reopenError.set(null);
+    this.reopenReason.set('');
+    this.showReopenModal.set(true);
+  }
+
+  confirmReopen(): void {
+    const reason = this.reopenReason().trim();
+    if (!reason) {
+      this.reopenError.set('Reopen reason is required.');
+      return;
+    }
+    const id = this.workorderId();
+    this.reopenModalState.set('loading');
+    this.reopenError.set(null);
+    const body: ReopenWorkorderRequest = { reopenReason: reason };
+    this.service
+      .reopenWorkorder(id, body, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.reopenModalState.set('success');
+          setTimeout(() => {
+            this.showReopenModal.set(false);
+            this.reopenModalState.set('idle');
+            this.loadWorkorder(id);
+          }, 1200);
+        },
+        error: (err) => {
+          this.reopenModalState.set('error');
+          const status = err?.status ?? 0;
+          this.reopenError.set(
+            status === 409
+              ? 'Work order cannot be reopened in its current state.'
+              : 'Failed to reopen work order. Please try again.',
+          );
+        },
+      });
+  }
+
+  cancelReopen(): void {
+    this.showReopenModal.set(false);
+    this.reopenModalState.set('idle');
+    this.reopenError.set(null);
+  }
+
+  // ── Generate Invoice / Create Invoice Draft (Story 213 — CAP-007) ────────
+
+  generateInvoice(): void {
+    const id = this.workorderId();
+    this.invoiceLoading.set(true);
+    this.invoiceError.set(null);
+    this.service
+      .generateInvoice(id, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.invoiceLoading.set(false);
+          this.router.navigate(['/app/billing/invoices', res.invoiceId]);
+        },
+        error: (err) => {
+          this.invoiceLoading.set(false);
+          const status = err?.status ?? 0;
+          const existingId = err?.error?.invoiceId;
+          if ((status === 409 || status === 200) && existingId) {
+            this.router.navigate(['/app/billing/invoices', existingId]);
+          } else {
+            this.invoiceError.set(
+              status === 409
+                ? 'An invoice draft already exists for this work order.'
+                : 'Failed to create invoice. Please try again.',
+            );
+          }
+        },
+      });
+  }
+
+  // ── Navigation helpers ────────────────────────────────────────────────────
+
   navigateToAssign(): void {
     this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'assign']);
   }
@@ -182,6 +387,10 @@ export class WorkorderDetailPageComponent implements OnInit {
 
   navigateToChangeRequests(): void {
     this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'change-requests']);
+  }
+
+  navigateToFinalize(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'finalize']);
   }
 
   refresh(): void {

--- a/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.css
+++ b/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.css
@@ -1,0 +1,91 @@
+.workorder-finalize {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+/* ── Finalize action card ───────────────────────────────────────────────── */
+
+.finalize-card {
+  margin: 1.5rem;
+  padding: 1.5rem;
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface-container, #f1f5f9);
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+}
+
+.finalize-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-on-surface, #1f2328);
+  margin-bottom: 0.5rem;
+}
+
+.finalize-card__desc {
+  font-size: 0.875rem;
+  color: var(--color-on-surface-muted, #57606a);
+  margin-bottom: 1.25rem;
+  line-height: 1.5;
+}
+
+.finalize-card__actions {
+  margin-top: 1.25rem;
+}
+
+/* ── Form inputs ────────────────────────────────────────────────────────── */
+
+.form-field { margin-bottom: 1rem; }
+
+.form-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 500;
+  margin-bottom: 0.35rem;
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-input {
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-outline-variant, #d0d7de);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: var(--color-surface, #ffffff);
+  color: var(--color-on-surface, #1f2328);
+}
+
+.form-input:focus {
+  outline: 2px solid var(--brand-accent, #14c8b4);
+  outline-offset: 1px;
+  border-color: var(--brand-accent, #14c8b4);
+}
+
+/* ── Info alert ─────────────────────────────────────────────────────────── */
+
+.alert--info {
+  background: var(--color-info-surface, #dbeafe);
+  color: var(--color-info, #1d4ed8);
+  border: 1px solid var(--color-info, #1d4ed8);
+  border-radius: var(--radius-sm, 4px);
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin: 1.5rem;
+}
+
+/* ── Section heading ────────────────────────────────────────────────────── */
+
+.section-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-on-surface, #1f2328);
+  margin-bottom: 1rem;
+}
+
+/* ── Ledger mono cell ───────────────────────────────────────────────────── */
+
+.ledger__cell--mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+}

--- a/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.html
+++ b/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.html
@@ -1,0 +1,111 @@
+<section class="workexec-page workorder-finalize" aria-labelledby="finalize-heading">
+
+  <header class="wo-header" aria-labelledby="finalize-heading">
+    <div class="wo-header__inner">
+      <div class="wo-header__identity">
+        <p class="wo-header__overline">Work Order</p>
+        <h1 id="finalize-heading" class="wo-header__id">{{ workorderId() }}</h1>
+        <span class="status-chip status-chip--pending">Finalize for Billing</span>
+      </div>
+      <div class="wo-header__actions">
+        <button class="btn btn--ghost" (click)="goBack()">← Back to Work Order</button>
+      </div>
+    </div>
+  </header>
+
+  @if (pageState() === 'loading') {
+    <p class="hint-text" aria-busy="true">Loading snapshot history…</p>
+  }
+
+  @if (pageState() === 'error') {
+    <div class="alert alert--error" role="alert">
+      {{ errorMessage() }}
+      <button class="btn-link" (click)="refresh()">Retry</button>
+    </div>
+  }
+
+  @if (pageState() === 'ready') {
+
+    <!-- Finalize action card -->
+    @if (!hasActiveSnapshot()) {
+      <div class="finalize-card" aria-labelledby="finalize-action-title">
+        <h2 id="finalize-action-title" class="finalize-card__title">Finalize Billable Scope</h2>
+        <p class="finalize-card__desc">
+          Create an immutable snapshot of the work order's billable scope. This snapshot captures
+          all authorized parts, labor, and totals for invoice generation.
+        </p>
+
+        <div class="form-field">
+          <label for="po-number" class="form-label">PO Number <span class="hint-text">(if required by location)</span></label>
+          <input
+            id="po-number"
+            type="text"
+            class="form-input"
+            [value]="poNumber()"
+            (input)="poNumber.set($any($event.target).value)"
+            placeholder="e.g. PO-2026-001"
+          />
+        </div>
+
+        @if (finalizeError()) {
+          <div class="alert alert--error" role="alert">{{ finalizeError() }}</div>
+        }
+
+        @if (finalizeState() === 'success' && finalizeResult()) {
+          <div class="alert alert--success" role="status">
+            Billable scope snapshot created — Version {{ finalizeResult()!.snapshotVersion }}.
+            Grand Total: {{ finalizeResult()!.grandTotal | currency }}.
+          </div>
+        }
+
+        <div class="finalize-card__actions">
+          <button
+            class="btn btn--accent"
+            (click)="finalizeForBilling()"
+            [disabled]="!canFinalize()"
+            [attr.aria-busy]="finalizeState() === 'loading'"
+          >
+            {{ finalizeState() === 'loading' ? 'Finalizing…' : 'Finalize for Billing' }}
+          </button>
+        </div>
+      </div>
+    } @else {
+      <div class="alert alert--info" role="status">
+        An active billable snapshot already exists for this work order.
+        Invoice generation is available from the work order detail.
+      </div>
+    }
+
+    <!-- Snapshot history -->
+    <div class="wo-section" aria-label="Billable scope snapshot history">
+      <h2 class="section-heading">Snapshot History</h2>
+
+      @if (snapshots().length === 0) {
+        <p class="hint-text">No billable scope snapshots recorded yet.</p>
+      } @else {
+        <div class="ledger">
+          <div class="ledger__header">
+            <span>ID</span>
+            <span>Status</span>
+            <span>Captured</span>
+            <span>By</span>
+            <span>Notes</span>
+          </div>
+          @for (snap of snapshots(); track snap.id; let even = $even) {
+            <div class="ledger__row" [class.ledger__row--alt]="even">
+              <span class="ledger__cell ledger__cell--mono">{{ snap.id | slice:0:8 }}…</span>
+              <span class="ledger__cell">
+                <span class="status-chip status-chip--{{ snap.status?.toLowerCase() }}">{{ snap.status }}</span>
+              </span>
+              <span class="ledger__cell">{{ snap.capturedAt | date:'medium' }}</span>
+              <span class="ledger__cell">{{ snap.capturedById ?? '—' }}</span>
+              <span class="ledger__cell">{{ snap.notes ?? '—' }}</span>
+            </div>
+          }
+        </div>
+      }
+    </div>
+
+  }
+
+</section>

--- a/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.ts
@@ -1,0 +1,132 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  BillableScopeSnapshot,
+  FinalizeWorkorderRequest,
+  WorkorderSnapshotHistoryEntry,
+} from '../../models/workexec.models';
+import { WorkexecService } from '../../services/workexec.service';
+
+type PageState = 'loading' | 'ready' | 'error';
+type FinalizeState = 'idle' | 'loading' | 'success' | 'error';
+
+/**
+ * WorkorderFinalizePageComponent — Story 216: Finalize Billable Scope Snapshot.
+ *
+ * Route: /app/workexec/workorders/:workorderId/finalize
+ *
+ * Allows Service Advisors to finalize a work order for billing, creating an
+ * immutable billable scope snapshot. Displays snapshot history.
+ */
+@Component({
+  selector: 'app-workorder-finalize-page',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './workorder-finalize-page.component.html',
+  styleUrl: './workorder-finalize-page.component.css',
+})
+export class WorkorderFinalizePageComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly service = inject(WorkexecService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly workorderId = signal<string>('');
+  readonly pageState = signal<PageState>('loading');
+  readonly snapshots = signal<WorkorderSnapshotHistoryEntry[]>([]);
+  readonly errorMessage = signal<string | null>(null);
+
+  /** Finalize form */
+  readonly poNumber = signal('');
+  readonly finalizeState = signal<FinalizeState>('idle');
+  readonly finalizeError = signal<string | null>(null);
+  readonly finalizeResult = signal<BillableScopeSnapshot | null>(null);
+
+  readonly hasActiveSnapshot = computed(() =>
+    this.snapshots().some(s => s.status === 'ACTIVE'),
+  );
+
+  readonly canFinalize = computed(
+    () => !this.hasActiveSnapshot() && this.finalizeState() !== 'loading',
+  );
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
+    this.workorderId.set(id);
+    this.loadSnapshots(id);
+  }
+
+  private loadSnapshots(id: string): void {
+    this.pageState.set('loading');
+    this.service
+      .getSnapshotHistory(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (snaps) => {
+          this.snapshots.set(snaps);
+          this.pageState.set('ready');
+        },
+        error: (err) => {
+          const status = err?.status ?? 0;
+          if (status === 404) {
+            this.snapshots.set([]);
+            this.pageState.set('ready');
+          } else {
+            this.errorMessage.set('Failed to load snapshot history. Please try again.');
+            this.pageState.set('error');
+          }
+        },
+      });
+  }
+
+  finalizeForBilling(): void {
+    if (!this.canFinalize()) return;
+    const id = this.workorderId();
+    this.finalizeState.set('loading');
+    this.finalizeError.set(null);
+    const body: FinalizeWorkorderRequest = {
+      snapshotType: 'BILLABLE_SNAPSHOT',
+      poNumber: this.poNumber() || undefined,
+    };
+    this.service
+      .finalizeWorkorder(id, body, uuidv4())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.finalizeResult.set(res);
+          this.finalizeState.set('success');
+          this.loadSnapshots(id);
+        },
+        error: (err) => {
+          this.finalizeState.set('error');
+          const status = err?.status ?? 0;
+          this.finalizeError.set(
+            status === 409
+              ? 'An active billable snapshot already exists for this work order.'
+              : status === 400
+                ? err?.error?.message ?? 'Finalization requirements not met. Check for unauthorized items or missing totals.'
+                : 'Failed to finalize. Please try again.',
+          );
+        },
+      });
+  }
+
+  goBack(): void {
+    this.router.navigate(['/app/workexec/workorders', this.workorderId()]);
+  }
+
+  refresh(): void {
+    this.loadSnapshots(this.workorderId());
+  }
+}

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -7,6 +7,8 @@ import {
   AssignTechnicianRequest,
   CalculateEstimateTotalsResponse,
   ChangeRequestResponse,
+  CompleteWorkorderRequest,
+  CompleteWorkorderResponse,
   ConsumePartsRequest,
   CreateChangeRequestRequest,
   CreateEstimateRequest,
@@ -15,9 +17,13 @@ import {
   EstimateResponse,
   EstimateSnapshotResponse,
   EstimateSummaryResponse,
+  FinalizeWorkorderRequest,
+  FinalizeWorkorderResponse,
   IssuePartsRequest,
   OperationalContextResponse,
   PartUsageResponse,
+  ReopenWorkorderRequest,
+  ReopenWorkorderResponse,
   ReturnPartsRequest,
   StartLaborRequest,
   StopLaborRequest,
@@ -28,6 +34,7 @@ import {
   WorkorderDetailResponse,
   WorkorderLaborEntryResponse,
   WorkorderResponse,
+  WorkorderSnapshotHistoryEntry,
   WorkorderStartResponse,
   WorkorderTransition,
 } from '../models/workexec.models';
@@ -613,6 +620,77 @@ export class WorkexecService {
     return this.api.post<ChangeRequestResponse>(
       `/v1/workorders/changeRequests/${changeId}/decline`,
       { reason },
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  // ── CAP-006: Complete / Reopen / Finalize (Stories 215, 214, 216) ──────────
+
+  /**
+   * operationId: completeWorkorder
+   * POST /v1/workorders/{workorderId}/complete
+   */
+  completeWorkorder(
+    workorderId: string,
+    body: CompleteWorkorderRequest,
+    idempotencyKey?: string,
+  ): Observable<CompleteWorkorderResponse> {
+    return this.api.post<CompleteWorkorderResponse>(
+      `/v1/workorders/${workorderId}/complete`,
+      body,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: reopenWorkorder
+   * POST /v1/workorders/{workorderId}/reopen
+   */
+  reopenWorkorder(
+    workorderId: string,
+    body: ReopenWorkorderRequest,
+    idempotencyKey?: string,
+  ): Observable<ReopenWorkorderResponse> {
+    return this.api.post<ReopenWorkorderResponse>(
+      `/v1/workorders/${workorderId}/reopen`,
+      body,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * POST /v1/workorders/{workorderId}/finalize
+   * Creates billable scope snapshot (Story 216).
+   */
+  finalizeWorkorder(
+    workorderId: string,
+    body: FinalizeWorkorderRequest,
+    idempotencyKey?: string,
+  ): Observable<FinalizeWorkorderResponse> {
+    return this.api.post<FinalizeWorkorderResponse>(
+      `/v1/workorders/${workorderId}/finalize`,
+      body,
+      this.idempotencyOptions(idempotencyKey),
+    );
+  }
+
+  /**
+   * operationId: getSnapshotHistory
+   * GET /v1/workorders/{workorderId}/snapshots
+   */
+  getSnapshotHistory(workorderId: string): Observable<WorkorderSnapshotHistoryEntry[]> {
+    return this.api.get<WorkorderSnapshotHistoryEntry[]>(`/v1/workorders/${workorderId}/snapshots`);
+  }
+
+  /**
+   * operationId: generateInvoice
+   * POST /v1/workorders/{workorderId}/generate-invoice
+   * CAP-007 Story 213 — triggers invoice draft creation; use billing service for detail.
+   */
+  generateInvoice(workorderId: string, idempotencyKey?: string): Observable<{ invoiceId: string; status?: string }> {
+    return this.api.post<{ invoiceId: string; status?: string }>(
+      `/v1/workorders/${workorderId}/generate-invoice`,
+      {},
       this.idempotencyOptions(idempotencyKey),
     );
   }

--- a/src/app/features/workexec/workexec.routes.ts
+++ b/src/app/features/workexec/workexec.routes.ts
@@ -4,9 +4,11 @@ import { WorkexecComponent } from './workexec.component';
 /**
  * Workexec feature routes
  * Capabilities: CAP-002 (Estimates), CAP-003 (Customer Approval Workflow),
- *               CAP-004 (Workorder Promotion), CAP-005 (Workorder Execution)
+ *               CAP-004 (Workorder Promotion), CAP-005 (Workorder Execution),
+ *               CAP-006 (Complete Workorder)
  * Wave B — stories 239, 238, 237, 236, 235, 234, 233, 271, 270, 269, 268,
  *           231, 230, 229, 228, 227, 226 (CAP-004), 225, 224, 223, 222, 221, 220, 219 (CAP-005)
+ * Wave C — stories 218, 217, 216, 215, 214 (CAP-006)
  */
 export const WORKEXEC_ROUTES: Routes = [
   {
@@ -162,6 +164,15 @@ export const WORKEXEC_ROUTES: Routes = [
         loadComponent: () =>
           import('./pages/workorder-change-requests/workorder-change-requests-page.component').then(
             m => m.WorkorderChangeRequestsPageComponent,
+          ),
+      },
+
+      /** Story 216 (CAP-006): Finalize Billable Scope Snapshot */
+      {
+        path: 'workorders/:workorderId/finalize',
+        loadComponent: () =>
+          import('./pages/workorder-finalize/workorder-finalize-page.component').then(
+            m => m.WorkorderFinalizePageComponent,
           ),
       },
 


### PR DESCRIPTION
## Wave C: CAP-006 + CAP-007

### CAP-006: Complete Workorder (Stories 218, 217, 216, 215, 214)
- **Story 218** — Completion checklist panel on workorder detail; surfaces pending change-requests as blockers before allow completion
- **Story 217** — Blocker banner on change-requests page, highlights approval-gated CRs with count + clear-to-complete confirmation
- **Story 216** — `WorkorderFinalizePageComponent` at `/app/workexec/workorders/:id/finalize`; creates immutable billable scope snapshot, shows snapshot history ledger, PO number input
- **Story 215** — Complete Work Order modal with optional completion notes; handles `failedChecks[]` inline validation errors
- **Story 214** — Reopen Work Order modal with required reopen reason; shown only when workorder is COMPLETED

### CAP-007: Convert Workorder to Invoice (Stories 213, 212, 211, 210, 209)
- **Story 213** — Create Invoice entry point on workorder detail; calls `generateInvoice()` → navigates to `/app/billing/invoices/:invoiceId`
- **Story 212** — Invoice totals summary: line items table, subtotal/tax/discount/grand-total breakdown
- **Story 211** — Traceability section: snapshot ID, captured/completed dates, generator identity
- **Story 210** — Adjustments display with debit/credit colouring and adjustment type chips
- **Story 209** — Issue Invoice CTA + manager-elevation modal (`POST /billing/auth/elevate` → `POST /billing/invoices/:id/issue`)

### New Files
- `billing/models/billing.models.ts`
- `billing/services/billing.service.ts`
- `billing/pages/invoice-detail/invoice-detail-page.component.{ts,html,css}`
- `workexec/pages/workorder-finalize/workorder-finalize-page.component.{ts,html,css}`

### Verification
```
npm run build   ✓  (0 errors, pre-existing CSS budget warnings only)
npm test        ✓  66/66 tests pass
```