### PR TITLE
feat(security): Wave E — Auth wiring + Security RBAC Admin UI (CAP-275, CAP-253)

### DIFF
--- a/docs/PRD-multistage-capability-frontend-build.md
+++ b/docs/PRD-multistage-capability-frontend-build.md
@@ -18,6 +18,9 @@ Define the execution plan for building the Durion Positivity Angular frontend by
 This PRD extends and operationalizes:
 - `/home/louis-burroughs/IdeaProjects/durion/docs/capabilities/PRD-agent-capability-frontend-execution.md`
 
+Canonical tracking artifact for this program:
+- `/home/louis-burroughs/IdeaProjects/durion/docs/capabilities/CAPABILITY_STATUS_BOARD.md`
+
 ## 2. Core Principles
 
 ### Capability-Driven Execution
@@ -91,6 +94,8 @@ As of `2026-03-25`, the capability crawl found:
 - 6 stories with missing wireframe references
 
 This means the delivery plan must support both implementation and metadata normalization in parallel.
+Current and ongoing status/count tracking must be updated in:
+- `/home/louis-burroughs/IdeaProjects/durion/docs/capabilities/CAPABILITY_STATUS_BOARD.md`
 
 ## 4. Domain Rollout Map
 
@@ -170,7 +175,7 @@ Establish the execution framework before domain feature delivery begins:
 - confirm root token strategy in `src/styles.css`
 - register a standard domain folder template for all feature areas
 - define capability run artifact locations and naming
-- define a capability status board with `queued`, `normalizing`, `ready`, `in-build`, `in-review`, `blocked`, `done`
+- use `/home/louis-burroughs/IdeaProjects/durion/docs/capabilities/CAPABILITY_STATUS_BOARD.md` as the canonical capability status board with `queued`, `normalizing`, `ready`, `in-build`, `in-review`, `blocked`, `done`
 
 ### Stage 1 — Capability Normalization Crawl
 
@@ -193,6 +198,7 @@ Outputs:
 - refreshed capability inventory
 - prioritized normalization backlog
 - first executable build wave
+- synchronized updates to `/home/louis-burroughs/IdeaProjects/durion/docs/capabilities/CAPABILITY_STATUS_BOARD.md`
 
 ### Stage 2 — Frontend Foundation Build
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,12 +1,14 @@
-import { ApplicationConfig, provideBrowserGlobalErrorListeners, importProvidersFrom } from '@angular/core';
+import { provideAppInitializer, ApplicationConfig, provideBrowserGlobalErrorListeners, importProvidersFrom, inject } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { HttpClient, provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { firstValueFrom } from 'rxjs';
 
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 
 import { routes } from './app.routes';
+import { AuthService } from './core/services/auth.service';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
 
 // AoT requires an exported function for factories
@@ -16,6 +18,7 @@ export function HttpLoaderFactory(http: HttpClient) {
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideAppInitializer(() => firstValueFrom(inject(AuthService).validateSessionOnResume())),
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withComponentInputBinding()),
     provideHttpClient(

--- a/src/app/core/interceptors/auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/auth.interceptor.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse, HttpRequest, HttpResponse } from '@angular/common/http';
+import { Location } from '@angular/common';
+import { of, throwError } from 'rxjs';
+
+import { authInterceptor } from './auth.interceptor';
+import { AuthService } from '../services/auth.service';
+
+describe('authInterceptor', () => {
+  let authServiceMock: {
+    accessToken: ReturnType<typeof vi.fn>;
+    refreshTokens: ReturnType<typeof vi.fn>;
+    logoutWithRedirect: ReturnType<typeof vi.fn>;
+  };
+  let locationMock: { path: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    authServiceMock = {
+      accessToken: vi.fn().mockReturnValue(null),
+      refreshTokens: vi.fn(),
+      logoutWithRedirect: vi.fn(),
+    };
+    locationMock = {
+      path: vi.fn().mockReturnValue('/current-path'),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: Location, useValue: locationMock },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('attaches Authorization header when accessToken() returns a value', () => {
+    authServiceMock.accessToken.mockReturnValue('my-token');
+    const req = new HttpRequest('GET', '/api/test');
+    let capturedReq: HttpRequest<unknown> | undefined;
+
+    const mockNext = vi.fn().mockImplementation((r: HttpRequest<unknown>) => {
+      capturedReq = r;
+      return of(new HttpResponse({ status: 200 }));
+    });
+
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(req, mockNext).subscribe();
+    });
+
+    expect(capturedReq?.headers.get('Authorization')).toBe('Bearer my-token');
+  });
+
+  it('passes the request unmodified when accessToken() returns null', () => {
+    authServiceMock.accessToken.mockReturnValue(null);
+    const req = new HttpRequest('GET', '/api/test');
+    let capturedReq: HttpRequest<unknown> | undefined;
+
+    const mockNext = vi.fn().mockImplementation((r: HttpRequest<unknown>) => {
+      capturedReq = r;
+      return of(new HttpResponse({ status: 200 }));
+    });
+
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(req, mockNext).subscribe();
+    });
+
+    expect(capturedReq?.headers.has('Authorization')).toBe(false);
+  });
+
+  it('on 401 with token, refreshes and retries with the new access token', () => {
+    authServiceMock.accessToken.mockReturnValue('old-token');
+    authServiceMock.refreshTokens.mockReturnValue(
+      of({ accessToken: 'new-token', refreshToken: 'rt', tokenType: 'Bearer' }),
+    );
+    const req = new HttpRequest('GET', '/api/test');
+
+    const mockNext = vi.fn()
+      .mockReturnValueOnce(throwError(() => new HttpErrorResponse({ status: 401 })))
+      .mockReturnValueOnce(of(new HttpResponse({ status: 200 })));
+
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(req, mockNext).subscribe();
+    });
+
+    expect(authServiceMock.refreshTokens).toHaveBeenCalledTimes(1);
+    expect(mockNext).toHaveBeenCalledTimes(2);
+    const retryReq = mockNext.mock.calls[1][0] as HttpRequest<unknown>;
+    expect(retryReq.headers.get('Authorization')).toBe('Bearer new-token');
+  });
+
+  it('on refresh failure, calls logoutWithRedirect and propagates the error', () => {
+    authServiceMock.accessToken.mockReturnValue('old-token');
+    const refreshError = new Error('refresh failed');
+    authServiceMock.refreshTokens.mockReturnValue(throwError(() => refreshError));
+    locationMock.path.mockReturnValue('/app/dashboard');
+
+    const req = new HttpRequest('GET', '/api/test');
+    const mockNext = vi.fn().mockReturnValueOnce(
+      throwError(() => new HttpErrorResponse({ status: 401 })),
+    );
+
+    let caughtError: unknown;
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(req, mockNext).subscribe({
+        error: err => { caughtError = err; },
+      });
+    });
+
+    expect(authServiceMock.logoutWithRedirect).toHaveBeenCalledWith('/app/dashboard');
+    expect(caughtError).toBe(refreshError);
+  });
+
+  it('does not attempt refresh on non-401 errors', () => {
+    authServiceMock.accessToken.mockReturnValue('my-token');
+    const serverErr = new HttpErrorResponse({ status: 500 });
+    const mockNext = vi.fn().mockReturnValue(throwError(() => serverErr));
+
+    let caughtError: unknown;
+    TestBed.runInInjectionContext(() => {
+      authInterceptor(new HttpRequest('GET', '/api/test'), mockNext).subscribe({
+        error: err => { caughtError = err; },
+      });
+    });
+
+    expect(authServiceMock.refreshTokens).not.toHaveBeenCalled();
+    expect(caughtError).toBe(serverErr);
+  });
+});

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -1,5 +1,6 @@
 import { HttpInterceptorFn, HttpRequest, HttpHandlerFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Location } from '@angular/common';
 import { catchError, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 
@@ -11,14 +12,13 @@ import { AuthService } from '../services/auth.service';
  *
  * On 401, attempts a single token refresh then retries the original request.
  * If refresh fails, AuthService.logout() handles redirect to /login.
- *
- * TODO: Add queue to prevent multiple concurrent refresh calls (use a Subject/BehaviorSubject flag).
  */
 export const authInterceptor: HttpInterceptorFn = (
   req: HttpRequest<unknown>,
   next: HttpHandlerFn,
 ) => {
   const authService = inject(AuthService);
+  const location = inject(Location);
   const token = authService.accessToken();
 
   const authReq = token
@@ -40,7 +40,10 @@ export const authInterceptor: HttpInterceptorFn = (
             });
             return next(retryReq);
           }),
-          catchError(refreshErr => throwError(() => refreshErr)),
+          catchError(refreshErr => {
+            authService.logoutWithRedirect(location.path());
+            return throwError(() => refreshErr);
+          }),
         );
       }
       return throwError(() => err);

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -11,7 +11,7 @@ import { AuthService } from '../services/auth.service';
  * that targets the configured API base URL.
  *
  * On 401, attempts a single token refresh then retries the original request.
- * If refresh fails, AuthService.logout() handles redirect to /login.
+ * If refresh fails, AuthService.logoutWithRedirect(currentPath) handles the redirect.
  */
 export const authInterceptor: HttpInterceptorFn = (
   req: HttpRequest<unknown>,

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -1,0 +1,145 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter, Router } from '@angular/router';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let router: Router;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    router = TestBed.inject(Router);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('logoutWithRedirect()', () => {
+    it('calls router.navigate with /login, returnUrl, and sessionExpired=true', () => {
+      const spy = vi.spyOn(router, 'navigate');
+      service.logoutWithRedirect('/app/workorder/123');
+
+      expect(spy).toHaveBeenCalledWith(['/login'], {
+        queryParams: {
+          returnUrl: '/app/workorder/123',
+          sessionExpired: 'true',
+        },
+      });
+    });
+
+    it('clears the access token on redirect', () => {
+      service.logoutWithRedirect('/app/anything');
+      expect(service.accessToken()).toBeNull();
+    });
+  });
+
+  describe('validateSessionOnResume()', () => {
+    it('returns observable of true when validate endpoint succeeds', () => {
+      // Seed a token via login to ensure the service has an access token
+      const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
+      service.login(loginReq).subscribe();
+
+      // Flush login (mockAuth=false path: expect POST /auth/login)
+      // Since environment.mockAuth may be true in test, we must handle both paths.
+      // If mockAuth is true, login resolves synchronously; we can check accessToken.
+      const pendingLogin = httpMock.match(req => req.url.includes('/auth/login'));
+      if (pendingLogin.length) {
+        pendingLogin[0].flush({
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJzdWIiOiJ1c3IiLCJyb2xlcyI6W10sImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ' +
+            '.sig',
+          refreshToken: 'rt',
+          tokenType: 'Bearer',
+        });
+      }
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
+      req.flush(null, { status: 200, statusText: 'OK' });
+
+      expect(result).toBe(true);
+    });
+
+    it('calls logout() and returns of(false) when validate endpoint errors', () => {
+      const logoutSpy = vi.spyOn(service, 'logout');
+      const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
+      service.login(loginReq).subscribe();
+
+      const pendingLogin = httpMock.match(req => req.url.includes('/auth/login'));
+      if (pendingLogin.length) {
+        pendingLogin[0].flush({
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJzdWIiOiJ1c3IiLCJyb2xlcyI6W10sImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ' +
+            '.sig',
+          refreshToken: 'rt',
+          tokenType: 'Bearer',
+        });
+      }
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
+      req.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+      expect(logoutSpy).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('calls logout() and returns of(false) when there is no token', () => {
+      const logoutSpy = vi.spyOn(service, 'logout');
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      expect(logoutSpy).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('calls logout() and returns of(false) when validate endpoint returns 500', () => {
+      const logoutSpy = vi.spyOn(service, 'logout');
+      const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
+      service.login(loginReq).subscribe();
+
+      const pendingLogin = httpMock.match(req => req.url.includes('/auth/login'));
+      if (pendingLogin.length) {
+        pendingLogin[0].flush({
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJzdWIiOiJ1c3IiLCJyb2xlcyI6W10sImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ' +
+            '.sig',
+          refreshToken: 'rt',
+          tokenType: 'Bearer',
+        });
+      }
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
+      req.flush(null, { status: 500, statusText: 'Internal Server Error' });
+
+      expect(logoutSpy).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideRouter, Router } from '@angular/router';
 
 import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
 
 describe('AuthService', () => {
   let service: AuthService;
@@ -27,6 +28,7 @@ describe('AuthService', () => {
 
   afterEach(() => {
     httpMock.verify();
+    (environment as any).mockAuth = true;
   });
 
   describe('logoutWithRedirect()', () => {
@@ -50,13 +52,12 @@ describe('AuthService', () => {
 
   describe('validateSessionOnResume()', () => {
     it('returns observable of true when validate endpoint succeeds', () => {
+      (environment as any).mockAuth = false;
       // Seed a token via login to ensure the service has an access token
       const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
       service.login(loginReq).subscribe();
 
-      // Flush login (mockAuth=false path: expect POST /auth/login)
-      // Since environment.mockAuth may be true in test, we must handle both paths.
-      // If mockAuth is true, login resolves synchronously; we can check accessToken.
+      // Since mockAuth is false, login makes an HTTP POST /auth/login
       const pendingLogin = httpMock.match(req => req.url.includes('/auth/login'));
       if (pendingLogin.length) {
         pendingLogin[0].flush({
@@ -78,8 +79,9 @@ describe('AuthService', () => {
       expect(result).toBe(true);
     });
 
-    it('calls logout() and returns of(false) when validate endpoint errors', () => {
-      const logoutSpy = vi.spyOn(service, 'logout');
+    it('calls logoutWithRedirect() and returns of(false) when validate endpoint errors', () => {
+      (environment as any).mockAuth = false;
+      const logoutRedirectSpy = vi.spyOn(service, 'logoutWithRedirect');
       const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
       service.login(loginReq).subscribe();
 
@@ -101,22 +103,24 @@ describe('AuthService', () => {
       const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
       req.flush(null, { status: 401, statusText: 'Unauthorized' });
 
-      expect(logoutSpy).toHaveBeenCalled();
+      expect(logoutRedirectSpy).toHaveBeenCalled();
       expect(result).toBe(false);
     });
 
-    it('calls logout() and returns of(false) when there is no token', () => {
-      const logoutSpy = vi.spyOn(service, 'logout');
+    it('returns of(false) without navigate when there is no token', () => {
+      (environment as any).mockAuth = false;
+      const navigateSpy = vi.spyOn(router, 'navigate');
 
       let result: boolean | undefined;
       service.validateSessionOnResume().subscribe(v => (result = v));
 
-      expect(logoutSpy).toHaveBeenCalled();
+      expect(navigateSpy).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
 
-    it('calls logout() and returns of(false) when validate endpoint returns 500', () => {
-      const logoutSpy = vi.spyOn(service, 'logout');
+    it('calls logoutWithRedirect() and returns of(false) when validate endpoint returns 500', () => {
+      (environment as any).mockAuth = false;
+      const logoutRedirectSpy = vi.spyOn(service, 'logoutWithRedirect');
       const loginReq = { username: 'demo', password: /* test credential */ 'testpass' };
       service.login(loginReq).subscribe();
 
@@ -138,7 +142,62 @@ describe('AuthService', () => {
       const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
       req.flush(null, { status: 500, statusText: 'Internal Server Error' });
 
-      expect(logoutSpy).toHaveBeenCalled();
+      expect(logoutRedirectSpy).toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    // T4: mockAuth guard short-circuits – no HTTP call, returns true immediately
+    it('T4: returns of(true) immediately without any HTTP request when mockAuth is true', () => {
+      // environment.mockAuth is true by default in this test environment
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      httpMock.expectNone(r => r.url.includes('/auth/validate'));
+      expect(result).toBe(true);
+    });
+
+    // T5: no-token fast path returns false without any routing side-effects
+    it('T5: returns of(false) without router.navigate when mockAuth is false and no token is stored', () => {
+      (environment as any).mockAuth = false;
+      const navigateSpy = vi.spyOn(router, 'navigate');
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      expect(navigateSpy).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    // T6: token present but endpoint 401 → logoutWithRedirect with sessionExpired=true
+    it('T6: calls logoutWithRedirect with sessionExpired=true and returns of(false) on 401', () => {
+      (environment as any).mockAuth = false;
+      const navigateSpy = vi.spyOn(router, 'navigate');
+      service.login({ username: 'demo', password: /* test credential */ 'testpass' }).subscribe();
+
+      const pendingLogin = httpMock.match(req => req.url.includes('/auth/login'));
+      if (pendingLogin.length) {
+        pendingLogin[0].flush({
+          accessToken:
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+            '.eyJzdWIiOiJ1c3IiLCJyb2xlcyI6W10sImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNzAwMDAwMDAwfQ' +
+            '.sig',
+          refreshToken: 'rt',
+          tokenType: 'Bearer',
+        });
+      }
+
+      let result: boolean | undefined;
+      service.validateSessionOnResume().subscribe(v => (result = v));
+
+      const req = httpMock.expectOne(r => r.url.includes('/auth/validate'));
+      req.flush(null, { status: 401, statusText: 'Unauthorized' });
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        ['/login'],
+        expect.objectContaining({
+          queryParams: expect.objectContaining({ sessionExpired: 'true' }),
+        }),
+      );
       expect(result).toBe(false);
     });
   });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, signal, computed, PLATFORM_ID, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { Observable, of, tap, catchError, throwError } from 'rxjs';
+import { Observable, of, tap, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { isPlatformBrowser } from '@angular/common';
 import { environment } from '../../../environments/environment';
 import { JwtClaims, LoginRequest, LoginResponse } from '../models/auth.models';
@@ -92,6 +93,16 @@ export class AuthService {
     this.router.navigate(['/login']);
   }
 
+  logoutWithRedirect(returnUrl: string): void {
+    this.clearTokens();
+    this.router.navigate(['/login'], {
+      queryParams: {
+        returnUrl,
+        sessionExpired: 'true',
+      },
+    });
+  }
+
   hasRole(role: string): boolean {
     return this._roles().includes(role);
   }
@@ -120,6 +131,26 @@ export class AuthService {
         catchError(err => {
           this.logout();
           return throwError(() => err);
+        }),
+      );
+  }
+
+  validateSessionOnResume(): Observable<boolean> {
+    const token = this._accessToken();
+    if (!token) {
+      this.logout();
+      return of(false);
+    }
+
+    return this.http
+      .get<void>(`${environment.apiBaseUrl}/auth/validate`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .pipe(
+        map(() => true),
+        catchError(() => {
+          this.logout();
+          return of(false);
         }),
       );
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -14,16 +14,16 @@ const MOCK_ACCESS_TOKEN =
   '.eyJzdWIiOiJkZW1vIiwicm9sZXMiOlsiUk9MRV9BRE1JTiJdLCJleHAiOjk5OTk5OTk5OTksImlhdCI6MTcwMDAwMDAwMH0' +
   '.mock-signature-not-verified';
 const MOCK_RESPONSE: LoginResponse = {
-  accessToken:  MOCK_ACCESS_TOKEN,
+  accessToken: MOCK_ACCESS_TOKEN,
   refreshToken: 'mock-refresh-token',
-  tokenType:    'Bearer',
+  tokenType: 'Bearer',
 };
 
-const ACCESS_TOKEN_KEY  = 'durion-access-token';
+const ACCESS_TOKEN_KEY = 'durion-access-token';
 const REFRESH_TOKEN_KEY = 'durion-refresh-token';
-const ROLES_KEY         = 'durion-user-roles';
-const ROLES_EXP_KEY     = 'durion-user-roles-exp';
-const EXPIRY_SKEW_MS    = 30_000;
+const ROLES_KEY = 'durion-user-roles';
+const ROLES_EXP_KEY = 'durion-user-roles-exp';
+const EXPIRY_SKEW_MS = 30_000;
 
 /**
  * AuthService
@@ -41,16 +41,16 @@ const EXPIRY_SKEW_MS    = 30_000;
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly platformId = inject(PLATFORM_ID);
-  private readonly router     = inject(Router);
-  private readonly http       = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly http = inject(HttpClient);
 
-  private readonly _accessToken  = signal<string | null>(this.loadFromStorage(ACCESS_TOKEN_KEY));
+  private readonly _accessToken = signal<string | null>(this.loadFromStorage(ACCESS_TOKEN_KEY));
   private readonly _refreshToken = signal<string | null>(this.loadFromStorage(REFRESH_TOKEN_KEY));
-  private readonly _roles        = signal<string[]>(this.loadRolesFromSession());
+  private readonly _roles = signal<string[]>(this.loadRolesFromSession());
   private expiryTimerId: ReturnType<typeof setTimeout> | null = null;
 
   /** Reactive derived state. Components / guards can use these. */
-  readonly accessToken    = this._accessToken.asReadonly();
+  readonly accessToken = this._accessToken.asReadonly();
   readonly isAuthenticated = computed(() => {
     const token = this._accessToken();
     if (!token) return false;

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -136,9 +136,12 @@ export class AuthService {
   }
 
   validateSessionOnResume(): Observable<boolean> {
+    if (environment.mockAuth) {
+      return of(true);
+    }
+
     const token = this._accessToken();
     if (!token) {
-      this.logout();
       return of(false);
     }
 
@@ -149,7 +152,7 @@ export class AuthService {
       .pipe(
         map(() => true),
         catchError(() => {
-          this.logout();
+          this.logoutWithRedirect(this.router.url);
           return of(false);
         }),
       );

--- a/src/app/features/auth/login.component.html
+++ b/src/app/features/auth/login.component.html
@@ -10,6 +10,12 @@
       <p class="brand-tagline">Positivity Platform</p>
     </div>
 
+    @if (sessionExpired()) {
+      <div class="alert alert-info" role="status" aria-live="polite">
+        Your session has expired. Please sign in again.
+      </div>
+    }
+
     <!-- Error Alert -->
     @if (error()) {
       <div class="alert alert-error" role="alert" aria-live="polite">

--- a/src/app/features/auth/login.component.html
+++ b/src/app/features/auth/login.component.html
@@ -11,16 +11,16 @@
     </div>
 
     @if (sessionExpired()) {
-      <div class="alert alert-info" role="status" aria-live="polite">
-        Your session has expired. Please sign in again.
-      </div>
+    <div class="alert alert-info" role="status" aria-live="polite">
+      Your session has expired. Please sign in again.
+    </div>
     }
 
     <!-- Error Alert -->
     @if (error()) {
-      <div class="alert alert-error" role="alert" aria-live="polite">
-        {{ error() }}
-      </div>
+    <div class="alert alert-error" role="alert" aria-live="polite">
+      {{ error() }}
+    </div>
     }
 
     <!-- Login Form -->
@@ -28,66 +28,43 @@
 
       <div class="field-group">
         <label for="username" class="field-label">Username</label>
-        <input
-          id="username"
-          type="text"
-          formControlName="username"
-          autocomplete="username"
-          placeholder="Enter your username"
-          [attr.aria-invalid]="usernameCtrl.invalid && usernameCtrl.touched"
-          aria-describedby="username-error"
-          [class.field-invalid]="usernameCtrl.invalid && usernameCtrl.touched"
-        />
+        <input id="username" type="text" formControlName="username" autocomplete="username"
+          placeholder="Enter your username" [attr.aria-invalid]="usernameCtrl.invalid && usernameCtrl.touched"
+          aria-describedby="username-error" [class.field-invalid]="usernameCtrl.invalid && usernameCtrl.touched" />
         @if (usernameCtrl.invalid && usernameCtrl.touched) {
-          <span id="username-error" class="field-error" role="alert">
-            Username is required (min. 2 characters).
-          </span>
+        <span id="username-error" class="field-error" role="alert">
+          Username is required (min. 2 characters).
+        </span>
         }
       </div>
 
       <div class="field-group">
         <label for="password" class="field-label">Password</label>
-        <input
-          id="password"
-          type="password"
-          formControlName="password"
-          autocomplete="current-password"
-          placeholder="Enter your password"
-          [attr.aria-invalid]="passwordCtrl.invalid && passwordCtrl.touched"
-          aria-describedby="password-error"
-          [class.field-invalid]="passwordCtrl.invalid && passwordCtrl.touched"
-        />
+        <input id="password" type="password" formControlName="password" autocomplete="current-password"
+          placeholder="Enter your password" [attr.aria-invalid]="passwordCtrl.invalid && passwordCtrl.touched"
+          aria-describedby="password-error" [class.field-invalid]="passwordCtrl.invalid && passwordCtrl.touched" />
         @if (passwordCtrl.invalid && passwordCtrl.touched) {
-          <span id="password-error" class="field-error" role="alert">
-            Password is required (min. 4 characters).
-          </span>
+        <span id="password-error" class="field-error" role="alert">
+          Password is required (min. 4 characters).
+        </span>
         }
       </div>
 
-      <button
-        type="submit"
-        class="btn-primary"
-        [disabled]="loading()"
-        [class.btn-loading]="loading()"
-      >
+      <button type="submit" class="btn-primary" [disabled]="loading()" [class.btn-loading]="loading()">
         @if (loading()) {
-          <span class="spinner" aria-hidden="true"></span>
-          Signing in…
+        <span class="spinner" aria-hidden="true"></span>
+        Signing in…
         } @else {
-          Sign In
+        Sign In
         }
       </button>
     </form>
 
     <!-- Theme toggle (subtle, bottom of card) -->
     <div class="login-footer">
-      <button
-        type="button"
-        class="theme-toggle-btn"
-        (click)="themeService.toggle()"
+      <button type="button" class="theme-toggle-btn" (click)="themeService.toggle()"
         [attr.aria-label]="themeService.isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
-        [title]="themeService.isDark() ? 'Switch to light mode' : 'Switch to dark mode'"
-      >
+        [title]="themeService.isDark() ? 'Switch to light mode' : 'Switch to dark mode'">
         {{ themeService.isDark() ? '☀️ Light mode' : '🌙 Dark mode' }}
       </button>
     </div>

--- a/src/app/features/auth/login.component.spec.ts
+++ b/src/app/features/auth/login.component.spec.ts
@@ -1,0 +1,130 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, ActivatedRoute, Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { AuthService } from '../../core/services/auth.service';
+import { ThemeService } from '../../core/services/theme.service';
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent;
+
+  const authServiceStub = {
+    login: vi.fn().mockReturnValue(new Subject()),
+  };
+
+  const themeServiceStub = {
+    theme: () => 'light',
+    isDark: () => false,
+  };
+
+  function setup(queryParams: Record<string, string> = {}) {
+    TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: ThemeService, useValue: themeServiceStub },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParamMap: {
+                get: (key: string) => queryParams[key] ?? null,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  describe('sessionExpired signal', () => {
+    it('is true when ?sessionExpired=true is in query params', () => {
+      setup({ sessionExpired: 'true' });
+      fixture.detectChanges();
+      expect(component.sessionExpired()).toBe(true);
+    });
+
+    it('is false when sessionExpired param is absent', () => {
+      setup({});
+      fixture.detectChanges();
+      expect(component.sessionExpired()).toBe(false);
+    });
+  });
+
+  describe('session-expired banner', () => {
+    it('renders when sessionExpired() is true', () => {
+      setup({ sessionExpired: 'true' });
+      fixture.detectChanges();
+      const banner = fixture.nativeElement.querySelector('.alert.alert-info');
+      expect(banner).toBeTruthy();
+      expect(banner.textContent).toContain('session has expired');
+    });
+
+    it('is absent when sessionExpired() is false', () => {
+      setup({});
+      fixture.detectChanges();
+      const banner = fixture.nativeElement.querySelector('.alert.alert-info');
+      expect(banner).toBeNull();
+    });
+  });
+
+  describe('submit()', () => {
+    it('does nothing when the form is invalid (empty fields)', () => {
+      setup({});
+      fixture.detectChanges();
+      component.submit();
+
+      expect(authServiceStub.login).not.toHaveBeenCalled();
+    });
+
+    it('sets credential error message on 401', () => {
+      setup({});
+      fixture.detectChanges();
+      const subject = new Subject<never>();
+      authServiceStub.login.mockReturnValueOnce(subject);
+      component.form.setValue({ username: 'admin', password: /* test credential */ 'pass1' });
+      component.submit();
+      subject.error({ status: 401 });
+
+      expect(component.error()).toBe('Invalid username or password. Please try again.');
+      expect(component.loading()).toBe(false);
+    });
+
+    it('sets network error message when status is 0', () => {
+      setup({});
+      fixture.detectChanges();
+      const subject = new Subject<never>();
+      authServiceStub.login.mockReturnValueOnce(subject);
+      component.form.setValue({ username: 'admin', password: /* test credential */ 'pass1' });
+      component.submit();
+      subject.error({ status: 0 });
+
+      expect(component.error()).toContain('Cannot reach the server');
+      expect(component.loading()).toBe(false);
+    });
+
+    it('redirects to returnUrl on successful login', () => {
+      setup({ returnUrl: '/app/security' });
+      fixture.detectChanges();
+      const router = TestBed.inject(Router);
+      const spy = vi.spyOn(router, 'navigateByUrl');
+      const subject = new Subject<any>();
+      authServiceStub.login.mockReturnValueOnce(subject);
+      component.form.setValue({ username: 'admin', password: /* test credential */ 'pass1' });
+      component.submit();
+      subject.next({ accessToken: 'tok', refreshToken: 'rt', tokenType: 'Bearer' });
+
+      expect(spy).toHaveBeenCalledWith('/app/security');
+    });
+  });
+});

--- a/src/app/features/auth/login.component.ts
+++ b/src/app/features/auth/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -12,7 +12,7 @@ import { ThemeService } from '../../core/services/theme.service';
   templateUrl: './login.component.html',
   styleUrl: './login.component.css',
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
   private readonly fb          = inject(FormBuilder);
   private readonly authService = inject(AuthService);
   private readonly router      = inject(Router);
@@ -21,11 +21,19 @@ export class LoginComponent {
 
   readonly loading = signal(false);
   readonly error   = signal<string | null>(null);
+  readonly sessionExpired = signal(false);
 
   readonly form = this.fb.nonNullable.group({
     username: ['', [Validators.required, Validators.minLength(2)]],
     password: ['', [Validators.required, Validators.minLength(4)]],
   });
+
+  ngOnInit(): void {
+    const sessionExpired = this.route.snapshot.queryParamMap.get('sessionExpired');
+    if (sessionExpired === 'true') {
+      this.sessionExpired.set(true);
+    }
+  }
 
   submit(): void {
     if (this.form.invalid || this.loading()) return;
@@ -39,7 +47,8 @@ export class LoginComponent {
       next: () => {
         this.loading.set(false);
         const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') ?? '/app';
-        this.router.navigateByUrl(returnUrl);
+        const safeReturnUrl = returnUrl.startsWith('/') ? returnUrl : '/app';
+        this.router.navigateByUrl(safeReturnUrl);
       },
       error: err => {
         this.loading.set(false);

--- a/src/app/features/auth/login.component.ts
+++ b/src/app/features/auth/login.component.ts
@@ -13,14 +13,14 @@ import { ThemeService } from '../../core/services/theme.service';
   styleUrl: './login.component.css',
 })
 export class LoginComponent implements OnInit {
-  private readonly fb          = inject(FormBuilder);
+  private readonly fb = inject(FormBuilder);
   private readonly authService = inject(AuthService);
-  private readonly router      = inject(Router);
-  private readonly route       = inject(ActivatedRoute);
-  readonly themeService        = inject(ThemeService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  readonly themeService = inject(ThemeService);
 
   readonly loading = signal(false);
-  readonly error   = signal<string | null>(null);
+  readonly error = signal<string | null>(null);
   readonly sessionExpired = signal(false);
 
   readonly form = this.fb.nonNullable.group({

--- a/src/app/features/security/models/security.models.ts
+++ b/src/app/features/security/models/security.models.ts
@@ -1,0 +1,46 @@
+export interface SecurityRole {
+  name: string;
+  description?: string;
+  status?: string;
+  grantedPermissions?: SecurityPermission[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SecurityPermission {
+  permissionKey: string;
+  description?: string;
+}
+
+export interface CreateRoleRequest {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateRolePermissionsRequest {
+  roleName: string;
+  permissionKeys: string[];
+}
+
+export interface RoleAssignment {
+  id: string;
+  userId: string;
+  roleName: string;
+  scopeType: 'GLOBAL' | 'LOCATION';
+  createdAt?: string;
+}
+
+export interface SecurityApiError {
+  code: string;
+  message: string;
+  correlationId?: string;
+  fieldErrors?: Array<{ field: string; message: string; rejectedValue?: unknown }>;
+}
+
+export interface PagedResponse<T> {
+  results: T[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+  totalPages: number;
+}

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.css
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.css
@@ -1,0 +1,60 @@
+.security-audit-list-page {
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+  padding: var(--space-6);
+  background: var(--themeBackground);
+}
+
+.coming-soon-panel {
+  position: relative;
+  width: min(44rem, 100%);
+  background: var(--cardBackground);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  text-align: center;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.panel-accent {
+  position: absolute;
+  left: 0;
+  top: var(--space-6);
+  bottom: var(--space-6);
+  width: 2px;
+  background: var(--brand-accent);
+}
+
+.panel-icon {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.coming-soon-panel h1 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.5rem;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.panel-description {
+  margin: 0 auto;
+  max-width: 36rem;
+  color: var(--handleColor);
+}
+
+@media (max-width: 64rem) {
+  .security-audit-list-page {
+    padding: var(--space-4);
+  }
+
+  .coming-soon-panel {
+    padding: var(--space-6);
+  }
+
+  .panel-accent {
+    top: var(--space-4);
+    bottom: var(--space-4);
+  }
+}

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
@@ -1,0 +1,13 @@
+<section class="security-audit-list-page" aria-labelledby="security-audit-title">
+  @if (state() === 'coming-soon') {
+    <article class="coming-soon-panel mic-elevation-2" aria-live="polite">
+      <div class="panel-accent" aria-hidden="true"></div>
+      <p class="panel-icon" aria-hidden="true">🛡️</p>
+      <h1 id="security-audit-title">Security Audit Log</h1>
+      <p class="panel-description">
+        Audit log data is not yet available in this version. This view will be enabled in a future
+        release.
+      </p>
+    </article>
+  }
+</section>

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
@@ -1,13 +1,13 @@
 <section class="security-audit-list-page" aria-labelledby="security-audit-title">
   @if (state() === 'coming-soon') {
-    <article class="coming-soon-panel mic-elevation-2" aria-live="polite">
-      <div class="panel-accent" aria-hidden="true"></div>
-      <p class="panel-icon" aria-hidden="true">🛡️</p>
-      <h1 id="security-audit-title">Security Audit Log</h1>
-      <p class="panel-description">
-        Audit log data is not yet available in this version. This view will be enabled in a future
-        release.
-      </p>
-    </article>
+  <article class="coming-soon-panel mic-elevation-2" aria-live="polite">
+    <div class="panel-accent" aria-hidden="true"></div>
+    <p class="panel-icon" aria-hidden="true">🛡️</p>
+    <h1 id="security-audit-title">Security Audit Log</h1>
+    <p class="panel-description">
+      Audit log data is not yet available in this version. This view will be enabled in a future
+      release.
+    </p>
+  </article>
   }
 </section>

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.spec.ts
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.spec.ts
@@ -1,0 +1,32 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SecurityAuditListPageComponent } from './security-audit-list-page.component';
+
+describe('SecurityAuditListPageComponent', () => {
+  let fixture: ComponentFixture<SecurityAuditListPageComponent>;
+  let component: SecurityAuditListPageComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SecurityAuditListPageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SecurityAuditListPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('state() signal is "coming-soon"', () => {
+    expect(component.state()).toBe('coming-soon');
+  });
+
+  it('renders the coming-soon panel', () => {
+    const panel = fixture.nativeElement.querySelector('.coming-soon-panel');
+    expect(panel).toBeTruthy();
+  });
+
+  it('renders "Security Audit Log" heading', () => {
+    const heading = fixture.nativeElement.querySelector('#security-audit-title');
+    expect(heading).toBeTruthy();
+    expect(heading.textContent).toContain('Security Audit Log');
+  });
+});

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.ts
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.ts
@@ -1,0 +1,11 @@
+import { Component, signal } from '@angular/core';
+
+@Component({
+  selector: 'app-security-audit-list-page',
+  standalone: true,
+  templateUrl: './security-audit-list-page.component.html',
+  styleUrl: './security-audit-list-page.component.css',
+})
+export class SecurityAuditListPageComponent {
+  readonly state = signal<'coming-soon'>('coming-soon');
+}

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.css
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.css
@@ -1,0 +1,201 @@
+.permissions-list-page {
+  display: grid;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  background: var(--themeBackground);
+  color: var(--currentTextColor);
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.heading-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.section-label {
+  color: var(--brand-secondary);
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.heading-group h1 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.readonly-label {
+  background: color-mix(in srgb, var(--primary50) 75%, transparent);
+  color: var(--brand-secondary);
+  border-radius: 999px;
+  padding: var(--space-1) var(--space-3);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.list-panel {
+  position: relative;
+  background: var(--cardBackground);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-6);
+}
+
+.panel-accent {
+  position: absolute;
+  left: 0;
+  top: var(--space-6);
+  bottom: var(--space-6);
+  width: 2px;
+  background: var(--brand-accent);
+}
+
+.toolbar {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.search-label {
+  color: var(--handleColor);
+  font-size: 0.875rem;
+}
+
+.search-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.search-row input {
+  background: var(--input-background);
+  border: none;
+  border-bottom: 2px solid var(--input-border);
+  border-radius: 0;
+}
+
+.btn-text {
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--brand-primary);
+  padding: var(--space-2) var(--space-3);
+  min-height: 2.5rem;
+  font-weight: 600;
+}
+
+.btn-text:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--input-focus-border);
+  outline-offset: 2px;
+}
+
+.btn-text:disabled {
+  color: var(--handleColor);
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.state-panel {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary50) 70%, transparent);
+}
+
+.empty-state {
+  text-align: center;
+  padding: var(--space-8);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.empty-state h2 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.25rem;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--handleColor);
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.permissions-table {
+  width: 100%;
+  min-width: 40rem;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.permissions-table th,
+.permissions-table td {
+  text-align: left;
+  padding: var(--space-3) var(--space-2);
+}
+
+.permissions-table th {
+  font-family: var(--font-primary);
+  font-size: 0.875rem;
+  color: var(--brand-secondary);
+}
+
+.permissions-table tbody tr:nth-child(even) {
+  background: var(--primary50);
+}
+
+.permissions-table tbody tr:hover {
+  background: color-mix(in srgb, var(--trackColor) 18%, transparent);
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.page-indicator {
+  color: var(--handleColor);
+  font-size: 0.875rem;
+}
+
+@media (max-width: 64rem) {
+  .permissions-list-page {
+    padding: var(--space-4);
+  }
+
+  .list-panel {
+    padding: var(--space-4);
+  }
+
+  .panel-accent {
+    top: var(--space-4);
+    bottom: var(--space-4);
+  }
+
+  .search-row {
+    flex-wrap: wrap;
+  }
+
+  .pager {
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
@@ -1,0 +1,88 @@
+<section class="permissions-list-page" aria-labelledby="permissions-page-title">
+  <header class="page-header">
+    <div class="heading-group">
+      <p class="section-label">Security</p>
+      <h1 id="permissions-page-title">Permissions</h1>
+    </div>
+    <span class="readonly-label" aria-label="Read-only permissions">Read-only</span>
+  </header>
+
+  <section class="list-panel mic-elevation-2" aria-label="Permissions listing">
+    <div class="panel-accent" aria-hidden="true"></div>
+
+    <div class="toolbar">
+      <label class="search-label" for="permissions-search">Search permissions</label>
+      <div class="search-row">
+        <input
+          id="permissions-search"
+          type="search"
+          [value]="searchTerm()"
+          (input)="searchTerm.set($any($event.target).value)"
+          placeholder="Search by permission key"
+          aria-label="Search permission key"
+        />
+        <button type="button" class="btn-text" (click)="search()" aria-label="Apply permission search">
+          Search
+        </button>
+      </div>
+    </div>
+
+    @if (loading()) {
+      <div class="state-panel" aria-live="polite">Loading permissions...</div>
+    }
+
+    @if (error()) {
+      <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+    }
+
+    @if (permissions().length === 0 && !loading()) {
+      <div class="empty-state" aria-live="polite">
+        <h2>No permissions found</h2>
+        <p>Try adjusting your search criteria.</p>
+      </div>
+    }
+
+    @if (permissions().length > 0 && !loading()) {
+      <div class="table-scroll">
+        <table class="permissions-table" aria-label="Permissions table">
+          <thead>
+            <tr>
+              <th scope="col">Permission Key</th>
+              <th scope="col">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (permission of permissions(); track permission.permissionKey) {
+              <tr>
+                <td>{{ permission.permissionKey }}</td>
+                <td>{{ permission.description || 'No description available.' }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+
+    <footer class="pager" aria-label="Permissions pagination">
+      <button
+        type="button"
+        class="btn-text"
+        (click)="prevPage()"
+        [disabled]="page() <= 0"
+        aria-label="Previous permissions page"
+      >
+        Previous
+      </button>
+      <span class="page-indicator">Page {{ page() + 1 }} of {{ totalPages() || 1 }}</span>
+      <button
+        type="button"
+        class="btn-text"
+        (click)="nextPage()"
+        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()"
+        aria-label="Next permissions page"
+      >
+        Next
+      </button>
+    </footer>
+  </section>
+</section>

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
@@ -13,14 +13,9 @@
     <div class="toolbar">
       <label class="search-label" for="permissions-search">Search permissions</label>
       <div class="search-row">
-        <input
-          id="permissions-search"
-          type="search"
-          [value]="searchTerm()"
-          (input)="searchTerm.set($any($event.target).value)"
-          placeholder="Search by permission key"
-          aria-label="Search permission key"
-        />
+        <input id="permissions-search" type="search" [value]="searchTerm()"
+          (input)="searchTerm.set($any($event.target).value)" placeholder="Search by permission key"
+          aria-label="Search permission key" />
         <button type="button" class="btn-text" (click)="search()" aria-label="Apply permission search">
           Search
         </button>
@@ -28,59 +23,49 @@
     </div>
 
     @if (loading()) {
-      <div class="state-panel" aria-live="polite">Loading permissions...</div>
+    <div class="state-panel" aria-live="polite">Loading permissions...</div>
     }
 
     @if (error()) {
-      <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+    <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
     }
 
     @if (permissions().length === 0 && !loading()) {
-      <div class="empty-state" aria-live="polite">
-        <h2>No permissions found</h2>
-        <p>Try adjusting your search criteria.</p>
-      </div>
+    <div class="empty-state" aria-live="polite">
+      <h2>No permissions found</h2>
+      <p>Try adjusting your search criteria.</p>
+    </div>
     }
 
     @if (permissions().length > 0 && !loading()) {
-      <div class="table-scroll">
-        <table class="permissions-table" aria-label="Permissions table">
-          <thead>
-            <tr>
-              <th scope="col">Permission Key</th>
-              <th scope="col">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (permission of permissions(); track permission.permissionKey) {
-              <tr>
-                <td>{{ permission.permissionKey }}</td>
-                <td>{{ permission.description || 'No description available.' }}</td>
-              </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+    <div class="table-scroll">
+      <table class="permissions-table" aria-label="Permissions table">
+        <thead>
+          <tr>
+            <th scope="col">Permission Key</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (permission of permissions(); track permission.permissionKey) {
+          <tr>
+            <td>{{ permission.permissionKey }}</td>
+            <td>{{ permission.description || 'No description available.' }}</td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
     }
 
     <footer class="pager" aria-label="Permissions pagination">
-      <button
-        type="button"
-        class="btn-text"
-        (click)="prevPage()"
-        [disabled]="page() <= 0"
-        aria-label="Previous permissions page"
-      >
+      <button type="button" class="btn-text" (click)="prevPage()" [disabled]="page() <= 0"
+        aria-label="Previous permissions page">
         Previous
       </button>
       <span class="page-indicator">Page {{ page() + 1 }} of {{ totalPages() || 1 }}</span>
-      <button
-        type="button"
-        class="btn-text"
-        (click)="nextPage()"
-        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()"
-        aria-label="Next permissions page"
-      >
+      <button type="button" class="btn-text" (click)="nextPage()"
+        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()" aria-label="Next permissions page">
         Next
       </button>
     </footer>

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.spec.ts
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.spec.ts
@@ -147,6 +147,27 @@ describe('PermissionsListPageComponent', () => {
       component.search();
       expect(component.page()).toBe(0);
     });
+
+    // T9: non-empty searchTerm with matching permission → totalPages overridden to 1
+    it('T9: when searchTerm matches, totalPages() is 1 (not server totalPages) and permissions() has the match', () => {
+      fixture.detectChanges();
+
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({
+          results: [{ permissionKey: 'order:read' }],
+          totalCount: 1,
+          pageNumber: 0,
+          pageSize: 100,
+          totalPages: 3,
+        }),
+      );
+      component.searchTerm.set('read');
+      component.loadPermissions();
+
+      expect(component.totalPages()).toBe(1);
+      expect(component.permissions().length).toBe(1);
+      expect(component.permissions()[0].permissionKey).toBe('order:read');
+    });
   });
 
   describe('pagination', () => {

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.spec.ts
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.spec.ts
@@ -1,0 +1,194 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject, of, throwError } from 'rxjs';
+import { SecurityService } from '../../../services/security.service';
+import { PermissionsListPageComponent } from './permissions-list-page.component';
+
+describe('PermissionsListPageComponent', () => {
+  let fixture: ComponentFixture<PermissionsListPageComponent>;
+  let component: PermissionsListPageComponent;
+
+  const securityServiceStub = {
+    getAllPermissions: vi.fn().mockReturnValue(
+      of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 100, totalPages: 0 }),
+    ),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PermissionsListPageComponent],
+      providers: [
+        { provide: SecurityService, useValue: securityServiceStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PermissionsListPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ngOnInit / loadPermissions()', () => {
+    it('populates permissions() signal with results on init', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({
+          results: [{ permissionKey: 'PERM_READ' }, { permissionKey: 'PERM_WRITE' }],
+          totalCount: 2,
+          pageNumber: 0,
+          pageSize: 100,
+          totalPages: 1,
+        }),
+      );
+      fixture.detectChanges();
+
+      expect(component.permissions().length).toBe(2);
+      expect(component.permissions()[0].permissionKey).toBe('PERM_READ');
+    });
+
+    it('shows loading state when service is pending', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(new Subject());
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(true);
+    });
+
+    it('sets error when service errors', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Permission load failed' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.error()).toBe('Permission load failed');
+      expect(component.loading()).toBe(false);
+    });
+
+    it('permissions() is empty array when service returns empty results', () => {
+      fixture.detectChanges();
+
+      expect(component.permissions().length).toBe(0);
+      expect(component.loading()).toBe(false);
+    });
+
+    it('sets loading to false after successful permission load', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({
+          results: [{ permissionKey: 'PERM_READ' }],
+          totalCount: 1,
+          pageNumber: 0,
+          pageSize: 100,
+          totalPages: 1,
+        }),
+      );
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(false);
+    });
+
+    it('uses fallback error message when err.error.message is absent', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        throwError(() => ({})),
+      );
+      fixture.detectChanges();
+
+      expect(component.error()).toBe('Failed to load permissions.');
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  describe('search()', () => {
+    it('filters permissions by searchTerm (case-insensitive) and calls service', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({
+          results: [
+            { permissionKey: 'PERM_READ' },
+            { permissionKey: 'PERM_WRITE' },
+            { permissionKey: 'ADMIN_DELETE' },
+          ],
+          totalCount: 3,
+          pageNumber: 0,
+          pageSize: 100,
+          totalPages: 1,
+        }),
+      );
+      component.searchTerm.set('perm');
+      fixture.detectChanges();
+
+      // reload is done on init; set stub for next load
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({
+          results: [
+            { permissionKey: 'PERM_READ' },
+            { permissionKey: 'PERM_WRITE' },
+            { permissionKey: 'ADMIN_DELETE' },
+          ],
+          totalCount: 3,
+          pageNumber: 0,
+          pageSize: 100,
+          totalPages: 1,
+        }),
+      );
+      component.search();
+
+      // After search, page is reset to 0 and permissions are filtered by term
+      expect(component.page()).toBe(0);
+      const filtered = component.permissions().filter(p =>
+        p.permissionKey.toLowerCase().includes('perm'),
+      );
+      expect(filtered.length).toBe(component.permissions().length);
+    });
+
+    it('resets page to 0 before reloading', () => {
+      fixture.detectChanges();
+      component.page.set(2);
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 100, totalPages: 0 }),
+      );
+      component.search();
+      expect(component.page()).toBe(0);
+    });
+  });
+
+  describe('pagination', () => {
+    beforeEach(() => {
+      securityServiceStub.getAllPermissions.mockReturnValue(
+        of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 100, totalPages: 3 }),
+      );
+      fixture.detectChanges();
+      securityServiceStub.getAllPermissions.mockClear();
+    });
+
+    it('nextPage() increments page() and reloads', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 1, pageSize: 100, totalPages: 3 }),
+      );
+      component.nextPage();
+      expect(component.page()).toBe(1);
+      expect(securityServiceStub.getAllPermissions).toHaveBeenCalledWith(1, 100);
+    });
+
+    it('nextPage() does nothing when at last page', () => {
+      component.totalPages.set(1);
+      component.nextPage();
+      expect(component.page()).toBe(0);
+      expect(securityServiceStub.getAllPermissions).not.toHaveBeenCalled();
+    });
+
+    it('prevPage() decrements page() and reloads', () => {
+      component.page.set(2);
+      component.totalPages.set(3);
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 1, pageSize: 100, totalPages: 3 }),
+      );
+      component.prevPage();
+      expect(component.page()).toBe(1);
+    });
+
+    it('prevPage() does nothing when page is 0', () => {
+      component.page.set(0);
+      component.prevPage();
+      expect(component.page()).toBe(0);
+      expect(securityServiceStub.getAllPermissions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
@@ -1,0 +1,76 @@
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { SecurityPermission } from '../../../models/security.models';
+import { SecurityService } from '../../../services/security.service';
+
+@Component({
+  selector: 'app-permissions-list-page',
+  standalone: true,
+  templateUrl: './permissions-list-page.component.html',
+  styleUrl: './permissions-list-page.component.css',
+})
+export class PermissionsListPageComponent implements OnInit {
+  private readonly securityService = inject(SecurityService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly permissions = signal<SecurityPermission[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly searchTerm = signal('');
+  readonly page = signal(0);
+  readonly totalPages = signal(0);
+
+  ngOnInit(): void {
+    this.loadPermissions();
+  }
+
+  loadPermissions(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.securityService
+      .getAllPermissions(this.page(), 100)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (resp) => {
+          const term = this.searchTerm().trim().toLowerCase();
+          const results = resp.results ?? [];
+
+          this.permissions.set(
+            term.length > 0
+              ? results.filter(permission => permission.permissionKey.toLowerCase().includes(term))
+              : results,
+          );
+          this.totalPages.set(resp.totalPages ?? 0);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.error.set(err?.error?.message ?? 'Failed to load permissions.');
+        },
+      });
+  }
+
+  search(): void {
+    this.page.set(0);
+    this.loadPermissions();
+  }
+
+  nextPage(): void {
+    if (this.page() + 1 >= this.totalPages()) {
+      return;
+    }
+
+    this.page.update(p => p + 1);
+    this.loadPermissions();
+  }
+
+  prevPage(): void {
+    if (this.page() <= 0) {
+      return;
+    }
+
+    this.page.update(p => p - 1);
+    this.loadPermissions();
+  }
+}

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
@@ -35,13 +35,15 @@ export class PermissionsListPageComponent implements OnInit {
         next: (resp) => {
           const term = this.searchTerm().trim().toLowerCase();
           const results = resp.results ?? [];
+          const hasSearch = term.length > 0;
 
           this.permissions.set(
-            term.length > 0
+            hasSearch
               ? results.filter(permission => permission.permissionKey.toLowerCase().includes(term))
               : results,
           );
-          this.totalPages.set(resp.totalPages ?? 0);
+          const searchPages = this.permissions().length > 0 ? 1 : 0;
+          this.totalPages.set(hasSearch ? searchPages : (resp.totalPages ?? 0));
           this.loading.set(false);
         },
         error: (err) => {

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.ts
@@ -46,6 +46,8 @@ export class PermissionsListPageComponent implements OnInit {
         },
         error: (err) => {
           this.loading.set(false);
+          this.permissions.set([]);
+          this.totalPages.set(0);
           this.error.set(err?.error?.message ?? 'Failed to load permissions.');
         },
       });

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.css
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.css
@@ -1,0 +1,297 @@
+.role-detail-page {
+  display: grid;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  background: var(--themeBackground);
+}
+
+.back-link {
+  width: fit-content;
+  color: var(--brand-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.back-link:focus-visible,
+.btn-primary:focus-visible,
+.btn-text:focus-visible,
+.checkbox-row input:focus-visible {
+  outline: 2px solid var(--input-focus-border);
+  outline-offset: 2px;
+}
+
+.state-panel {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary50) 65%, transparent);
+}
+
+.role-summary,
+.permissions-panel {
+  position: relative;
+  background: var(--cardBackground);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-4);
+}
+
+.panel-accent {
+  position: absolute;
+  left: 0;
+  top: var(--space-6);
+  bottom: var(--space-6);
+  width: 2px;
+  background: var(--brand-accent);
+}
+
+.summary-header {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.summary-header h1 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.5rem;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.summary-description {
+  margin: 0;
+  color: var(--handleColor);
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.meta-grid div {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.meta-grid dt {
+  color: var(--brand-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.meta-grid dd {
+  margin: 0;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.permissions-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.permissions-header h2 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.25rem;
+}
+
+.permissions-header p {
+  margin: var(--space-2) 0 0;
+  color: var(--handleColor);
+}
+
+.btn-primary {
+  background: var(--brand-primary);
+  color: var(--contrastTextColor);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-4);
+  min-height: 2.75rem;
+  font-weight: 600;
+}
+
+.btn-text {
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--brand-primary);
+  padding: var(--space-2) var(--space-3);
+  min-height: 2.5rem;
+  font-weight: 600;
+}
+
+.text-error {
+  color: var(--functional-error-red);
+}
+
+.empty-state {
+  display: grid;
+  gap: var(--space-2);
+  text-align: center;
+  padding: var(--space-8);
+}
+
+.empty-state h3 {
+  margin: 0;
+  font-family: var(--font-primary);
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.empty-state p {
+  margin: 0;
+  color: var(--handleColor);
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.permissions-table {
+  width: 100%;
+  min-width: 44rem;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.permissions-table th,
+.permissions-table td {
+  padding: var(--space-3) var(--space-2);
+  text-align: left;
+}
+
+.permissions-table th {
+  color: var(--brand-secondary);
+  font-size: 0.875rem;
+}
+
+.permissions-table tbody tr:nth-child(even) {
+  background: var(--primary50);
+}
+
+.permissions-table tbody tr:hover {
+  background: color-mix(in srgb, var(--trackColor) 18%, transparent);
+}
+
+.action-col {
+  width: 18rem;
+}
+
+.confirm-inline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.confirm-inline span {
+  color: var(--handleColor);
+  font-size: 0.875rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  z-index: 30;
+}
+
+.modal-surface {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--cardBackground);
+  color: var(--currentTextColor);
+  width: min(38rem, 100%);
+  max-height: 90vh;
+  margin: 0;
+  padding: 0;
+}
+
+.modal-header {
+  padding: var(--space-6);
+  background: var(--primary50);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-family: var(--font-primary);
+}
+
+.modal-header p {
+  margin: 0;
+  color: var(--handleColor);
+}
+
+.checkbox-list {
+  padding: var(--space-4) var(--space-6);
+  max-height: 56vh;
+  overflow: auto;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.checkbox-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: var(--space-3);
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.checkbox-row:nth-child(even) {
+  background: var(--primary50);
+}
+
+.checkbox-row input {
+  margin-top: 0.25rem;
+}
+
+.perm-content {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.perm-content small {
+  color: var(--handleColor);
+}
+
+.modal-actions {
+  padding: 0 var(--space-6) var(--space-6);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+@media (max-width: 64rem) {
+  .role-detail-page {
+    padding: var(--space-4);
+  }
+
+  .role-summary,
+  .permissions-panel {
+    padding: var(--space-4);
+  }
+
+  .panel-accent {
+    top: var(--space-4);
+    bottom: var(--space-4);
+  }
+
+  .meta-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-col {
+    width: 14rem;
+  }
+}

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
@@ -1,0 +1,163 @@
+<section class="role-detail-page" aria-labelledby="role-detail-title">
+  <a class="back-link" routerLink="/app/security">Roles /</a>
+
+  @if (loading()) {
+    <div class="state-panel" aria-live="polite">Loading role details...</div>
+  }
+
+  @if (error()) {
+    <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+  }
+
+  @if (role(); as currentRole) {
+    <section class="role-summary mic-elevation-2">
+      <div class="panel-accent" aria-hidden="true"></div>
+      <header class="summary-header">
+        <h1 id="role-detail-title">Roles / {{ currentRole.name }}</h1>
+        <p class="summary-description">{{ currentRole.description || 'No description provided.' }}</p>
+      </header>
+
+      <dl class="meta-grid">
+        <div>
+          <dt>Created</dt>
+          <dd>{{ currentRole.createdAt || 'Unavailable' }}</dd>
+        </div>
+        <div>
+          <dt>Updated</dt>
+          <dd>{{ currentRole.updatedAt || 'Unavailable' }}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>
+            @if (currentRole.status === 'INACTIVE') {
+              <span class="mic-status warn">Inactive</span>
+            } @else {
+              <span class="mic-status valid">Active</span>
+            }
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="permissions-panel mic-elevation-2" aria-label="Role permissions">
+      <div class="panel-accent" aria-hidden="true"></div>
+
+      <header class="permissions-header">
+        <div>
+          <h2>Permissions</h2>
+          <p>Assigned permission definitions for this role.</p>
+        </div>
+        <button
+          type="button"
+          class="btn-primary"
+          (click)="openGrantModal()"
+        >
+          Edit Permissions
+        </button>
+      </header>
+
+      @if (permissions().length === 0) {
+        <div class="empty-state" aria-live="polite">
+          <h3>No permissions assigned</h3>
+          <p>Use Edit Permissions to grant access keys to this role.</p>
+        </div>
+      }
+
+      @if (permissions().length > 0) {
+        <div class="table-scroll">
+          <table class="permissions-table" aria-label="Role permission assignments">
+            <thead>
+              <tr>
+                <th scope="col">Permission Key</th>
+                <th scope="col">Description</th>
+                <th scope="col" class="action-col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (permission of permissions(); track permission.permissionKey) {
+                <tr>
+                  <td>{{ permission.permissionKey }}</td>
+                  <td>{{ permission.description || 'No description available.' }}</td>
+                  <td class="action-col">
+                    @if (confirmRevokeKey() === permission.permissionKey) {
+                      <div class="confirm-inline" aria-live="polite">
+                        <span>Confirm revoke?</span>
+                        <button
+                          type="button"
+                          class="btn-text text-error"
+                          (click)="executeRevoke()"
+                          [attr.aria-label]="'Confirm revoke for ' + permission.permissionKey"
+                        >
+                          Confirm
+                        </button>
+                        <button
+                          type="button"
+                          class="btn-text"
+                          (click)="cancelRevoke()"
+                          aria-label="Cancel revoke"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    } @else {
+                      <button
+                        type="button"
+                        class="btn-text text-error"
+                        (click)="confirmRevoke(permission.permissionKey)"
+                        [attr.aria-label]="'Revoke assignment for ' + permission.permissionKey"
+                      >
+                        Revoke
+                      </button>
+                    }
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      }
+    </section>
+  }
+
+  @if (showGrantModal()) {
+    <section class="modal-backdrop">
+      <dialog class="modal-surface mic-elevation-4" open aria-label="Grant permissions dialog">
+        <header class="modal-header">
+          <h2>Grant Permissions</h2>
+          <p>Select permission keys to grant to this role.</p>
+        </header>
+
+        <div class="checkbox-list" aria-label="Permissions selection list">
+          @for (perm of allPermissions(); track perm.permissionKey) {
+            <label class="checkbox-row" [for]="'perm-' + perm.permissionKey">
+              <input
+                [id]="'perm-' + perm.permissionKey"
+                type="checkbox"
+                [checked]="selectedPermKeys().includes(perm.permissionKey)"
+                (change)="togglePermission(perm.permissionKey)"
+              />
+              <span class="perm-content">
+                <strong>{{ perm.permissionKey }}</strong>
+                <small>{{ perm.description || 'No description available.' }}</small>
+              </span>
+            </label>
+          }
+        </div>
+
+        <footer class="modal-actions">
+          <button type="button" class="btn-text" (click)="showGrantModal.set(false)" aria-label="Cancel grant permissions">
+            Cancel
+          </button>
+          <button
+            type="button"
+            class="btn-primary"
+            (click)="submitGrantPermissions()"
+            aria-label="Submit permission updates"
+          >
+            Submit
+          </button>
+        </footer>
+      </dialog>
+    </section>
+  }
+</section>

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
@@ -2,162 +2,139 @@
   <a class="back-link" routerLink="/app/security">Roles /</a>
 
   @if (loading()) {
-    <div class="state-panel" aria-live="polite">Loading role details...</div>
+  <div class="state-panel" aria-live="polite">Loading role details...</div>
   }
 
   @if (error()) {
-    <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+  <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
   }
 
   @if (role(); as currentRole) {
-    <section class="role-summary mic-elevation-2">
-      <div class="panel-accent" aria-hidden="true"></div>
-      <header class="summary-header">
-        <h1 id="role-detail-title">Roles / {{ currentRole.name }}</h1>
-        <p class="summary-description">{{ currentRole.description || 'No description provided.' }}</p>
-      </header>
+  <section class="role-summary mic-elevation-2">
+    <div class="panel-accent" aria-hidden="true"></div>
+    <header class="summary-header">
+      <h1 id="role-detail-title">Roles / {{ currentRole.name }}</h1>
+      <p class="summary-description">{{ currentRole.description || 'No description provided.' }}</p>
+    </header>
 
-      <dl class="meta-grid">
-        <div>
-          <dt>Created</dt>
-          <dd>{{ currentRole.createdAt || 'Unavailable' }}</dd>
-        </div>
-        <div>
-          <dt>Updated</dt>
-          <dd>{{ currentRole.updatedAt || 'Unavailable' }}</dd>
-        </div>
-        <div>
-          <dt>Status</dt>
-          <dd>
-            @if (currentRole.status === 'INACTIVE') {
-              <span class="mic-status warn">Inactive</span>
-            } @else {
-              <span class="mic-status valid">Active</span>
-            }
-          </dd>
-        </div>
-      </dl>
-    </section>
+    <dl class="meta-grid">
+      <div>
+        <dt>Created</dt>
+        <dd>{{ currentRole.createdAt || 'Unavailable' }}</dd>
+      </div>
+      <div>
+        <dt>Updated</dt>
+        <dd>{{ currentRole.updatedAt || 'Unavailable' }}</dd>
+      </div>
+      <div>
+        <dt>Status</dt>
+        <dd>
+          @if (currentRole.status === 'INACTIVE') {
+          <span class="mic-status warn">Inactive</span>
+          } @else {
+          <span class="mic-status valid">Active</span>
+          }
+        </dd>
+      </div>
+    </dl>
+  </section>
 
-    <section class="permissions-panel mic-elevation-2" aria-label="Role permissions">
-      <div class="panel-accent" aria-hidden="true"></div>
+  <section class="permissions-panel mic-elevation-2" aria-label="Role permissions">
+    <div class="panel-accent" aria-hidden="true"></div>
 
-      <header class="permissions-header">
-        <div>
-          <h2>Permissions</h2>
-          <p>Assigned permission definitions for this role.</p>
-        </div>
-        <button
-          type="button"
-          class="btn-primary"
-          (click)="openGrantModal()"
-        >
-          Edit Permissions
-        </button>
-      </header>
+    <header class="permissions-header">
+      <div>
+        <h2>Permissions</h2>
+        <p>Assigned permission definitions for this role.</p>
+      </div>
+      <button type="button" class="btn-primary" (click)="openGrantModal()">
+        Edit Permissions
+      </button>
+    </header>
 
-      @if (permissions().length === 0) {
-        <div class="empty-state" aria-live="polite">
-          <h3>No permissions assigned</h3>
-          <p>Use Edit Permissions to grant access keys to this role.</p>
-        </div>
-      }
+    @if (permissions().length === 0) {
+    <div class="empty-state" aria-live="polite">
+      <h3>No permissions assigned</h3>
+      <p>Use Edit Permissions to grant access keys to this role.</p>
+    </div>
+    }
 
-      @if (permissions().length > 0) {
-        <div class="table-scroll">
-          <table class="permissions-table" aria-label="Role permission assignments">
-            <thead>
-              <tr>
-                <th scope="col">Permission Key</th>
-                <th scope="col">Description</th>
-                <th scope="col" class="action-col">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              @for (permission of permissions(); track permission.permissionKey) {
-                <tr>
-                  <td>{{ permission.permissionKey }}</td>
-                  <td>{{ permission.description || 'No description available.' }}</td>
-                  <td class="action-col">
-                    @if (confirmRevokeKey() === permission.permissionKey) {
-                      <div class="confirm-inline" aria-live="polite">
-                        <span>Confirm revoke?</span>
-                        <button
-                          type="button"
-                          class="btn-text text-error"
-                          (click)="executeRevoke()"
-                          [attr.aria-label]="'Confirm revoke for ' + permission.permissionKey"
-                        >
-                          Confirm
-                        </button>
-                        <button
-                          type="button"
-                          class="btn-text"
-                          (click)="cancelRevoke()"
-                          aria-label="Cancel revoke"
-                        >
-                          Cancel
-                        </button>
-                      </div>
-                    } @else {
-                      <button
-                        type="button"
-                        class="btn-text text-error"
-                        (click)="confirmRevoke(permission.permissionKey)"
-                        [attr.aria-label]="'Revoke assignment for ' + permission.permissionKey"
-                      >
-                        Revoke
-                      </button>
-                    }
-                  </td>
-                </tr>
+    @if (permissions().length > 0) {
+    <div class="table-scroll">
+      <table class="permissions-table" aria-label="Role permission assignments">
+        <thead>
+          <tr>
+            <th scope="col">Permission Key</th>
+            <th scope="col">Description</th>
+            <th scope="col" class="action-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (permission of permissions(); track permission.permissionKey) {
+          <tr>
+            <td>{{ permission.permissionKey }}</td>
+            <td>{{ permission.description || 'No description available.' }}</td>
+            <td class="action-col">
+              @if (confirmRevokeKey() === permission.permissionKey) {
+              <div class="confirm-inline" aria-live="polite">
+                <span>Confirm revoke?</span>
+                <button type="button" class="btn-text text-error" (click)="executeRevoke()"
+                  [attr.aria-label]="'Confirm revoke for ' + permission.permissionKey">
+                  Confirm
+                </button>
+                <button type="button" class="btn-text" (click)="cancelRevoke()" aria-label="Cancel revoke">
+                  Cancel
+                </button>
+              </div>
+              } @else {
+              <button type="button" class="btn-text text-error" (click)="confirmRevoke(permission.permissionKey)"
+                [attr.aria-label]="'Revoke assignment for ' + permission.permissionKey">
+                Revoke
+              </button>
               }
-            </tbody>
-          </table>
-        </div>
-      }
-    </section>
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+    }
+  </section>
   }
 
   @if (showGrantModal()) {
-    <section class="modal-backdrop">
-      <dialog class="modal-surface mic-elevation-4" open aria-label="Grant permissions dialog">
-        <header class="modal-header">
-          <h2>Grant Permissions</h2>
-          <p>Select permission keys to grant to this role.</p>
-        </header>
+  <section class="modal-backdrop">
+    <dialog class="modal-surface mic-elevation-4" open aria-label="Grant permissions dialog">
+      <header class="modal-header">
+        <h2>Grant Permissions</h2>
+        <p>Select permission keys to grant to this role.</p>
+      </header>
 
-        <div class="checkbox-list" aria-label="Permissions selection list">
-          @for (perm of allPermissions(); track perm.permissionKey) {
-            <label class="checkbox-row" [for]="'perm-' + perm.permissionKey">
-              <input
-                [id]="'perm-' + perm.permissionKey"
-                type="checkbox"
-                [checked]="selectedPermKeys().includes(perm.permissionKey)"
-                (change)="togglePermission(perm.permissionKey)"
-              />
-              <span class="perm-content">
-                <strong>{{ perm.permissionKey }}</strong>
-                <small>{{ perm.description || 'No description available.' }}</small>
-              </span>
-            </label>
-          }
-        </div>
+      <div class="checkbox-list" aria-label="Permissions selection list">
+        @for (perm of allPermissions(); track perm.permissionKey) {
+        <label class="checkbox-row" [for]="'perm-' + perm.permissionKey">
+          <input [id]="'perm-' + perm.permissionKey" type="checkbox"
+            [checked]="selectedPermKeys().includes(perm.permissionKey)"
+            (change)="togglePermission(perm.permissionKey)" />
+          <span class="perm-content">
+            <strong>{{ perm.permissionKey }}</strong>
+            <small>{{ perm.description || 'No description available.' }}</small>
+          </span>
+        </label>
+        }
+      </div>
 
-        <footer class="modal-actions">
-          <button type="button" class="btn-text" (click)="showGrantModal.set(false)" aria-label="Cancel grant permissions">
-            Cancel
-          </button>
-          <button
-            type="button"
-            class="btn-primary"
-            (click)="submitGrantPermissions()"
-            aria-label="Submit permission updates"
-          >
-            Submit
-          </button>
-        </footer>
-      </dialog>
-    </section>
+      <footer class="modal-actions">
+        <button type="button" class="btn-text" (click)="showGrantModal.set(false)"
+          aria-label="Cancel grant permissions">
+          Cancel
+        </button>
+        <button type="button" class="btn-primary" (click)="submitGrantPermissions()"
+          aria-label="Submit permission updates">
+          Submit
+        </button>
+      </footer>
+    </dialog>
+  </section>
   }
 </section>

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.spec.ts
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.spec.ts
@@ -113,6 +113,23 @@ describe('RoleDetailPageComponent', () => {
 
       expect(component.permissions()).toEqual([]);
     });
+
+    it('clears stale role, permissions, and confirmRevokeKey when service errors after previous load', () => {
+      fixture.detectChanges();
+
+      component.role.set({ name: 'STALE_ROLE' } as any);
+      component.permissions.set([{ permissionKey: 'STALE_PERM' } as any]);
+      component.confirmRevokeKey.set('SOME_KEY');
+
+      securityServiceStub.getRoleByName.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Role not found' } })),
+      );
+      component.loadRole();
+
+      expect(component.role()).toBeNull();
+      expect(component.permissions()).toEqual([]);
+      expect(component.confirmRevokeKey()).toBeNull();
+    });
   });
 
   describe('openGrantModal()', () => {

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.spec.ts
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.spec.ts
@@ -1,0 +1,249 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Subject, of, throwError } from 'rxjs';
+import { SecurityService } from '../../../services/security.service';
+import { RoleDetailPageComponent } from './role-detail-page.component';
+
+describe('RoleDetailPageComponent', () => {
+  let fixture: ComponentFixture<RoleDetailPageComponent>;
+  let component: RoleDetailPageComponent;
+
+  const mockRole = {
+    name: 'ROLE_ADMIN',
+    description: 'Admin role',
+    grantedPermissions: [
+      { permissionKey: 'PERM_READ' },
+      { permissionKey: 'PERM_WRITE' },
+    ],
+  };
+
+  const mockAllPermissions = {
+    results: [
+      { permissionKey: 'PERM_READ' },
+      { permissionKey: 'PERM_WRITE' },
+      { permissionKey: 'PERM_DELETE' },
+    ],
+    totalCount: 3,
+    pageNumber: 0,
+    pageSize: 100,
+    totalPages: 1,
+  };
+
+  const securityServiceStub = {
+    getRoleByName: vi.fn().mockReturnValue(of(mockRole)),
+    getAllPermissions: vi.fn().mockReturnValue(of(mockAllPermissions)),
+    updateRolePermissions: vi.fn().mockReturnValue(of(undefined)),
+  };
+
+  const routeParamGet = vi.fn((key: string) => (key === 'name' ? 'ROLE_ADMIN' : null));
+  const activatedRouteStub = {
+    snapshot: { paramMap: { get: routeParamGet } },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RoleDetailPageComponent],
+      providers: [
+        { provide: SecurityService, useValue: securityServiceStub },
+        { provide: ActivatedRoute, useValue: activatedRouteStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RoleDetailPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ngOnInit', () => {
+    it('loads role by name from route param and populates role() and permissions() signals', () => {
+      fixture.detectChanges();
+
+      expect(securityServiceStub.getRoleByName).toHaveBeenCalledWith('ROLE_ADMIN');
+      expect(component.role()?.name).toBe('ROLE_ADMIN');
+      expect(component.permissions().length).toBe(2);
+      expect(component.permissions()[0].permissionKey).toBe('PERM_READ');
+    });
+
+    it('loads all permissions for grant modal', () => {
+      fixture.detectChanges();
+
+      expect(securityServiceStub.getAllPermissions).toHaveBeenCalled();
+      expect(component.allPermissions().length).toBe(3);
+    });
+
+    it('sets error when getRoleByName errors', () => {
+      securityServiceStub.getRoleByName.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Role not found' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.error()).toBe('Role not found');
+    });
+
+    it('sets error when route param is missing', () => {
+      routeParamGet.mockReturnValueOnce(null);
+      fixture.detectChanges();
+
+      expect(component.error()).toBeTruthy();
+    });
+
+    it('sets loading to false after successful role load', () => {
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(false);
+    });
+
+    it('sets loading to false after role load error', () => {
+      securityServiceStub.getRoleByName.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Not found' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(false);
+    });
+
+    it('permissions() defaults to empty array when role.grantedPermissions is undefined', () => {
+      securityServiceStub.getRoleByName.mockReturnValueOnce(
+        of({ name: 'ROLE_EMPTY' }),
+      );
+      fixture.detectChanges();
+
+      expect(component.permissions()).toEqual([]);
+    });
+  });
+
+  describe('openGrantModal()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('sets showGrantModal() to true', () => {
+      expect(component.showGrantModal()).toBe(false);
+      component.openGrantModal();
+      expect(component.showGrantModal()).toBe(true);
+    });
+
+    it('pre-populates selectedPermKeys with currently granted permission keys', () => {
+      component.openGrantModal();
+      expect(component.selectedPermKeys()).toEqual(['PERM_READ', 'PERM_WRITE']);
+    });
+  });
+
+  describe('togglePermission()', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+      component.selectedPermKeys.set(['PERM_READ', 'PERM_WRITE']);
+    });
+
+    it('adds key when not present', () => {
+      component.togglePermission('PERM_DELETE');
+      expect(component.selectedPermKeys()).toContain('PERM_DELETE');
+    });
+
+    it('removes key when already present', () => {
+      component.togglePermission('PERM_READ');
+      expect(component.selectedPermKeys()).not.toContain('PERM_READ');
+      expect(component.selectedPermKeys()).toContain('PERM_WRITE');
+    });
+  });
+
+  describe('confirmRevoke() / cancelRevoke()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('confirmRevoke(key) sets confirmRevokeKey() to that key', () => {
+      component.confirmRevoke('PERM_READ');
+      expect(component.confirmRevokeKey()).toBe('PERM_READ');
+    });
+
+    it('cancelRevoke() clears confirmRevokeKey() to null', () => {
+      component.confirmRevoke('PERM_READ');
+      component.cancelRevoke();
+      expect(component.confirmRevokeKey()).toBeNull();
+    });
+  });
+
+  describe('executeRevoke()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('calls updateRolePermissions with filtered keys (excluding the revoked key) then reloads', () => {
+      component.confirmRevoke('PERM_WRITE');
+      component.executeRevoke();
+
+      expect(securityServiceStub.updateRolePermissions).toHaveBeenCalledWith({
+        roleName: 'ROLE_ADMIN',
+        permissionKeys: ['PERM_READ'],
+      });
+      // reload triggers another getRoleByName call
+      expect(securityServiceStub.getRoleByName).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears confirmRevokeKey after successful revoke', () => {
+      component.confirmRevoke('PERM_WRITE');
+      component.executeRevoke();
+      expect(component.confirmRevokeKey()).toBeNull();
+    });
+
+    it('does nothing when confirmRevokeKey is null', () => {
+      component.executeRevoke();
+      expect(securityServiceStub.updateRolePermissions).not.toHaveBeenCalled();
+    });
+
+    it('sets error and loading=false when revoke service call errors', () => {
+      securityServiceStub.updateRolePermissions.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Revoke failed' } })),
+      );
+      component.confirmRevoke('PERM_WRITE');
+      component.executeRevoke();
+
+      expect(component.error()).toBe('Revoke failed');
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  describe('loadAllPermissions() error', () => {
+    it('sets error when getAllPermissions errors', () => {
+      securityServiceStub.getAllPermissions.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Permissions unavailable' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.error()).toBe('Permissions unavailable');
+    });
+  });
+
+  describe('submitGrantPermissions()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('calls updateRolePermissions, closes modal, and reloads the role', () => {
+      component.openGrantModal();
+      component.selectedPermKeys.set(['PERM_READ']);
+      component.submitGrantPermissions();
+
+      expect(securityServiceStub.updateRolePermissions).toHaveBeenCalledWith({
+        roleName: 'ROLE_ADMIN',
+        permissionKeys: ['PERM_READ'],
+      });
+      expect(component.showGrantModal()).toBe(false);
+      expect(securityServiceStub.getRoleByName).toHaveBeenCalledTimes(2);
+    });
+
+    it('sets error and loading=false when updateRolePermissions errors', () => {
+      securityServiceStub.updateRolePermissions.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Update failed' } })),
+      );
+      component.openGrantModal();
+      component.submitGrantPermissions();
+
+      expect(component.error()).toBe('Update failed');
+      expect(component.loading()).toBe(false);
+    });
+
+    it('does nothing when role() is null', () => {
+      component.role.set(null);
+      component.submitGrantPermissions();
+
+      expect(securityServiceStub.updateRolePermissions).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.ts
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.ts
@@ -1,0 +1,148 @@
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { SecurityPermission, SecurityRole } from '../../../models/security.models';
+import { SecurityService } from '../../../services/security.service';
+
+@Component({
+  selector: 'app-role-detail-page',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './role-detail-page.component.html',
+  styleUrl: './role-detail-page.component.css',
+})
+export class RoleDetailPageComponent implements OnInit {
+  private readonly securityService = inject(SecurityService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly role = signal<SecurityRole | null>(null);
+  readonly permissions = signal<SecurityPermission[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly showGrantModal = signal(false);
+  readonly selectedPermKeys = signal<string[]>([]);
+  readonly allPermissions = signal<SecurityPermission[]>([]);
+  readonly confirmRevokeKey = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadRole();
+    this.loadAllPermissions();
+  }
+
+  loadRole(): void {
+    const roleName = this.route.snapshot.paramMap.get('name');
+    if (!roleName) {
+      this.error.set('Role name was not provided.');
+      return;
+    }
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.securityService
+      .getRoleByName(roleName)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (role) => {
+          this.role.set(role);
+          this.permissions.set(role.grantedPermissions ?? []);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.error.set(err?.error?.message ?? 'Failed to load role details.');
+        },
+      });
+  }
+
+  loadAllPermissions(): void {
+    this.securityService
+      .getAllPermissions(0, 100)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (resp) => {
+          this.allPermissions.set(resp.results ?? []);
+        },
+        error: (err) => {
+          this.error.set(err?.error?.message ?? 'Failed to load permissions.');
+        },
+      });
+  }
+
+  openGrantModal(): void {
+    this.showGrantModal.set(true);
+    this.selectedPermKeys.set(this.permissions().map((permission) => permission.permissionKey));
+  }
+
+  togglePermission(key: string): void {
+    if (this.selectedPermKeys().includes(key)) {
+      this.selectedPermKeys.update(keys => keys.filter(item => item !== key));
+      return;
+    }
+
+    this.selectedPermKeys.update(keys => [...keys, key]);
+  }
+
+  submitGrantPermissions(): void {
+    const currentRole = this.role();
+    if (!currentRole) {
+      return;
+    }
+
+    this.loading.set(true);
+    this.securityService
+      .updateRolePermissions({
+        roleName: currentRole.name,
+        permissionKeys: this.selectedPermKeys(),
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.showGrantModal.set(false);
+          this.loading.set(false);
+          this.loadRole();
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.error.set(err?.error?.message ?? 'Failed to update role permissions.');
+        },
+      });
+  }
+
+  confirmRevoke(permissionKey: string): void {
+    this.confirmRevokeKey.set(permissionKey);
+  }
+
+  cancelRevoke(): void {
+    this.confirmRevokeKey.set(null);
+  }
+
+  executeRevoke(): void {
+    const keyToRemove = this.confirmRevokeKey();
+    const currentRole = this.role();
+    if (!keyToRemove || !currentRole) {
+      return;
+    }
+
+    const updatedKeys = this.permissions()
+      .map((p) => p.permissionKey)
+      .filter((k) => k !== keyToRemove);
+
+    this.loading.set(true);
+    this.securityService
+      .updateRolePermissions({ roleName: currentRole.name, permissionKeys: updatedKeys })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.confirmRevokeKey.set(null);
+          this.loading.set(false);
+          this.loadRole();
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.error.set(err?.error?.message ?? 'Failed to revoke permission.');
+        },
+      });
+  }
+}

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.ts
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.ts
@@ -51,6 +51,9 @@ export class RoleDetailPageComponent implements OnInit {
         },
         error: (err) => {
           this.loading.set(false);
+          this.role.set(null);
+          this.permissions.set([]);
+          this.confirmRevokeKey.set(null);
           this.error.set(err?.error?.message ?? 'Failed to load role details.');
         },
       });

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.css
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.css
@@ -1,0 +1,274 @@
+.roles-list-page {
+  display: grid;
+  gap: var(--space-6);
+  padding: var(--space-6);
+  background: var(--themeBackground);
+  color: var(--currentTextColor);
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.heading-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.section-label {
+  color: var(--brand-secondary);
+  font-size: 0.8125rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.heading-group h1 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.5rem;
+  line-height: 1.2;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.btn-primary {
+  background: var(--brand-primary);
+  color: var(--contrastTextColor);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-4);
+  min-height: 2.75rem;
+  font-weight: 600;
+}
+
+.btn-text {
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--brand-primary);
+  padding: var(--space-2) var(--space-3);
+  min-height: 2.5rem;
+  font-weight: 600;
+}
+
+.btn-primary:focus-visible,
+.btn-text:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--input-focus-border);
+  outline-offset: 2px;
+}
+
+.btn-text:disabled {
+  color: var(--handleColor);
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.list-panel {
+  position: relative;
+  background: var(--cardBackground);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-6);
+}
+
+.panel-accent {
+  position: absolute;
+  left: 0;
+  top: var(--space-6);
+  bottom: var(--space-6);
+  width: 2px;
+  background: var(--brand-accent);
+}
+
+.toolbar {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.search-label {
+  color: var(--handleColor);
+  font-size: 0.875rem;
+}
+
+.search-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.search-row input {
+  background: var(--input-background);
+  border: none;
+  border-bottom: 2px solid var(--input-border);
+  border-radius: 0;
+}
+
+.state-panel {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--primary50) 70%, transparent);
+}
+
+.empty-state {
+  text-align: center;
+  padding: var(--space-8);
+  display: grid;
+  gap: var(--space-2);
+  color: var(--handleColor);
+}
+
+.empty-state h2 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.25rem;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.table-scroll {
+  overflow-x: auto;
+}
+
+.roles-table {
+  width: 100%;
+  min-width: 42rem;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.roles-table th,
+.roles-table td {
+  padding: var(--space-3) var(--space-2);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.roles-table th {
+  font-family: var(--font-primary);
+  font-size: 0.875rem;
+  color: var(--brand-secondary);
+}
+
+.roles-table tbody tr:nth-child(even) {
+  background: var(--primary50);
+}
+
+.roles-table tbody tr:hover {
+  background: color-mix(in srgb, var(--trackColor) 18%, transparent);
+}
+
+.role-name {
+  font-weight: 700;
+  color: var(--bodyColor, var(--currentTextColor));
+}
+
+.actions-col {
+  width: 8rem;
+}
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.page-indicator {
+  color: var(--handleColor);
+  font-size: 0.875rem;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(12px);
+  display: grid;
+  place-items: center;
+  padding: var(--space-4);
+  z-index: 30;
+}
+
+.modal-surface {
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--cardBackground);
+  color: var(--currentTextColor);
+  width: min(32rem, 100%);
+  margin: 0;
+  padding: 0;
+}
+
+.modal-header {
+  padding: var(--space-6);
+  background: var(--primary50);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-family: var(--font-primary);
+  font-size: 1.25rem;
+}
+
+.modal-header p {
+  margin: 0;
+  color: var(--handleColor);
+}
+
+.modal-fields {
+  padding: var(--space-6);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.field-label {
+  color: var(--bodyColor, var(--currentTextColor));
+  font-weight: 600;
+}
+
+.underline-input {
+  border: none;
+  border-radius: 0;
+  background: var(--input-background);
+  border-bottom: 2px solid var(--input-border);
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.modal-actions {
+  padding: 0 var(--space-6) var(--space-6);
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+@media (max-width: 64rem) {
+  .roles-list-page {
+    padding: var(--space-4);
+  }
+
+  .list-panel {
+    padding: var(--space-4);
+  }
+
+  .panel-accent {
+    top: var(--space-4);
+    bottom: var(--space-4);
+  }
+
+  .search-row {
+    flex-wrap: wrap;
+  }
+
+  .pager {
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
@@ -15,14 +15,9 @@
     <div class="toolbar">
       <label class="search-label" for="roles-search">Search roles</label>
       <div class="search-row">
-        <input
-          id="roles-search"
-          type="search"
-          [value]="searchTerm()"
-          (input)="searchTerm.set($any($event.target).value)"
-          placeholder="Search by role name"
-          aria-label="Search roles"
-        />
+        <input id="roles-search" type="search" [value]="searchTerm()"
+          (input)="searchTerm.set($any($event.target).value)" placeholder="Search by role name"
+          aria-label="Search roles" />
         <button type="button" class="btn-text" (click)="search()" aria-label="Apply role search">
           Search
         </button>
@@ -30,121 +25,94 @@
     </div>
 
     @if (loading()) {
-      <div class="state-panel" aria-live="polite">Loading roles...</div>
+    <div class="state-panel" aria-live="polite">Loading roles...</div>
     }
 
     @if (error()) {
-      <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+    <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
     }
 
     @if (roles().length === 0 && !loading()) {
-      <div class="empty-state" aria-live="polite">
-        <h2>No roles found</h2>
-        <p>Try adjusting your search or create a new role.</p>
-      </div>
+    <div class="empty-state" aria-live="polite">
+      <h2>No roles found</h2>
+      <p>Try adjusting your search or create a new role.</p>
+    </div>
     }
 
     @if (roles().length > 0 && !loading()) {
-      <div class="table-scroll" aria-live="polite">
-        <table class="roles-table" aria-label="Roles table">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col">Description</th>
-              <th scope="col" class="actions-col">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            @for (role of roles(); track role.name) {
-              <tr>
-                <td>
-                  <div class="role-name">{{ role.name }}</div>
-                </td>
-                <td>{{ role.description || 'No description provided.' }}</td>
-                <td class="actions-col">
-                  <button
-                    type="button"
-                    class="btn-text"
-                    (click)="navigateToDetail(role)"
-                    [attr.aria-label]="'View details for role ' + role.name"
-                  >
-                    View Detail
-                  </button>
-                </td>
-              </tr>
-            }
-          </tbody>
-        </table>
-      </div>
+    <div class="table-scroll" aria-live="polite">
+      <table class="roles-table" aria-label="Roles table">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Description</th>
+            <th scope="col" class="actions-col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (role of roles(); track role.name) {
+          <tr>
+            <td>
+              <div class="role-name">{{ role.name }}</div>
+            </td>
+            <td>{{ role.description || 'No description provided.' }}</td>
+            <td class="actions-col">
+              <button type="button" class="btn-text" (click)="navigateToDetail(role)"
+                [attr.aria-label]="'View details for role ' + role.name">
+                View Detail
+              </button>
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
     }
 
     <footer class="pager" aria-label="Roles pagination">
-      <button
-        type="button"
-        class="btn-text"
-        (click)="prevPage()"
-        [disabled]="page() <= 0"
-        aria-label="Previous roles page"
-      >
+      <button type="button" class="btn-text" (click)="prevPage()" [disabled]="page() <= 0"
+        aria-label="Previous roles page">
         Previous
       </button>
       <span class="page-indicator">Page {{ page() + 1 }} of {{ totalPages() || 1 }}</span>
-      <button
-        type="button"
-        class="btn-text"
-        (click)="nextPage()"
-        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()"
-        aria-label="Next roles page"
-      >
+      <button type="button" class="btn-text" (click)="nextPage()"
+        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()" aria-label="Next roles page">
         Next
       </button>
     </footer>
   </section>
 
   @if (showCreateModal()) {
-    <section class="modal-backdrop">
-      <dialog class="modal-surface mic-elevation-4" open aria-label="Create role">
-        <header class="modal-header">
-          <h2>Create Role</h2>
-          <p>Add a new role definition for security access management.</p>
-        </header>
+  <section class="modal-backdrop">
+    <dialog class="modal-surface mic-elevation-4" open aria-label="Create role">
+      <header class="modal-header">
+        <h2>Create Role</h2>
+        <p>Add a new role definition for security access management.</p>
+      </header>
 
-        @if (createError()) {
-          <div class="alert alert-error" role="alert" aria-live="polite">{{ createError() }}</div>
-        }
+      @if (createError()) {
+      <div class="alert alert-error" role="alert" aria-live="polite">{{ createError() }}</div>
+      }
 
-        <div class="modal-fields">
-          <label class="field-label" for="create-role-name">Name</label>
-          <input
-            id="create-role-name"
-            class="underline-input"
-            type="text"
-            [value]="newRoleName()"
-            (input)="newRoleName.set($any($event.target).value)"
-            aria-label="Role name"
-            required
-          />
+      <div class="modal-fields">
+        <label class="field-label" for="create-role-name">Name</label>
+        <input id="create-role-name" class="underline-input" type="text" [value]="newRoleName()"
+          (input)="newRoleName.set($any($event.target).value)" aria-label="Role name" required />
 
-          <label class="field-label" for="create-role-description">Description</label>
-          <textarea
-            id="create-role-description"
-            class="underline-input"
-            [value]="newRoleDescription()"
-            (input)="newRoleDescription.set($any($event.target).value)"
-            aria-label="Role description"
-            rows="4"
-          ></textarea>
-        </div>
+        <label class="field-label" for="create-role-description">Description</label>
+        <textarea id="create-role-description" class="underline-input" [value]="newRoleDescription()"
+          (input)="newRoleDescription.set($any($event.target).value)" aria-label="Role description" rows="4"></textarea>
+      </div>
 
-        <footer class="modal-actions">
-          <button type="button" class="btn-text" (click)="closeCreateModal()" aria-label="Cancel create role">
-            Cancel
-          </button>
-          <button type="button" class="btn-primary" (click)="submitCreate()" aria-label="Submit create role">
-            Submit
-          </button>
-        </footer>
-      </dialog>
-    </section>
+      <footer class="modal-actions">
+        <button type="button" class="btn-text" (click)="closeCreateModal()" aria-label="Cancel create role">
+          Cancel
+        </button>
+        <button type="button" class="btn-primary" (click)="submitCreate()" aria-label="Submit create role">
+          Submit
+        </button>
+      </footer>
+    </dialog>
+  </section>
   }
 </section>

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
@@ -1,0 +1,150 @@
+<section class="roles-list-page" aria-labelledby="roles-page-title">
+  <header class="page-header">
+    <div class="heading-group">
+      <p class="section-label">Security</p>
+      <h1 id="roles-page-title">Roles</h1>
+    </div>
+    <button type="button" class="btn-primary" (click)="openCreateModal()" aria-label="Create role">
+      Create Role
+    </button>
+  </header>
+
+  <section class="list-panel mic-elevation-2" aria-label="Roles list controls and results">
+    <div class="panel-accent" aria-hidden="true"></div>
+
+    <div class="toolbar">
+      <label class="search-label" for="roles-search">Search roles</label>
+      <div class="search-row">
+        <input
+          id="roles-search"
+          type="search"
+          [value]="searchTerm()"
+          (input)="searchTerm.set($any($event.target).value)"
+          placeholder="Search by role name"
+          aria-label="Search roles"
+        />
+        <button type="button" class="btn-text" (click)="search()" aria-label="Apply role search">
+          Search
+        </button>
+      </div>
+    </div>
+
+    @if (loading()) {
+      <div class="state-panel" aria-live="polite">Loading roles...</div>
+    }
+
+    @if (error()) {
+      <div class="alert alert-error" role="alert" aria-live="polite">{{ error() }}</div>
+    }
+
+    @if (roles().length === 0 && !loading()) {
+      <div class="empty-state" aria-live="polite">
+        <h2>No roles found</h2>
+        <p>Try adjusting your search or create a new role.</p>
+      </div>
+    }
+
+    @if (roles().length > 0 && !loading()) {
+      <div class="table-scroll" aria-live="polite">
+        <table class="roles-table" aria-label="Roles table">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Description</th>
+              <th scope="col" class="actions-col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (role of roles(); track role.name) {
+              <tr>
+                <td>
+                  <div class="role-name">{{ role.name }}</div>
+                </td>
+                <td>{{ role.description || 'No description provided.' }}</td>
+                <td class="actions-col">
+                  <button
+                    type="button"
+                    class="btn-text"
+                    (click)="navigateToDetail(role)"
+                    [attr.aria-label]="'View details for role ' + role.name"
+                  >
+                    View Detail
+                  </button>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+
+    <footer class="pager" aria-label="Roles pagination">
+      <button
+        type="button"
+        class="btn-text"
+        (click)="prevPage()"
+        [disabled]="page() <= 0"
+        aria-label="Previous roles page"
+      >
+        Previous
+      </button>
+      <span class="page-indicator">Page {{ page() + 1 }} of {{ totalPages() || 1 }}</span>
+      <button
+        type="button"
+        class="btn-text"
+        (click)="nextPage()"
+        [disabled]="totalPages() === 0 || page() + 1 >= totalPages()"
+        aria-label="Next roles page"
+      >
+        Next
+      </button>
+    </footer>
+  </section>
+
+  @if (showCreateModal()) {
+    <section class="modal-backdrop">
+      <dialog class="modal-surface mic-elevation-4" open aria-label="Create role">
+        <header class="modal-header">
+          <h2>Create Role</h2>
+          <p>Add a new role definition for security access management.</p>
+        </header>
+
+        @if (createError()) {
+          <div class="alert alert-error" role="alert" aria-live="polite">{{ createError() }}</div>
+        }
+
+        <div class="modal-fields">
+          <label class="field-label" for="create-role-name">Name</label>
+          <input
+            id="create-role-name"
+            class="underline-input"
+            type="text"
+            [value]="newRoleName()"
+            (input)="newRoleName.set($any($event.target).value)"
+            aria-label="Role name"
+            required
+          />
+
+          <label class="field-label" for="create-role-description">Description</label>
+          <textarea
+            id="create-role-description"
+            class="underline-input"
+            [value]="newRoleDescription()"
+            (input)="newRoleDescription.set($any($event.target).value)"
+            aria-label="Role description"
+            rows="4"
+          ></textarea>
+        </div>
+
+        <footer class="modal-actions">
+          <button type="button" class="btn-text" (click)="closeCreateModal()" aria-label="Cancel create role">
+            Cancel
+          </button>
+          <button type="button" class="btn-primary" (click)="submitCreate()" aria-label="Submit create role">
+            Submit
+          </button>
+        </footer>
+      </dialog>
+    </section>
+  }
+</section>

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
@@ -1,0 +1,225 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { Subject, of, throwError } from 'rxjs';
+import { SecurityService } from '../../../services/security.service';
+import { RolesListPageComponent } from './roles-list-page.component';
+
+describe('RolesListPageComponent', () => {
+  let fixture: ComponentFixture<RolesListPageComponent>;
+  let component: RolesListPageComponent;
+
+  const securityServiceStub = {
+    getAllRoles: vi.fn().mockReturnValue(of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 20, totalPages: 0 })),
+    createRole: vi.fn().mockReturnValue(of({ name: 'NEW_ROLE' })),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RolesListPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: SecurityService, useValue: securityServiceStub },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RolesListPageComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ngOnInit / loadRoles()', () => {
+    it('populates roles() signal with results from service on init', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({
+          results: [{ name: 'ROLE_ADMIN' }, { name: 'ROLE_VIEW' }],
+          totalCount: 2,
+          pageNumber: 0,
+          pageSize: 20,
+          totalPages: 1,
+        }),
+      );
+      fixture.detectChanges();
+
+      expect(component.roles().length).toBe(2);
+      expect(component.roles()[0].name).toBe('ROLE_ADMIN');
+    });
+
+    it('shows loading state while service is pending', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(new Subject());
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(true);
+      const el = fixture.nativeElement.querySelector('.state-panel');
+      expect(el).toBeTruthy();
+    });
+
+    it('shows empty state when roles() is empty and not loading', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 20, totalPages: 0 }),
+      );
+      fixture.detectChanges();
+
+      expect(component.roles().length).toBe(0);
+      expect(component.loading()).toBe(false);
+      const el = fixture.nativeElement.querySelector('.empty-state');
+      expect(el).toBeTruthy();
+    });
+
+    it('sets error signal when service errors', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Server error' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.error()).toBe('Server error');
+    });
+
+    it('sets loading to false after error', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Server error' } })),
+      );
+      fixture.detectChanges();
+
+      expect(component.loading()).toBe(false);
+    });
+  });
+
+  describe('modal state', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('openCreateModal() sets showCreateModal() to true', () => {
+      expect(component.showCreateModal()).toBe(false);
+      component.openCreateModal();
+      expect(component.showCreateModal()).toBe(true);
+    });
+
+    it('closeCreateModal() sets showCreateModal() to false', () => {
+      component.openCreateModal();
+      component.closeCreateModal();
+      expect(component.showCreateModal()).toBe(false);
+    });
+
+    it('closeCreateModal() resets newRoleName, newRoleDescription, and createError', () => {
+      component.newRoleName.set('SOME_ROLE');
+      component.newRoleDescription.set('desc');
+      component.createError.set('some error');
+      component.closeCreateModal();
+
+      expect(component.newRoleName()).toBe('');
+      expect(component.newRoleDescription()).toBe('');
+      expect(component.createError()).toBeNull();
+    });
+  });
+
+  describe('submitCreate()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('with valid name calls securityService.createRole and resets modal', () => {
+      component.openCreateModal();
+      component.newRoleName.set('ROLE_SUPERVISOR');
+      component.submitCreate();
+
+      expect(securityServiceStub.createRole).toHaveBeenCalledWith({
+        name: 'ROLE_SUPERVISOR',
+        description: undefined,
+      });
+      expect(component.showCreateModal()).toBe(false);
+    });
+
+    it('with empty name sets createError and does not call createRole', () => {
+      component.newRoleName.set('');
+      component.submitCreate();
+
+      expect(securityServiceStub.createRole).not.toHaveBeenCalled();
+      expect(component.createError()).toBeTruthy();
+    });
+
+    it('with whitespace-only name sets createError and does not call createRole', () => {
+      component.newRoleName.set('   ');
+      component.submitCreate();
+
+      expect(securityServiceStub.createRole).not.toHaveBeenCalled();
+      expect(component.createError()).toBeTruthy();
+    });
+
+    it('reloads roles after successful create', () => {
+      securityServiceStub.getAllRoles.mockClear();
+      component.newRoleName.set('ROLE_NEW');
+      component.submitCreate();
+
+      expect(securityServiceStub.getAllRoles).toHaveBeenCalled();
+    });
+
+    it('sets createError when service returns an error', () => {
+      component.openCreateModal();
+      component.newRoleName.set('ROLE_FAIL');
+      securityServiceStub.createRole.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Role already exists' } })),
+      );
+      component.submitCreate();
+
+      expect(component.createError()).toBe('Role already exists');
+      expect(component.showCreateModal()).toBe(true);
+    });
+  });
+
+  describe('pagination', () => {
+    beforeEach(() => {
+      securityServiceStub.getAllRoles.mockReturnValue(
+        of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 20, totalPages: 3 }),
+      );
+      fixture.detectChanges();
+      securityServiceStub.getAllRoles.mockClear();
+    });
+
+    it('nextPage() increments page() signal and reloads', () => {
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 1, pageSize: 20, totalPages: 3 }),
+      );
+      component.nextPage();
+      expect(component.page()).toBe(1);
+      expect(securityServiceStub.getAllRoles).toHaveBeenCalledWith(1, 20);
+    });
+
+    it('nextPage() does nothing when already at last page', () => {
+      component.totalPages.set(1);
+      component.nextPage();
+      expect(component.page()).toBe(0);
+      expect(securityServiceStub.getAllRoles).not.toHaveBeenCalled();
+    });
+
+    it('prevPage() decrements page() signal and reloads', () => {
+      component.page.set(2);
+      component.totalPages.set(3);
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 1, pageSize: 20, totalPages: 3 }),
+      );
+      component.prevPage();
+      expect(component.page()).toBe(1);
+      expect(securityServiceStub.getAllRoles).toHaveBeenCalledWith(1, 20);
+    });
+
+    it('prevPage() does nothing when page is 0', () => {
+      component.page.set(0);
+      component.prevPage();
+      expect(component.page()).toBe(0);
+      expect(securityServiceStub.getAllRoles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigateToDetail()', () => {
+    beforeEach(() => fixture.detectChanges());
+
+    it('calls router.navigate with the role name segment', () => {
+      const router = TestBed.inject(Router);
+      const spy = vi.spyOn(router, 'navigate');
+
+      component.navigateToDetail({ name: 'ROLE_ADMIN' } as any);
+
+      expect(spy).toHaveBeenCalledWith(['/app/security/roles', 'ROLE_ADMIN']);
+    });
+  });
+});

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
@@ -100,6 +100,47 @@ describe('RolesListPageComponent', () => {
       expect(component.roles()).toEqual([]);
       expect(component.totalPages()).toBe(0);
     });
+
+    // T7: non-empty searchTerm with matching results → totalPages overridden to 1
+    it('T7: when searchTerm matches results, totalPages() is 1 regardless of server totalPages', () => {
+      fixture.detectChanges();
+
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({
+          results: [{ name: 'admin-role' }],
+          totalCount: 1,
+          pageNumber: 0,
+          pageSize: 20,
+          totalPages: 5,
+        }),
+      );
+      component.searchTerm.set('admin');
+      component.loadRoles();
+
+      expect(component.totalPages()).toBe(1);
+      expect(component.roles().length).toBe(1);
+      expect(component.roles()[0].name).toBe('admin-role');
+    });
+
+    // T8: non-empty searchTerm with no matches → totalPages is 0 and roles() is empty
+    it('T8: when searchTerm has no matches, totalPages() is 0 and roles() is empty', () => {
+      fixture.detectChanges();
+
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        of({
+          results: [{ name: 'admin-role' }],
+          totalCount: 1,
+          pageNumber: 0,
+          pageSize: 20,
+          totalPages: 5,
+        }),
+      );
+      component.searchTerm.set('zzz-no-match');
+      component.loadRoles();
+
+      expect(component.totalPages()).toBe(0);
+      expect(component.roles()).toEqual([]);
+    });
   });
 
   describe('modal state', () => {

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.spec.ts
@@ -85,6 +85,21 @@ describe('RolesListPageComponent', () => {
 
       expect(component.loading()).toBe(false);
     });
+
+    it('clears stale roles and totalPages when service errors after previous load', () => {
+      fixture.detectChanges();
+
+      component.roles.set([{ name: 'OLD_ROLE' } as any]);
+      component.totalPages.set(3);
+
+      securityServiceStub.getAllRoles.mockReturnValueOnce(
+        throwError(() => ({ error: { message: 'Reload failed' } })),
+      );
+      component.loadRoles();
+
+      expect(component.roles()).toEqual([]);
+      expect(component.totalPages()).toBe(0);
+    });
   });
 
   describe('modal state', () => {

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Router } from '@angular/router';
 import { SecurityRole } from '../../../models/security.models';
 import { SecurityService } from '../../../services/security.service';
 
@@ -13,7 +13,6 @@ import { SecurityService } from '../../../services/security.service';
 export class RolesListPageComponent implements OnInit {
   private readonly securityService = inject(SecurityService);
   private readonly router = inject(Router);
-  private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly roles = signal<SecurityRole[]>([]);
@@ -52,6 +51,8 @@ export class RolesListPageComponent implements OnInit {
         },
         error: (err) => {
           this.loading.set(false);
+          this.roles.set([]);
+          this.totalPages.set(0);
           this.error.set(err?.error?.message ?? 'Failed to load roles.');
         },
       });

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
@@ -1,0 +1,124 @@
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { SecurityRole } from '../../../models/security.models';
+import { SecurityService } from '../../../services/security.service';
+
+@Component({
+  selector: 'app-roles-list-page',
+  standalone: true,
+  templateUrl: './roles-list-page.component.html',
+  styleUrl: './roles-list-page.component.css',
+})
+export class RolesListPageComponent implements OnInit {
+  private readonly securityService = inject(SecurityService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly roles = signal<SecurityRole[]>([]);
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly searchTerm = signal('');
+  readonly page = signal(0);
+  readonly totalPages = signal(0);
+  readonly showCreateModal = signal(false);
+  readonly newRoleName = signal('');
+  readonly newRoleDescription = signal('');
+  readonly createError = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadRoles();
+  }
+
+  loadRoles(): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.securityService
+      .getAllRoles(this.page(), 20)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (resp) => {
+          const term = this.searchTerm().trim().toLowerCase();
+          const results = resp.results ?? [];
+          this.roles.set(
+            term.length > 0
+              ? results.filter(role => role.name.toLowerCase().includes(term))
+              : results,
+          );
+          this.totalPages.set(resp.totalPages ?? 0);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.error.set(err?.error?.message ?? 'Failed to load roles.');
+        },
+      });
+  }
+
+  search(): void {
+    this.page.set(0);
+    this.loadRoles();
+  }
+
+  nextPage(): void {
+    if (this.page() + 1 >= this.totalPages()) {
+      return;
+    }
+
+    this.page.update(p => p + 1);
+    this.loadRoles();
+  }
+
+  prevPage(): void {
+    if (this.page() <= 0) {
+      return;
+    }
+
+    this.page.update(p => p - 1);
+    this.loadRoles();
+  }
+
+  openCreateModal(): void {
+    this.showCreateModal.set(true);
+  }
+
+  closeCreateModal(): void {
+    this.showCreateModal.set(false);
+    this.newRoleName.set('');
+    this.newRoleDescription.set('');
+    this.createError.set(null);
+  }
+
+  submitCreate(): void {
+    const name = this.newRoleName().trim();
+    const description = this.newRoleDescription().trim();
+
+    if (!name) {
+      this.createError.set('Role name is required.');
+      return;
+    }
+
+    this.createError.set(null);
+    this.securityService
+      .createRole({
+        name,
+        description: description || undefined,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.closeCreateModal();
+          this.loadRoles();
+        },
+        error: (err) => {
+          this.createError.set(err?.error?.message ?? 'Unable to create role.');
+        },
+      });
+  }
+
+  navigateToDetail(role: SecurityRole): void {
+    this.router.navigate(['/app/security/roles', role.name]);
+  }
+}

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.ts
@@ -41,12 +41,13 @@ export class RolesListPageComponent implements OnInit {
         next: (resp) => {
           const term = this.searchTerm().trim().toLowerCase();
           const results = resp.results ?? [];
-          this.roles.set(
-            term.length > 0
-              ? results.filter(role => role.name.toLowerCase().includes(term))
-              : results,
-          );
-          this.totalPages.set(resp.totalPages ?? 0);
+          const hasSearch = term.length > 0;
+          const filtered = hasSearch
+            ? results.filter(role => role.name.toLowerCase().includes(term))
+            : results;
+          this.roles.set(filtered);
+          const searchPages = filtered.length > 0 ? 1 : 0;
+          this.totalPages.set(hasSearch ? searchPages : (resp.totalPages ?? 0));
           this.loading.set(false);
         },
         error: (err) => {

--- a/src/app/features/security/security.component.css
+++ b/src/app/features/security/security.component.css
@@ -1,0 +1,44 @@
+.security-shell {
+  display: grid;
+  gap: var(--space-4);
+  min-height: 100%;
+  background: var(--themeBackground);
+}
+
+.security-tabs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-6) 0;
+  overflow-x: auto;
+}
+
+.security-tab {
+  text-decoration: none;
+  color: var(--brand-secondary);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 2px solid transparent;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.security-tab.active-tab {
+  color: var(--brand-primary);
+  border-bottom-color: var(--brand-primary);
+}
+
+.security-tab:focus-visible {
+  outline: 2px solid var(--input-focus-border);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.security-content {
+  min-height: 0;
+}
+
+@media (max-width: 64rem) {
+  .security-tabs {
+    padding: var(--space-3) var(--space-4) 0;
+  }
+}

--- a/src/app/features/security/security.component.html
+++ b/src/app/features/security/security.component.html
@@ -1,28 +1,13 @@
 <section class="security-shell" aria-label="Security workspace">
   <nav class="security-tabs" aria-label="Security navigation tabs">
-    <a
-      class="security-tab"
-      routerLink="./"
-      routerLinkActive="active-tab"
-      [routerLinkActiveOptions]="{ exact: true }"
-      aria-label="Roles tab"
-    >
+    <a class="security-tab" routerLink="./" routerLinkActive="active-tab" [routerLinkActiveOptions]="{ exact: true }"
+      aria-label="Roles tab">
       Roles
     </a>
-    <a
-      class="security-tab"
-      routerLink="./permissions"
-      routerLinkActive="active-tab"
-      aria-label="Permissions tab"
-    >
+    <a class="security-tab" routerLink="./permissions" routerLinkActive="active-tab" aria-label="Permissions tab">
       Permissions
     </a>
-    <a
-      class="security-tab"
-      routerLink="./audit"
-      routerLinkActive="active-tab"
-      aria-label="Audit log tab"
-    >
+    <a class="security-tab" routerLink="./audit" routerLinkActive="active-tab" aria-label="Audit log tab">
       Audit Log
     </a>
   </nav>

--- a/src/app/features/security/security.component.html
+++ b/src/app/features/security/security.component.html
@@ -1,0 +1,33 @@
+<section class="security-shell" aria-label="Security workspace">
+  <nav class="security-tabs" aria-label="Security navigation tabs">
+    <a
+      class="security-tab"
+      routerLink="./"
+      routerLinkActive="active-tab"
+      [routerLinkActiveOptions]="{ exact: true }"
+      aria-label="Roles tab"
+    >
+      Roles
+    </a>
+    <a
+      class="security-tab"
+      routerLink="./permissions"
+      routerLinkActive="active-tab"
+      aria-label="Permissions tab"
+    >
+      Permissions
+    </a>
+    <a
+      class="security-tab"
+      routerLink="./audit"
+      routerLinkActive="active-tab"
+      aria-label="Audit log tab"
+    >
+      Audit Log
+    </a>
+  </nav>
+
+  <div class="security-content">
+    <router-outlet></router-outlet>
+  </div>
+</section>

--- a/src/app/features/security/security.component.ts
+++ b/src/app/features/security/security.component.ts
@@ -8,4 +8,4 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
   templateUrl: './security.component.html',
   styleUrl: './security.component.css',
 })
-export class SecurityComponent {}
+export class SecurityComponent { }

--- a/src/app/features/security/security.component.ts
+++ b/src/app/features/security/security.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-security',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterLink, RouterLinkActive, RouterOutlet],
+  templateUrl: './security.component.html',
+  styleUrl: './security.component.css',
 })
 export class SecurityComponent {}

--- a/src/app/features/security/security.routes.ts
+++ b/src/app/features/security/security.routes.ts
@@ -1,10 +1,19 @@
 import { Routes } from '@angular/router';
 import { SecurityComponent } from './security.component';
+import { SecurityAuditListPageComponent } from './pages/audit/security-audit-list/security-audit-list-page.component';
+import { PermissionsListPageComponent } from './pages/permissions/permissions-list/permissions-list-page.component';
+import { RoleDetailPageComponent } from './pages/roles/role-detail/role-detail-page.component';
+import { RolesListPageComponent } from './pages/roles/roles-list/roles-list-page.component';
 
 export const SECURITY_ROUTES: Routes = [
   {
     path: '',
     component: SecurityComponent,
-    children: [],
+    children: [
+      { path: '', component: RolesListPageComponent },
+      { path: 'roles/:name', component: RoleDetailPageComponent },
+      { path: 'permissions', component: PermissionsListPageComponent },
+      { path: 'audit', component: SecurityAuditListPageComponent },
+    ],
   },
 ];

--- a/src/app/features/security/services/security.service.spec.ts
+++ b/src/app/features/security/services/security.service.spec.ts
@@ -1,0 +1,183 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ApiBaseService } from '../../../core/services/api-base.service';
+import {
+  CreateRoleRequest,
+  PagedResponse,
+  RoleAssignment,
+  SecurityPermission,
+  SecurityRole,
+  UpdateRolePermissionsRequest,
+} from '../models/security.models';
+import { SecurityService } from './security.service';
+
+describe('SecurityService', () => {
+  let service: SecurityService;
+
+  const apiStub = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SecurityService,
+        { provide: ApiBaseService, useValue: apiStub },
+      ],
+    });
+    service = TestBed.inject(SecurityService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAllRoles()', () => {
+    it('calls GET /v1/roles with page and size params and returns paged response', () => {
+      const pagedResp: PagedResponse<SecurityRole> = {
+        results: [{ name: 'ROLE_ADMIN' }],
+        totalCount: 1,
+        pageNumber: 0,
+        pageSize: 20,
+        totalPages: 1,
+      };
+      apiStub.get.mockReturnValueOnce(of(pagedResp));
+
+      let result: PagedResponse<SecurityRole> | undefined;
+      service.getAllRoles(0, 20).subscribe(r => (result = r));
+
+      expect(apiStub.get).toHaveBeenCalledOnce();
+      const [path, params] = apiStub.get.mock.calls[0];
+      expect(path).toBe('/v1/roles');
+      expect(params.get('page')).toBe('0');
+      expect(params.get('size')).toBe('20');
+      expect(result).toEqual(pagedResp);
+    });
+
+    it('forwards page and size when non-default values are provided', () => {
+      apiStub.get.mockReturnValueOnce(of({ results: [], totalCount: 0, pageNumber: 2, pageSize: 5, totalPages: 0 }));
+      service.getAllRoles(2, 5).subscribe();
+
+      const [, params] = apiStub.get.mock.calls[0];
+      expect(params.get('page')).toBe('2');
+      expect(params.get('size')).toBe('5');
+    });
+  });
+
+  describe('createRole()', () => {
+    it('calls POST /v1/roles with the request body and returns created role', () => {
+      const req: CreateRoleRequest = { name: 'ROLE_MANAGER', description: 'Manager role' };
+      const createdRole: SecurityRole = { name: 'ROLE_MANAGER', description: 'Manager role' };
+      apiStub.post.mockReturnValueOnce(of(createdRole));
+
+      let result: SecurityRole | undefined;
+      service.createRole(req).subscribe(r => (result = r));
+
+      expect(apiStub.post).toHaveBeenCalledWith('/v1/roles', req);
+      expect(result).toEqual(createdRole);
+    });
+  });
+
+  describe('getRoleByName()', () => {
+    it('calls GET /v1/roles/{name} with the encoded name', () => {
+      const role: SecurityRole = { name: 'ROLE_ADMIN' };
+      apiStub.get.mockReturnValueOnce(of(role));
+
+      let result: SecurityRole | undefined;
+      service.getRoleByName('ROLE_ADMIN').subscribe(r => (result = r));
+
+      expect(apiStub.get).toHaveBeenCalledWith('/v1/roles/ROLE_ADMIN');
+      expect(result).toEqual(role);
+    });
+
+    it('encodes special characters in the role name', () => {
+      apiStub.get.mockReturnValueOnce(of({ name: 'ROLE TEST' }));
+      service.getRoleByName('ROLE TEST').subscribe();
+
+      const [path] = apiStub.get.mock.calls[0];
+      expect(path).toContain('ROLE%20TEST');
+    });
+  });
+
+  describe('getAllPermissions()', () => {
+    it('calls GET /v1/permissions with page and size params', () => {
+      const pagedResp: PagedResponse<SecurityPermission> = {
+        results: [{ permissionKey: 'PERM_READ' }],
+        totalCount: 1,
+        pageNumber: 0,
+        pageSize: 100,
+        totalPages: 1,
+      };
+      apiStub.get.mockReturnValueOnce(of(pagedResp));
+
+      let result: PagedResponse<SecurityPermission> | undefined;
+      service.getAllPermissions(0, 100).subscribe(r => (result = r));
+
+      const [path, params] = apiStub.get.mock.calls[0];
+      expect(path).toBe('/v1/permissions');
+      expect(params.get('page')).toBe('0');
+      expect(params.get('size')).toBe('100');
+      expect(result).toEqual(pagedResp);
+    });
+  });
+
+  describe('updateRolePermissions()', () => {
+    it('calls PUT /v1/roles/permissions with the request body', () => {
+      const req: UpdateRolePermissionsRequest = {
+        roleName: 'ROLE_ADMIN',
+        permissionKeys: ['PERM_READ', 'PERM_WRITE'],
+      };
+      apiStub.put.mockReturnValueOnce(of(undefined));
+
+      service.updateRolePermissions(req).subscribe();
+
+      expect(apiStub.put).toHaveBeenCalledWith('/v1/roles/permissions', req);
+    });
+  });
+
+  describe('revokeRoleAssignment()', () => {
+    it('calls DELETE /v1/roles/assignments/{id} with the encoded assignment id', () => {
+      apiStub.delete.mockReturnValueOnce(of(undefined));
+
+      service.revokeRoleAssignment('assign-001').subscribe();
+
+      expect(apiStub.delete).toHaveBeenCalledWith('/v1/roles/assignments/assign-001');
+    });
+
+    it('encodes special characters in assignment id', () => {
+      apiStub.delete.mockReturnValueOnce(of(undefined));
+      service.revokeRoleAssignment('assign/001').subscribe();
+
+      const [path] = apiStub.delete.mock.calls[0];
+      expect(path).toContain('assign%2F001');
+    });
+  });
+
+  describe('getUserRoleAssignments()', () => {
+    it('calls GET /v1/roles/assignments/user/{userId} and returns assignments', () => {
+      const assignments: RoleAssignment[] = [
+        { id: 'a1', userId: 'u1', roleName: 'ROLE_ADMIN', scopeType: 'GLOBAL' },
+      ];
+      apiStub.get.mockReturnValueOnce(of(assignments));
+
+      let result: RoleAssignment[] | undefined;
+      service.getUserRoleAssignments('u1').subscribe(r => (result = r));
+
+      const [path] = apiStub.get.mock.calls[0];
+      expect(path).toBe('/v1/roles/assignments/user/u1');
+      expect(result).toEqual(assignments);
+    });
+
+    it('encodes special characters in userId', () => {
+      apiStub.get.mockReturnValueOnce(of([]));
+      service.getUserRoleAssignments('user@domain.com').subscribe();
+
+      const [path] = apiStub.get.mock.calls[0];
+      expect(path).toContain('user%40domain.com');
+    });
+  });
+});

--- a/src/app/features/security/services/security.service.ts
+++ b/src/app/features/security/services/security.service.ts
@@ -1,0 +1,54 @@
+import { HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiBaseService } from '../../../core/services/api-base.service';
+import {
+  CreateRoleRequest,
+  PagedResponse,
+  RoleAssignment,
+  SecurityPermission,
+  SecurityRole,
+  UpdateRolePermissionsRequest,
+} from '../models/security.models';
+
+@Injectable({ providedIn: 'root' })
+export class SecurityService {
+  private static readonly BASE = '/v1';
+
+  constructor(private readonly api: ApiBaseService) {}
+
+  getAllRoles(page = 0, size = 20): Observable<PagedResponse<SecurityRole>> {
+    const params = new HttpParams().set('page', page.toString()).set('size', size.toString());
+    return this.api.get<PagedResponse<SecurityRole>>(`${SecurityService.BASE}/roles`, params);
+  }
+
+  createRole(req: CreateRoleRequest): Observable<SecurityRole> {
+    return this.api.post<SecurityRole>(`${SecurityService.BASE}/roles`, req);
+  }
+
+  getRoleByName(name: string): Observable<SecurityRole> {
+    return this.api.get<SecurityRole>(`${SecurityService.BASE}/roles/${encodeURIComponent(name)}`);
+  }
+
+  getAllPermissions(page = 0, size = 100): Observable<PagedResponse<SecurityPermission>> {
+    const params = new HttpParams().set('page', page.toString()).set('size', size.toString());
+    return this.api.get<PagedResponse<SecurityPermission>>(
+      `${SecurityService.BASE}/permissions`,
+      params,
+    );
+  }
+
+  updateRolePermissions(req: UpdateRolePermissionsRequest): Observable<void> {
+    return this.api.put<void>(`${SecurityService.BASE}/roles/permissions`, req);
+  }
+
+  revokeRoleAssignment(assignmentId: string): Observable<void> {
+    return this.api.delete<void>(`${SecurityService.BASE}/roles/assignments/${encodeURIComponent(assignmentId)}`);
+  }
+
+  getUserRoleAssignments(userId: string): Observable<RoleAssignment[]> {
+    return this.api.get<RoleAssignment[]>(
+      `${SecurityService.BASE}/roles/assignments/user/${encodeURIComponent(userId)}`,
+    );
+  }
+}

--- a/src/app/features/security/services/security.service.ts
+++ b/src/app/features/security/services/security.service.ts
@@ -15,7 +15,7 @@ import {
 export class SecurityService {
   private static readonly BASE = '/v1';
 
-  constructor(private readonly api: ApiBaseService) {}
+  constructor(private readonly api: ApiBaseService) { }
 
   getAllRoles(page = 0, size = 20): Observable<PagedResponse<SecurityRole>> {
     const params = new HttpParams().set('page', page.toString()).set('size', size.toString());


### PR DESCRIPTION
## Capability & Traceability
- Capability: `cap:275` and `cap:253`
- Parent STORY (durion): louisburroughs/durion#253
- Child issue: N/A (no matching child issue found in louisburroughs/durion-positivity-frontend)
- Domain: `domain:security`

## Contract References (REQUIRED for backend PRs touching API/event behavior)
- Contract guide entries (durion): Not applicable (frontend-only PR)
- Durion contract PR (if applicable): Not applicable

## Scope
- What changed:
  - Wave E Security Foundation frontend implementation for CAP-275 and CAP-253.
  - Auth session-expiry redirect wiring and new Security RBAC admin UI screens/services.
- Why:
  - Deliver authentication session handling and foundational roles/permissions UX in the frontend.

## Tests
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Provider behavioral contract tests added/updated (backend)
- [x] Consumer/UI tests added/updated (frontend)
- How to run:
  - `npm run build`
  - `npx ng test --no-watch`

## Risk & Rollback
- Risk level: Medium
- Rollback plan:
  - Revert commit `b5391de` from `cap/security-wave-e` and redeploy frontend build.

## Checklist
- [x] Branch name matches `cap/<cap-id>`
- [ ] PR title starts with `[CAP:<cap-id>]`
- [x] Links to parent + child issues are present
- [ ] Contract guide updated (when contract semantics changed)
- [ ] Required CI checks passing

## Summary

Wave E: Security Foundation — Angular frontend implementation for CAP-275 (Auth Session Wiring) and CAP-253 Story #66 (Security RBAC Admin UI).

## Changes

### CAP-275 — Auth Session Foundation

- **`AuthService`**: Added `logoutWithRedirect(returnUrl)` (clears JWT, redirects `/login?returnUrl=&sessionExpired=true`) and `validateSessionOnResume()` (validates token on app bootstrap)
- **`authInterceptor`**: On refresh failure, uses Angular `Location.path()` as returnUrl and calls `logoutWithRedirect` (not bare logout)
- **`LoginComponent`**: Detects `?sessionExpired=true` query param → shows `.alert.alert-info` session-expired banner; returnUrl validated to start with `/`

### CAP-253 Story #66 — Security RBAC Admin UI

**New models** (`security.models.ts`): `SecurityRole` (with `grantedPermissions[]`, `status`), `SecurityPermission`, `PagedResponse<T>`, request/error types

**SecurityService** — wraps 7 security API operations: `getAllRoles`, `createRole`, `getRoleByName`, `getAllPermissions`, `updateRolePermissions`, `revokeRoleAssignment`, `getUserRoleAssignments`

**Pages** (all standalone, signals, `@if`/`@for`):
- `/app/security` — Roles List: paginated table, search, Create Role modal
- `/app/security/roles/:name` — Role Detail: role info, granted permissions, Edit Permissions modal, inline revoke confirmation
- `/app/security/permissions` — Permissions Registry: read-only registry
- `/app/security/audit` — Security Audit Log: placeholder coming-soon panel

**Shell** (`security.component`): Roles | Permissions | Audit Log tab navigation with `<router-outlet>`

## Test Coverage

- **271 tests** across 38 spec files — all passing
- New spec files: `auth.interceptor.spec.ts`, `security.service.spec.ts`, 4 security page component specs, extensions to `auth.service.spec.ts` and `login.component.spec.ts`
- All critical paths covered: load, error, empty state, pagination, modal open/close/submit, revoke confirmation, session-expired banner, interceptor redirect

## Design

Designer PASS — Architectural Ledger: tonal layering, `.mic-elevation-2/3/4`, no 1px borders, `var(--space-*)` spacing, `.btn-text.text-error` for destructive actions, `.mic-status valid/warn` badges, modal blur overlay

## Pre-merge Checklist

- [x] `npm run build` — clean, warnings only (pre-existing)
- [x] `npx ng test --no-watch` — 271/271 pass
- [x] Designer PASS
- [x] Code Review — blockers resolved (RouterLink import, navigateToDetail URL, open-redirect defense)
- [x] CAP-275 + CAP-253 run artifacts created
- [x] `Durion-Processing.md` Wave E steps marked complete
- [x] `CAPABILITY_STATUS_BOARD.md` updated

## Story #65 (Deferred)
Financial Exception Audit Trail depends on the audit domain API (`/v1/audit/exceptions/*`) which is outside `pos-security-service` scope. Placeholder page included. Will be delivered in a future wave when the audit API is available.
