### PR TITLE
[CAP:CAP-218] Inventory rollup facade service and by-location route scaffolding (F1)

### DIFF
--- a/src/app/features/inventory/inventory.routes.ts
+++ b/src/app/features/inventory/inventory.routes.ts
@@ -15,6 +15,27 @@ export const INVENTORY_ROUTES: Routes = [
           ),
       },
       {
+        path: 'by-location',
+        loadComponent: () =>
+          import(
+            './pages/by-location/location-overview/location-inventory-overview-page.component'
+          ).then(m => m.LocationInventoryOverviewPageComponent),
+      },
+      {
+        path: 'by-location/site/:siteId',
+        loadComponent: () =>
+          import('./pages/by-location/site-tree/site-inventory-tree-page.component').then(
+            m => m.SiteInventoryTreePageComponent,
+          ),
+      },
+      {
+        path: 'by-location/:locationId',
+        loadComponent: () =>
+          import(
+            './pages/by-location/location-overview/location-inventory-overview-page.component'
+          ).then(m => m.LocationInventoryOverviewPageComponent),
+      },
+      {
         path: 'availability',
         loadComponent: () =>
           import('./pages/availability/availability.component').then(

--- a/src/app/features/inventory/models/inventory-rollup.models.ts
+++ b/src/app/features/inventory/models/inventory-rollup.models.ts
@@ -51,11 +51,20 @@ export type RollupError =
   | { kind: 'validation'; message: string }
   | { kind: 'unknown'; message: string };
 
+const ROLLUP_ERROR_KINDS: readonly RollupError['kind'][] = [
+  'not-found',
+  'upstream-down',
+  'forbidden',
+  'validation',
+  'unknown',
+];
+
 export function isRollupError(value: unknown): value is RollupError {
   return (
     typeof value === 'object'
     && value !== null
     && 'kind' in value
     && typeof (value as { kind: unknown }).kind === 'string'
+    && (ROLLUP_ERROR_KINDS as readonly string[]).includes((value as { kind: string }).kind)
   );
 }

--- a/src/app/features/inventory/models/inventory-rollup.models.ts
+++ b/src/app/features/inventory/models/inventory-rollup.models.ts
@@ -1,0 +1,61 @@
+import type {
+  LocationInventoryRollupResponse,
+  RollupQuantities,
+  SiteInventoryRollupResponse,
+  SiteRollupSummary,
+  StorageLocationRollupNode,
+} from '@durion-sdk/inventory';
+
+/**
+ * Inventory-by-location rollup models (CAP-218 frontend story F1).
+ *
+ * Payload types come from the generated SDK and are re-exported here so
+ * feature code never imports `@durion-sdk/inventory` directly (spec
+ * SPEC-inventory-location-rollup-frontend.md §4.1). Hand-written parallels
+ * of these payloads are prohibited.
+ */
+export type {
+  LocationInventoryRollupResponse,
+  RollupQuantities,
+  SiteInventoryRollupResponse,
+  SiteRollupSummary,
+  StorageLocationRollupNode,
+};
+
+/** Options for the site rollup query. */
+export interface SiteRollupOptions {
+  /** Optional stock item (SKU) filter; blank treated as absent. */
+  sku?: string;
+  /** Maximum tree depth to return (1 = root storage locations only). */
+  depth?: number;
+  /** Include storage locations with zero on-hand and zero allocations. */
+  includeEmpty?: boolean;
+}
+
+/** Options for the parent-location rollup query. v1 never sends expand=tree. */
+export interface LocationRollupOptions {
+  /** Typed parent chain to walk; backend defaults to PHYSICAL. */
+  parentType?: string;
+  /** Optional stock item (SKU) filter; blank treated as absent. */
+  sku?: string;
+}
+
+/**
+ * Discriminated error union surfaced by the rollup facade so views can
+ * render contract-driven states (spec §5) without inspecting HTTP details.
+ */
+export type RollupError =
+  | { kind: 'not-found'; message: string }
+  | { kind: 'upstream-down'; message: string; retryable: true }
+  | { kind: 'forbidden'; message: string }
+  | { kind: 'validation'; message: string }
+  | { kind: 'unknown'; message: string };
+
+export function isRollupError(value: unknown): value is RollupError {
+  return (
+    typeof value === 'object'
+    && value !== null
+    && 'kind' in value
+    && typeof (value as { kind: unknown }).kind === 'string'
+  );
+}

--- a/src/app/features/inventory/models/inventory-rollup.models.ts
+++ b/src/app/features/inventory/models/inventory-rollup.models.ts
@@ -64,7 +64,7 @@ export function isRollupError(value: unknown): value is RollupError {
     typeof value === 'object'
     && value !== null
     && 'kind' in value
-    && typeof (value as { kind: unknown }).kind === 'string'
+    && typeof value.kind === 'string'
     && (ROLLUP_ERROR_KINDS as readonly string[]).includes((value as { kind: string }).kind)
   );
 }

--- a/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.ts
+++ b/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 /**
  * Location Inventory Overview — parent-location rollup with per-site
@@ -11,10 +12,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   selector: 'app-location-inventory-overview-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslatePipe],
   template: `
     <section class="page-placeholder" aria-labelledby="invByLocationHeading">
-      <h1 id="invByLocationHeading">Inventory by Location</h1>
-      <p>Location overview arrives with story F3.</p>
+      <h1 id="invByLocationHeading">{{ 'INVENTORY.BY_LOCATION.OVERVIEW_PLACEHOLDER.TITLE' | translate }}</h1>
+      <p>{{ 'INVENTORY.BY_LOCATION.OVERVIEW_PLACEHOLDER.BODY' | translate }}</p>
     </section>
   `,
 })

--- a/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.ts
+++ b/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+/**
+ * Location Inventory Overview — parent-location rollup with per-site
+ * summaries and grand total (spec §3 Screen 1).
+ *
+ * F1 route scaffolding placeholder; full implementation lands with
+ * story F3 (SPEC-inventory-location-rollup-frontend.md §8).
+ */
+@Component({
+  selector: 'app-location-inventory-overview-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="page-placeholder" aria-labelledby="invByLocationHeading">
+      <h1 id="invByLocationHeading">Inventory by Location</h1>
+      <p>Location overview arrives with story F3.</p>
+    </section>
+  `,
+})
+export class LocationInventoryOverviewPageComponent {}

--- a/src/app/features/inventory/pages/by-location/site-tree/site-inventory-tree-page.component.ts
+++ b/src/app/features/inventory/pages/by-location/site-tree/site-inventory-tree-page.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+/**
+ * Site Inventory Tree — storage-location hierarchy with own/rolled-up
+ * quantities for one site (spec §3 Screen 2).
+ *
+ * F1 route scaffolding placeholder; full implementation lands with
+ * story F2 (SPEC-inventory-location-rollup-frontend.md §8).
+ */
+@Component({
+  selector: 'app-site-inventory-tree-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section class="page-placeholder" aria-labelledby="siteInventoryHeading">
+      <h1 id="siteInventoryHeading">Site Inventory</h1>
+      <p>Site storage-location tree arrives with story F2.</p>
+    </section>
+  `,
+})
+export class SiteInventoryTreePageComponent {}

--- a/src/app/features/inventory/pages/by-location/site-tree/site-inventory-tree-page.component.ts
+++ b/src/app/features/inventory/pages/by-location/site-tree/site-inventory-tree-page.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
 
 /**
  * Site Inventory Tree — storage-location hierarchy with own/rolled-up
@@ -11,10 +12,11 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   selector: 'app-site-inventory-tree-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslatePipe],
   template: `
     <section class="page-placeholder" aria-labelledby="siteInventoryHeading">
-      <h1 id="siteInventoryHeading">Site Inventory</h1>
-      <p>Site storage-location tree arrives with story F2.</p>
+      <h1 id="siteInventoryHeading">{{ 'INVENTORY.BY_LOCATION.SITE_PLACEHOLDER.TITLE' | translate }}</h1>
+      <p>{{ 'INVENTORY.BY_LOCATION.SITE_PLACEHOLDER.BODY' | translate }}</p>
     </section>
   `,
 })

--- a/src/app/features/inventory/services/inventory-rollup.service.spec.ts
+++ b/src/app/features/inventory/services/inventory-rollup.service.spec.ts
@@ -4,6 +4,7 @@ import { Observable, of, throwError } from 'rxjs';
 import { InventoryRollupService } from '@durion-sdk/inventory';
 import { InventoryRollupApiService } from './inventory-rollup.service';
 import {
+  isRollupError,
   LocationInventoryRollupResponse,
   RollupError,
   SiteInventoryRollupResponse,
@@ -47,6 +48,8 @@ describe('InventoryRollupApiService', () => {
       observable.subscribe({
         next: () => reject(new Error('expected error')),
         error: (err: RollupError) => resolve(err),
+        complete: () =>
+          reject(new Error('expected the observable to error, but it completed')),
       });
     });
   }
@@ -104,7 +107,7 @@ describe('InventoryRollupApiService', () => {
 
       const error = await captureError(service.getSiteRollup('site-1'));
 
-      expect(error.kind).toBe('upstream-down');
+      expect(error).toMatchObject({ kind: 'upstream-down', retryable: true });
     });
 
     it('maps 403 to forbidden', async () => {
@@ -133,6 +136,22 @@ describe('InventoryRollupApiService', () => {
       const error = await captureError(service.getSiteRollup('site-1'));
       expect(error).toEqual({ kind: 'unknown', message: 'boom' });
     });
+
+    it('falls back to the HttpErrorResponse message when the body has no string message', async () => {
+      const emptyBody = httpError(404, {});
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => emptyBody));
+      expect(await captureError(service.getSiteRollup('site-1'))).toEqual({
+        kind: 'not-found',
+        message: emptyBody.message,
+      });
+
+      const nonStringMessage = httpError(404, { code: 'NOT_FOUND', message: 42 });
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => nonStringMessage));
+      expect(await captureError(service.getSiteRollup('site-1'))).toEqual({
+        kind: 'not-found',
+        message: nonStringMessage.message,
+      });
+    });
   });
 
   describe('getLocationRollup', () => {
@@ -155,12 +174,49 @@ describe('InventoryRollupApiService', () => {
       expect(result).toEqual(locationResponse);
     });
 
+    it('treats a blank sku as absent', () => {
+      sdkStub.getLocationInventoryRollup.mockReturnValue(of(locationResponse));
+
+      service.getLocationRollup('loc-1', { sku: '   ' }).subscribe();
+
+      expect(sdkStub.getLocationInventoryRollup).toHaveBeenCalledWith(
+        'loc-1',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
     it('maps errors with the same union as the site rollup', async () => {
       sdkStub.getLocationInventoryRollup.mockReturnValue(throwError(() => httpError(404)));
 
       const error = await captureError(service.getLocationRollup('loc-1'));
 
       expect(error.kind).toBe('not-found');
+    });
+  });
+
+  describe('isRollupError', () => {
+    it('accepts every valid kind', () => {
+      const kinds = ['not-found', 'upstream-down', 'forbidden', 'validation', 'unknown'] as const;
+      for (const kind of kinds) {
+        expect(isRollupError({ kind, message: 'm' }), kind).toBe(true);
+      }
+    });
+
+    it('rejects an object with an unrecognized kind', () => {
+      expect(isRollupError({ kind: 'nope', message: 'm' })).toBe(false);
+    });
+
+    it('rejects values that are not RollupError shapes', () => {
+      expect(isRollupError(null)).toBe(false);
+      expect(isRollupError(undefined)).toBe(false);
+      expect(isRollupError('not-found')).toBe(false);
+      expect(isRollupError(42)).toBe(false);
+      expect(isRollupError({})).toBe(false);
+      expect(isRollupError({ kind: 404 })).toBe(false);
     });
   });
 });

--- a/src/app/features/inventory/services/inventory-rollup.service.spec.ts
+++ b/src/app/features/inventory/services/inventory-rollup.service.spec.ts
@@ -1,0 +1,166 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { InventoryRollupService } from '@durion-sdk/inventory';
+import { InventoryRollupApiService } from './inventory-rollup.service';
+import {
+  LocationInventoryRollupResponse,
+  RollupError,
+  SiteInventoryRollupResponse,
+} from '../models/inventory-rollup.models';
+
+describe('InventoryRollupApiService', () => {
+  let service: InventoryRollupApiService;
+
+  const sdkStub = {
+    getSiteInventoryRollup: vi.fn(),
+    getLocationInventoryRollup: vi.fn(),
+  };
+
+  const siteResponse: SiteInventoryRollupResponse = {
+    siteId: 'site-1',
+    totals: { onHand: 480, allocated: 30, available: 450 },
+    nodes: [],
+  };
+
+  const locationResponse: LocationInventoryRollupResponse = {
+    locationId: 'loc-1',
+    parentType: 'PHYSICAL',
+    totals: { onHand: 150, allocated: 15, available: 135 },
+    sites: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [{ provide: InventoryRollupService, useValue: sdkStub }],
+    });
+    service = TestBed.inject(InventoryRollupApiService);
+  });
+
+  function httpError(status: number, body?: unknown): HttpErrorResponse {
+    return new HttpErrorResponse({ status, error: body ?? null, url: '/test' });
+  }
+
+  function captureError(observable: Observable<unknown>): Promise<RollupError> {
+    return new Promise((resolve, reject) => {
+      observable.subscribe({
+        next: () => reject(new Error('expected error')),
+        error: (err: RollupError) => resolve(err),
+      });
+    });
+  }
+
+  describe('getSiteRollup', () => {
+    it('passes siteId and normalized options to the SDK', () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(of(siteResponse));
+
+      let result: SiteInventoryRollupResponse | undefined;
+      service
+        .getSiteRollup('site-1', { sku: '  SKU-9  ', depth: 2, includeEmpty: true })
+        .subscribe(value => (result = value));
+
+      expect(sdkStub.getSiteInventoryRollup).toHaveBeenCalledWith('site-1', 'SKU-9', 2, true);
+      expect(result).toEqual(siteResponse);
+    });
+
+    it('treats a blank sku as absent', () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(of(siteResponse));
+
+      service.getSiteRollup('site-1', { sku: '   ' }).subscribe();
+
+      expect(sdkStub.getSiteInventoryRollup).toHaveBeenCalledWith(
+        'site-1',
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('maps 404 to not-found with the ApiError message', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(
+        throwError(() => httpError(404, { code: 'NOT_FOUND', message: 'Location not found: x' })),
+      );
+
+      const error = await captureError(service.getSiteRollup('site-1'));
+
+      expect(error).toEqual({ kind: 'not-found', message: 'Location not found: x' });
+    });
+
+    it('maps 503 to retryable upstream-down', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(
+        throwError(() =>
+          httpError(503, { code: 'LOCATION_SERVICE_UNAVAILABLE', message: 'down' }),
+        ),
+      );
+
+      const error = await captureError(service.getSiteRollup('site-1'));
+
+      expect(error).toEqual({ kind: 'upstream-down', message: 'down', retryable: true });
+    });
+
+    it('maps network failure (status 0) to retryable upstream-down', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => httpError(0)));
+
+      const error = await captureError(service.getSiteRollup('site-1'));
+
+      expect(error.kind).toBe('upstream-down');
+    });
+
+    it('maps 403 to forbidden', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => httpError(403)));
+
+      const error = await captureError(service.getSiteRollup('site-1'));
+
+      expect(error.kind).toBe('forbidden');
+    });
+
+    it('maps 400 and 422 to validation', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => httpError(400)));
+      expect((await captureError(service.getSiteRollup('site-1'))).kind).toBe('validation');
+
+      sdkStub.getSiteInventoryRollup.mockReturnValue(
+        throwError(() => httpError(422, { code: 'ROLLUP_EXPANSION_TOO_LARGE', message: 'cap' })),
+      );
+      expect((await captureError(service.getSiteRollup('site-1'))).kind).toBe('validation');
+    });
+
+    it('maps unexpected statuses and non-HTTP errors to unknown', async () => {
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => httpError(500)));
+      expect((await captureError(service.getSiteRollup('site-1'))).kind).toBe('unknown');
+
+      sdkStub.getSiteInventoryRollup.mockReturnValue(throwError(() => new Error('boom')));
+      const error = await captureError(service.getSiteRollup('site-1'));
+      expect(error).toEqual({ kind: 'unknown', message: 'boom' });
+    });
+  });
+
+  describe('getLocationRollup', () => {
+    it('passes options through and never requests expand=tree', () => {
+      sdkStub.getLocationInventoryRollup.mockReturnValue(of(locationResponse));
+
+      let result: LocationInventoryRollupResponse | undefined;
+      service
+        .getLocationRollup('loc-1', { parentType: 'PHYSICAL', sku: 'SKU-1' })
+        .subscribe(value => (result = value));
+
+      expect(sdkStub.getLocationInventoryRollup).toHaveBeenCalledWith(
+        'loc-1',
+        'PHYSICAL',
+        'SKU-1',
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(result).toEqual(locationResponse);
+    });
+
+    it('maps errors with the same union as the site rollup', async () => {
+      sdkStub.getLocationInventoryRollup.mockReturnValue(throwError(() => httpError(404)));
+
+      const error = await captureError(service.getLocationRollup('loc-1'));
+
+      expect(error.kind).toBe('not-found');
+    });
+  });
+});

--- a/src/app/features/inventory/services/inventory-rollup.service.ts
+++ b/src/app/features/inventory/services/inventory-rollup.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { InventoryRollupService } from '@durion-sdk/inventory';
+import {
+  LocationInventoryRollupResponse,
+  LocationRollupOptions,
+  RollupError,
+  SiteInventoryRollupResponse,
+  SiteRollupOptions,
+} from '../models/inventory-rollup.models';
+
+/**
+ * Facade over the generated {@link InventoryRollupService} SDK client
+ * (CAP-218 frontend story F1).
+ *
+ * Responsibilities: parameter normalization, mapping transport errors to
+ * the {@link RollupError} discriminated union for the views. Views depend
+ * on this facade, never on the SDK client directly (spec §2a/§4.2).
+ *
+ * Authorization note: per current module convention, route-level role data
+ * is not declared for read views; the backend enforces
+ * `inventory:on_hand:view` and a 403 surfaces as `kind: 'forbidden'`
+ * (spec open question 2).
+ */
+@Injectable({ providedIn: 'root' })
+export class InventoryRollupApiService {
+  private readonly rollupSdk = inject(InventoryRollupService);
+
+  /**
+   * Storage-location rollup tree for one site
+   * (`GET /v1/inventory/sites/{siteId}/inventory-rollup`).
+   */
+  getSiteRollup(
+    siteId: string,
+    options: SiteRollupOptions = {},
+  ): Observable<SiteInventoryRollupResponse> {
+    return this.rollupSdk
+      .getSiteInventoryRollup(
+        siteId,
+        normalizeSku(options.sku),
+        options.depth,
+        options.includeEmpty,
+      )
+      .pipe(catchError(error => throwError(() => toRollupError(error))));
+  }
+
+  /**
+   * Per-site summaries plus grand total for a parent location
+   * (`GET /v1/inventory/locations/{locationId}/inventory-rollup`).
+   * v1 never requests `expand=tree`, so the descendant-site cap (422)
+   * cannot be hit from this facade.
+   */
+  getLocationRollup(
+    locationId: string,
+    options: LocationRollupOptions = {},
+  ): Observable<LocationInventoryRollupResponse> {
+    return this.rollupSdk
+      .getLocationInventoryRollup(
+        locationId,
+        options.parentType,
+        normalizeSku(options.sku),
+        undefined, // expand — intentionally never 'tree' in v1
+        undefined, // depth — only meaningful with expand=tree
+        undefined, // includeEmpty — only meaningful with expand=tree
+      )
+      .pipe(catchError(error => throwError(() => toRollupError(error))));
+  }
+}
+
+function normalizeSku(sku: string | undefined): string | undefined {
+  const trimmed = sku?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function toRollupError(error: unknown): RollupError {
+  if (error instanceof HttpErrorResponse) {
+    const message = extractMessage(error);
+    switch (error.status) {
+      case 404:
+        return { kind: 'not-found', message };
+      case 403:
+        return { kind: 'forbidden', message };
+      case 400:
+      case 422:
+        return { kind: 'validation', message };
+      case 0: // network/connection failure
+      case 503:
+        return { kind: 'upstream-down', message, retryable: true };
+      default:
+        return { kind: 'unknown', message };
+    }
+  }
+  return { kind: 'unknown', message: error instanceof Error ? error.message : String(error) };
+}
+
+function extractMessage(error: HttpErrorResponse): string {
+  const body = error.error as { message?: unknown; code?: unknown } | null | undefined;
+  if (body && typeof body.message === 'string' && body.message) {
+    return body.message;
+  }
+  return error.message;
+}

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -3173,6 +3173,16 @@
       "CATEGORY": {
         "INVENTORY": "Inventory"
       }
+    },
+    "BY_LOCATION": {
+      "OVERVIEW_PLACEHOLDER": {
+        "TITLE": "Inventory by Location",
+        "BODY": "Location overview arrives with story F3."
+      },
+      "SITE_PLACEHOLDER": {
+        "TITLE": "Site Inventory",
+        "BODY": "Site storage-location tree arrives with story F2."
+      }
     }
   },
   "BILLING": {

--- a/src/assets/i18n/es-US.json
+++ b/src/assets/i18n/es-US.json
@@ -3173,6 +3173,16 @@
       "CATEGORY": {
         "INVENTORY": "Inventario"
       }
+    },
+    "BY_LOCATION": {
+      "OVERVIEW_PLACEHOLDER": {
+        "TITLE": "Inventario por ubicación",
+        "BODY": "La vista general de ubicaciones llegará con la historia F3."
+      },
+      "SITE_PLACEHOLDER": {
+        "TITLE": "Inventario del sitio",
+        "BODY": "El árbol de ubicaciones de almacenamiento del sitio llegará con la historia F2."
+      }
     }
   },
   "BILLING": {

--- a/src/assets/i18n/fr-CA.json
+++ b/src/assets/i18n/fr-CA.json
@@ -3173,6 +3173,16 @@
       "CATEGORY": {
         "INVENTORY": "Inventaire"
       }
+    },
+    "BY_LOCATION": {
+      "OVERVIEW_PLACEHOLDER": {
+        "TITLE": "Inventaire par emplacement",
+        "BODY": "L'aperçu des emplacements arrivera avec le récit F3."
+      },
+      "SITE_PLACEHOLDER": {
+        "TITLE": "Inventaire du site",
+        "BODY": "L'arborescence des emplacements d'entreposage du site arrivera avec le récit F2."
+      }
     }
   },
   "BILLING": {

--- a/src/assets/i18n/qps-ploc.json
+++ b/src/assets/i18n/qps-ploc.json
@@ -203,8 +203,8 @@
           "DESCRIPTION": "[!! ØØṕëëñ ŕøøľëë ààççëëšš ààñđ ľøøçààŧïïøøñ ààššïïğñḿëëñŧ ṕààğëëš ŵïïŧħ ŧħëë ÏÏĐš ÿøøüüŕ ŵøøŕķƒľøøŵ ñëëëëđš. !!]"
         },
         "DATA_IMPORT": {
-          "TITLE": "[!! Data Import !!]",
-          "DESCRIPTION": "[!! Bulk import people and HR data. !!]"
+          "TITLE": "[!! Đààŧàà ÏÏḿṕøøŕŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṕëëøøṕľëë ààñđ ĦŔ đààŧàà. !!]"
         }
       },
       "CARD": {
@@ -249,8 +249,8 @@
           "DESCRIPTION": "[!! Ŕëëṽïïëëŵ ààñđ üüṕđààŧëë ľøøçààŧïïøøñ ààššïïğñḿëëñŧš ƒøøŕ àà šṕëëçïïƒïïç ṕëëŕšøøñ ÏÏĐ. !!]"
         },
         "IMPORT_PEOPLE": {
-          "TITLE": "[!! Import People !!]",
-          "DESCRIPTION": "[!! Bulk import people and HR records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ṕëëøøṕľëë !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṕëëøøṕľëë ààñđ ĦŔ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         }
       },
       "FIELD": {
@@ -275,7 +275,7 @@
         "OPEN_EMPLOYEE_OFFBOARD": "[!! ØØṕëëñ ØØƒƒƀøøààŕđ Ṕààğëë !!]",
         "OPEN_RBAC": "[!! ØØṕëëñ Ŕøøľëë AAššïïğñḿëëñŧ !!]",
         "OPEN_PERSON_LOCATIONS": "[!! ØØṕëëñ Ŀøøçààŧïïøøñ AAššïïğñḿëëñŧš !!]",
-        "IMPORT_DATA": "[!! Import Data !!]"
+        "IMPORT_DATA": "[!! ÏÏḿṕøøŕŧ Đààŧàà !!]"
       },
       "ERROR": {
         "REQUIRED_IDENTIFIER": "[!! ËËñŧëëŕ ŧħëë ŕëëqüüïïŕëëđ ïïđëëñŧïïƒïïëëŕ ƀëëƒøøŕëë øøṕëëñïïñğ ŧħïïš ṕààğëë. !!]",
@@ -395,8 +395,8 @@
           "DESCRIPTION": "[!! AAççëëšš ŧħëë ÇŔḾ šñààṕšħøøŧ ƒøøŕ çüüšŧøøḿëëŕ çøøñŧëëẍŧ ààŧ àà ğľààñçëë, ààñđ ŕëëṽïïëëŵ ïïñŧëëğŕààŧïïøøñ ëëṽëëñŧš ƒøøŕ đïïààğñøøšŧïïçš. !!]"
         },
         "DATA_IMPORT": {
-          "TITLE": "[!! Data Import !!]",
-          "DESCRIPTION": "[!! Bulk import CRM data. !!]"
+          "TITLE": "[!! Đààŧàà ÏÏḿṕøøŕŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ÇŔḾ đààŧàà. !!]"
         }
       },
       "CARD": {
@@ -445,16 +445,16 @@
           "DESCRIPTION": "[!! Ŕëëṽïïëëŵ ŧħëë ľøøğ øøƒ ïïñŧëëğŕààŧïïøøñ ëëṽëëñŧš ƀëëŧŵëëëëñ ŧħëë ÇŔḾ ààñđ ëëẍŧëëŕñààľ šÿšŧëëḿš. !!]"
         },
         "IMPORT_CUSTOMER": {
-          "TITLE": "[!! Import Customers !!]",
-          "DESCRIPTION": "[!! Bulk import customer records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Çüüšŧøøḿëëŕš !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ çüüšŧøøḿëëŕ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         },
         "IMPORT_VEHICLE_INVENTORY": {
-          "TITLE": "[!! Import Vehicle Inventory !!]",
-          "DESCRIPTION": "[!! Bulk import vehicle inventory records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ṽëëħïïçľëë ÏÏñṽëëñŧøøŕÿ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṽëëħïïçľëë ïïñṽëëñŧøøŕÿ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         },
         "IMPORT_VEHICLE_FITMENT": {
-          "TITLE": "[!! Import Vehicle Fitment !!]",
-          "DESCRIPTION": "[!! Bulk import vehicle fitment records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ṽëëħïïçľëë Ƒïïŧḿëëñŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṽëëħïïçľëë ƒïïŧḿëëñŧ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         }
       },
       "FIELD": {
@@ -475,7 +475,7 @@
         "OPEN_BILLING_RULES": "[!! Ṽïïëëŵ Ɓïïľľïïñğ Ŕüüľëëš !!]",
         "OPEN_SNAPSHOT": "[!! Ŀøøààđ Šñààṕšħøøŧ !!]",
         "OPENING_PAGE": "[!! ØØṕëëñïïñğ... !!]",
-        "IMPORT_DATA": "[!! Import Data !!]"
+        "IMPORT_DATA": "[!! ÏÏḿṕøøŕŧ Đààŧàà !!]"
       },
       "ERROR": {
         "REQUIRED_IDENTIFIER": "[!! AA Ṕààŕŧÿ ÏÏĐ ïïš ŕëëqüüïïŕëëđ. !!]",
@@ -823,8 +823,8 @@
           "DESCRIPTION": "[!! AAççëëšš ƀààÿš, ḿøøƀïïľëë üüñïïŧš, šŧøøŕààğëë ľøøçààŧïïøøñš, ààñđ šÿñç ŧøøøøľš. !!]"
         },
         "DATA_IMPORT": {
-          "TITLE": "[!! Data Import !!]",
-          "DESCRIPTION": "[!! Bulk import location data. !!]"
+          "TITLE": "[!! Đààŧàà ÏÏḿṕøøŕŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ľøøçààŧïïøøñ đààŧàà. !!]"
         }
       },
       "CARD": {
@@ -861,8 +861,8 @@
           "DESCRIPTION": "[!! Ŕüüñ ààñđ ḿøøñïïŧøøŕ šÿñçħŕøøñïïžààŧïïøøñ ĵøøƀš ƒøøŕ ľøøçààŧïïøøñ đààŧàà. !!]"
         },
         "IMPORT_LOCATION": {
-          "TITLE": "[!! Import Locations !!]",
-          "DESCRIPTION": "[!! Bulk import location records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ŀøøçààŧïïøøñš !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ľøøçààŧïïøøñ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         }
       },
       "FIELD": {
@@ -878,7 +878,7 @@
         "OPENING_PAGE": "[!! ØØṕëëñïïñğ… !!]",
         "OPEN_LOCATION": "[!! ØØṕëëñ Ŀøøçààŧïïøøñ !!]",
         "OPEN_LOCATION_DEFAULTS": "[!! ØØṕëëñ Đëëƒààüüľŧš !!]",
-        "IMPORT_DATA": "[!! Import Data !!]"
+        "IMPORT_DATA": "[!! ÏÏḿṕøøŕŧ Đààŧàà !!]"
       },
       "ERROR": {
         "REQUIRED_IDENTIFIER": "[!! ËËñŧëëŕ ŧħëë ŕëëqüüïïŕëëđ ïïđëëñŧïïƒïïëëŕ ƀëëƒøøŕëë øøṕëëñïïñğ ŧħïïš ṕààğëë. !!]",
@@ -1875,74 +1875,74 @@
       }
     },
     "LANDING": {
-      "EYEBROW": "[!! Product & Catalog !!]",
-      "TITLE": "[!! Product Management !!]",
-      "SUBTITLE": "[!! Manage your product catalog, pricing, inventory feeds, and bulk imports. !!]",
+      "EYEBROW": "[!! Ṕŕøøđüüçŧ & Çààŧààľøøğ !!]",
+      "TITLE": "[!! Ṕŕøøđüüçŧ Ḿààñààğëëḿëëñŧ !!]",
+      "SUBTITLE": "[!! Ḿààñààğëë ÿøøüüŕ ṕŕøøđüüçŧ çààŧààľøøğ, ṕŕïïçïïñğ, ïïñṽëëñŧøøŕÿ ƒëëëëđš, ààñđ ƀüüľķ ïïḿṕøøŕŧš. !!]",
       "HERO": {
-        "OPEN_CATALOG": "[!! Open Catalog !!]",
-        "OPEN_PRICE_BOOKS": "[!! Open Price Books !!]"
+        "OPEN_CATALOG": "[!! ØØṕëëñ Çààŧààľøøğ !!]",
+        "OPEN_PRICE_BOOKS": "[!! ØØṕëëñ Ṕŕïïçëë Ɓøøøøķš !!]"
       },
       "STAT": {
-        "ARIA": "[!! Product management statistics !!]",
-        "PAGES": "[!! Total pages !!]",
-        "DIRECT_LINKS": "[!! Quick links !!]",
-        "GUIDED_LAUNCHES": "[!! Guided launches !!]"
+        "ARIA": "[!! Ṕŕøøđüüçŧ ḿààñààğëëḿëëñŧ šŧààŧïïšŧïïçš !!]",
+        "PAGES": "[!! Ŧøøŧààľ ṕààğëëš !!]",
+        "DIRECT_LINKS": "[!! Qüüïïçķ ľïïñķš !!]",
+        "GUIDED_LAUNCHES": "[!! Ğüüïïđëëđ ľààüüñçħëëš !!]"
       },
-      "LOADING": "[!! Loading product data... !!]",
+      "LOADING": "[!! Ŀøøààđïïñğ ṕŕøøđüüçŧ đààŧàà... !!]",
       "ACTION": {
-        "OPEN_PAGE": "[!! Open !!]",
-        "IMPORT_DATA": "[!! Import Data !!]"
+        "OPEN_PAGE": "[!! ØØṕëëñ !!]",
+        "IMPORT_DATA": "[!! ÏÏḿṕøøŕŧ Đààŧàà !!]"
       },
       "SECTION": {
         "CATALOG": {
-          "TITLE": "[!! Catalog !!]",
-          "DESCRIPTION": "[!! Browse and manage product records. !!]"
+          "TITLE": "[!! Çààŧààľøøğ !!]",
+          "DESCRIPTION": "[!! Ɓŕøøŵšëë ààñđ ḿààñààğëë ṕŕøøđüüçŧ ŕëëçøøŕđš. !!]"
         },
         "PRICING": {
-          "TITLE": "[!! Pricing !!]",
-          "DESCRIPTION": "[!! Manage price books, MSRP, and location overrides. !!]"
+          "TITLE": "[!! Ṕŕïïçïïñğ !!]",
+          "DESCRIPTION": "[!! Ḿààñààğëë ṕŕïïçëë ƀøøøøķš, ḾŠŔṔ, ààñđ ľøøçààŧïïøøñ øøṽëëŕŕïïđëëš. !!]"
         },
         "INVENTORY": {
-          "TITLE": "[!! Inventory !!]",
-          "DESCRIPTION": "[!! Track availability and manage inventory feeds. !!]"
+          "TITLE": "[!! ÏÏñṽëëñŧøøŕÿ !!]",
+          "DESCRIPTION": "[!! Ŧŕààçķ ààṽààïïľààƀïïľïïŧÿ ààñđ ḿààñààğëë ïïñṽëëñŧøøŕÿ ƒëëëëđš. !!]"
         },
         "DATA_IMPORT": {
-          "TITLE": "[!! Data Import !!]",
-          "DESCRIPTION": "[!! Bulk import product catalog and pricing data. !!]"
+          "TITLE": "[!! Đààŧàà ÏÏḿṕøøŕŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṕŕøøđüüçŧ çààŧààľøøğ ààñđ ṕŕïïçïïñğ đààŧàà. !!]"
         }
       },
       "CARD": {
         "CATALOG_LIST": {
-          "TITLE": "[!! Product List !!]",
-          "DESCRIPTION": "[!! View and manage all products in the catalog. !!]"
+          "TITLE": "[!! Ṕŕøøđüüçŧ Ŀïïšŧ !!]",
+          "DESCRIPTION": "[!! Ṽïïëëŵ ààñđ ḿààñààğëë ààľľ ṕŕøøđüüçŧš ïïñ ŧħëë çààŧààľøøğ. !!]"
         },
         "PRICE_BOOKS": {
-          "TITLE": "[!! Price Books !!]",
-          "DESCRIPTION": "[!! Manage price books and customer pricing tiers. !!]"
+          "TITLE": "[!! Ṕŕïïçëë Ɓøøøøķš !!]",
+          "DESCRIPTION": "[!! Ḿààñààğëë ṕŕïïçëë ƀøøøøķš ààñđ çüüšŧøøḿëëŕ ṕŕïïçïïñğ ŧïïëëŕš. !!]"
         },
         "MSRP": {
-          "TITLE": "[!! MSRP !!]",
-          "DESCRIPTION": "[!! Set and manage manufacturer suggested retail prices. !!]"
+          "TITLE": "[!! ḾŠŔṔ !!]",
+          "DESCRIPTION": "[!! Šëëŧ ààñđ ḿààñààğëë ḿààñüüƒààçŧüüŕëëŕ šüüğğëëšŧëëđ ŕëëŧààïïľ ṕŕïïçëëš. !!]"
         },
         "LOCATION_OVERRIDES": {
-          "TITLE": "[!! Location Overrides !!]",
-          "DESCRIPTION": "[!! Manage location-specific pricing overrides. !!]"
+          "TITLE": "[!! Ŀøøçààŧïïøøñ ØØṽëëŕŕïïđëëš !!]",
+          "DESCRIPTION": "[!! Ḿààñààğëë ľøøçààŧïïøøñ-šṕëëçïïƒïïç ṕŕïïçïïñğ øøṽëëŕŕïïđëëš. !!]"
         },
         "AVAILABILITY": {
-          "TITLE": "[!! Availability !!]",
-          "DESCRIPTION": "[!! Track and manage product availability. !!]"
+          "TITLE": "[!! AAṽààïïľààƀïïľïïŧÿ !!]",
+          "DESCRIPTION": "[!! Ŧŕààçķ ààñđ ḿààñààğëë ṕŕøøđüüçŧ ààṽààïïľààƀïïľïïŧÿ. !!]"
         },
         "FEEDS": {
-          "TITLE": "[!! Inventory Feeds !!]",
-          "DESCRIPTION": "[!! Manage automated inventory data feeds. !!]"
+          "TITLE": "[!! ÏÏñṽëëñŧøøŕÿ Ƒëëëëđš !!]",
+          "DESCRIPTION": "[!! Ḿààñààğëë ààüüŧøøḿààŧëëđ ïïñṽëëñŧøøŕÿ đààŧàà ƒëëëëđš. !!]"
         },
         "IMPORT_CATALOG": {
-          "TITLE": "[!! Import Catalog !!]",
-          "DESCRIPTION": "[!! Bulk import product catalog records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Çààŧààľøøğ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṕŕøøđüüçŧ çààŧààľøøğ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         },
         "IMPORT_PRICE": {
-          "TITLE": "[!! Import Pricing !!]",
-          "DESCRIPTION": "[!! Bulk import pricing data from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ṕŕïïçïïñğ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ ṕŕïïçïïñğ đààŧàà ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         }
       }
     }
@@ -2267,8 +2267,8 @@
           "DESCRIPTION": "[!! Ḿààñààğëë ṕëëŕḿïïššïïøøñš ààñđ çøøñƒïïğüüŕààŧïïøøñ ƒøøŕ ïïñṽëëñŧøøŕÿ. !!]"
         },
         "DATA_IMPORT": {
-          "TITLE": "[!! Data Import !!]",
-          "DESCRIPTION": "[!! Bulk import stock inventory data. !!]"
+          "TITLE": "[!! Đààŧàà ÏÏḿṕøøŕŧ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ šŧøøçķ ïïñṽëëñŧøøŕÿ đààŧàà. !!]"
         }
       },
       "CARD": {
@@ -2361,8 +2361,8 @@
           "DESCRIPTION": "[!! Ḿààñààğëë ïïñṽëëñŧøøŕÿ ààççëëšš ààñđ ṕëëŕḿïïššïïøøñ šëëŧŧïïñğš. !!]"
         },
         "IMPORT_STOCK": {
-          "TITLE": "[!! Import Stock !!]",
-          "DESCRIPTION": "[!! Bulk import stock inventory records from a CSV or XLSX file. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Šŧøøçķ !!]",
+          "DESCRIPTION": "[!! Ɓüüľķ ïïḿṕøøŕŧ šŧøøçķ ïïñṽëëñŧøøŕÿ ŕëëçøøŕđš ƒŕøøḿ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë. !!]"
         }
       },
       "FIELD": {
@@ -3173,6 +3173,16 @@
       "CATEGORY": {
         "INVENTORY": "[!! ÏÏñṽëëñŧøøŕÿ !!]"
       }
+    },
+    "BY_LOCATION": {
+      "OVERVIEW_PLACEHOLDER": {
+        "TITLE": "[!! ÏÏñṽëëñŧøøŕÿ ƀÿ Ŀøøçààŧïïøøñ !!]",
+        "BODY": "[!! Ŀøøçààŧïïøøñ øøṽëëŕṽïïëëŵ ààŕŕïïṽëëš ŵïïŧħ šŧøøŕÿ Ƒ3. !!]"
+      },
+      "SITE_PLACEHOLDER": {
+        "TITLE": "[!! Šïïŧëë ÏÏñṽëëñŧøøŕÿ !!]",
+        "BODY": "[!! Šïïŧëë šŧøøŕààğëë-ľøøçààŧïïøøñ ŧŕëëëë ààŕŕïïṽëëš ŵïïŧħ šŧøøŕÿ Ƒ2. !!]"
+      }
     }
   },
   "BILLING": {
@@ -3282,7 +3292,7 @@
         "GENERATED_BY": "[!! Ğëëñëëŕààŧëëđ Ɓÿ !!]"
       },
       "ADJUSTMENT": {
-        "META": "[!! {{timestamp}} - ƀÿ {{user}} !!]"
+        "META": "{{timestamp}}[!!  - ƀÿ  !!]{{user}}"
       },
       "ARIA": {
         "LINE_ITEMS": "[!! ÏÏñṽøøïïçëë ľïïñëë ïïŧëëḿš !!]",
@@ -3561,8 +3571,8 @@
           "DESCRIPTION": "[!! Ŕëëṽïïëëŵ šëëçüüŕïïŧÿ ààüüđïïŧ ëëñŧŕïïëëš ààñđ ŧħëë ƒüüľľ ṕľààŧƒøøŕḿ ààüüđïïŧ ëëṽëëñŧ ľøøğ. !!]"
         },
         "DATA_TOOLS": {
-          "TITLE": "[!! Data Tools !!]",
-          "DESCRIPTION": "[!! Manage bulk data imports and system data operations. !!]"
+          "TITLE": "[!! Đààŧàà Ŧøøøøľš !!]",
+          "DESCRIPTION": "[!! Ḿààñààğëë ƀüüľķ đààŧàà ïïḿṕøøŕŧš ààñđ šÿšŧëëḿ đààŧàà øøṕëëŕààŧïïøøñš. !!]"
         }
       },
       "CARD": {
@@ -3591,8 +3601,8 @@
           "DESCRIPTION": "[!! Ɓŕøøŵšëë ààñđ ëëẍṕøøŕŧ ŧħëë ƒüüľľ ṕľààŧƒøøŕḿ ààüüđïïŧ ëëṽëëñŧ ľøøğ ŵïïŧħ ààçŧøøŕ ààñđ ŧïïḿëëšŧààḿṕ ƒïïľŧëëŕš. !!]"
         },
         "IMPORT_JOBS": {
-          "TITLE": "[!! Import Jobs !!]",
-          "DESCRIPTION": "[!! View and manage all bulk data import jobs across all domains. !!]"
+          "TITLE": "[!! ÏÏḿṕøøŕŧ Ĵøøƀš !!]",
+          "DESCRIPTION": "[!! Ṽïïëëŵ ààñđ ḿààñààğëë ààľľ ƀüüľķ đààŧàà ïïḿṕøøŕŧ ĵøøƀš ààçŕøøšš ààľľ đøøḿààïïñš. !!]"
         }
       },
       "FIELD": {
@@ -3614,236 +3624,236 @@
   },
   "BULK_IMPORT": {
     "DOMAIN": {
-      "CATALOG": "[!! Product Catalog !!]",
-      "INVENTORY": "[!! Stock Inventory !!]",
-      "LOCATION": "[!! Location !!]",
-      "CUSTOMER": "[!! Customer !!]",
-      "PEOPLE": "[!! People / HR !!]",
-      "PRICE": "[!! Pricing !!]",
-      "VEHICLE_INVENTORY": "[!! Vehicle Inventory !!]",
-      "VEHICLE_FITMENT": "[!! Vehicle Fitment !!]"
+      "CATALOG": "[!! Ṕŕøøđüüçŧ Çààŧààľøøğ !!]",
+      "INVENTORY": "[!! Šŧøøçķ ÏÏñṽëëñŧøøŕÿ !!]",
+      "LOCATION": "[!! Ŀøøçààŧïïøøñ !!]",
+      "CUSTOMER": "[!! Çüüšŧøøḿëëŕ !!]",
+      "PEOPLE": "[!! Ṕëëøøṕľëë / ĦŔ !!]",
+      "PRICE": "[!! Ṕŕïïçïïñğ !!]",
+      "VEHICLE_INVENTORY": "[!! Ṽëëħïïçľëë ÏÏñṽëëñŧøøŕÿ !!]",
+      "VEHICLE_FITMENT": "[!! Ṽëëħïïçľëë Ƒïïŧḿëëñŧ !!]"
     },
     "STATUS": {
-      "CREATED": "[!! Created !!]",
-      "UPLOADING": "[!! Uploading !!]",
-      "DETECTING": "[!! Detecting !!]",
-      "MAPPING_REVIEW": "[!! Mapping Review !!]",
-      "DEDUP": "[!! Dedup !!]",
-      "PROCESSING": "[!! Processing !!]",
-      "COMPLETED": "[!! Completed !!]",
-      "FAILED": "[!! Failed !!]",
-      "CANCELLED": "[!! Cancelled !!]"
+      "CREATED": "[!! Çŕëëààŧëëđ !!]",
+      "UPLOADING": "[!! ÜÜṕľøøààđïïñğ !!]",
+      "DETECTING": "[!! Đëëŧëëçŧïïñğ !!]",
+      "MAPPING_REVIEW": "[!! Ḿààṕṕïïñğ Ŕëëṽïïëëŵ !!]",
+      "DEDUP": "[!! Đëëđüüṕ !!]",
+      "PROCESSING": "[!! Ṕŕøøçëëššïïñğ !!]",
+      "COMPLETED": "[!! Çøøḿṕľëëŧëëđ !!]",
+      "FAILED": "[!! Ƒààïïľëëđ !!]",
+      "CANCELLED": "[!! Çààñçëëľľëëđ !!]"
     },
     "JOBS": {
-      "TITLE": "[!! Import Jobs !!]",
-      "SUBTITLE": "[!! Track and manage all bulk data import jobs. !!]",
-      "LOADING": "[!! Loading jobs… !!]",
-      "EMPTY": "[!! No import jobs found. !!]",
-      "REFRESH": "[!! Refresh !!]",
+      "TITLE": "[!! ÏÏḿṕøøŕŧ Ĵøøƀš !!]",
+      "SUBTITLE": "[!! Ŧŕààçķ ààñđ ḿààñààğëë ààľľ ƀüüľķ đààŧàà ïïḿṕøøŕŧ ĵøøƀš. !!]",
+      "LOADING": "[!! Ŀøøààđïïñğ ĵøøƀš… !!]",
+      "EMPTY": "[!! Ňøø ïïḿṕøøŕŧ ĵøøƀš ƒøøüüñđ. !!]",
+      "REFRESH": "[!! Ŕëëƒŕëëšħ !!]",
       "ERROR": {
-        "LOAD": "[!! Unable to load jobs. Please try again. !!]"
+        "LOAD": "[!! ÜÜñààƀľëë ŧøø ľøøààđ ĵøøƀš. Ṕľëëààšëë ŧŕÿ ààğààïïñ. !!]"
       },
       "FILTERS": {
-        "ARIA_LABEL": "[!! Filter jobs !!]",
-        "DOMAIN": "[!! Domain !!]",
-        "STATUS": "[!! Status !!]",
-        "ALL_DOMAINS": "[!! All domains !!]",
-        "ALL_STATUSES": "[!! All statuses !!]"
+        "ARIA_LABEL": "[!! Ƒïïľŧëëŕ ĵøøƀš !!]",
+        "DOMAIN": "[!! Đøøḿààïïñ !!]",
+        "STATUS": "[!! Šŧààŧüüš !!]",
+        "ALL_DOMAINS": "[!! AAľľ đøøḿààïïñš !!]",
+        "ALL_STATUSES": "[!! AAľľ šŧààŧüüšëëš !!]"
       },
       "TABLE": {
-        "CAPTION": "[!! Import jobs list !!]",
-        "DOMAIN": "[!! Domain !!]",
-        "FILE": "[!! File !!]",
-        "STATUS": "[!! Status !!]",
-        "ROWS": "[!! Rows !!]",
-        "CREATED": "[!! Created !!]",
-        "ACTIONS": "[!! Actions !!]",
-        "VIEW": "[!! View !!]",
-        "OPEN_JOB": "[!! Open job !!]"
+        "CAPTION": "[!! ÏÏḿṕøøŕŧ ĵøøƀš ľïïšŧ !!]",
+        "DOMAIN": "[!! Đøøḿààïïñ !!]",
+        "FILE": "[!! Ƒïïľëë !!]",
+        "STATUS": "[!! Šŧààŧüüš !!]",
+        "ROWS": "[!! Ŕøøŵš !!]",
+        "CREATED": "[!! Çŕëëààŧëëđ !!]",
+        "ACTIONS": "[!! AAçŧïïøøñš !!]",
+        "VIEW": "[!! Ṽïïëëŵ !!]",
+        "OPEN_JOB": "[!! ØØṕëëñ ĵøøƀ !!]"
       }
     },
     "JOB_DETAIL": {
-      "TITLE": "[!! Job Details !!]",
-      "LOADING": "[!! Loading job details… !!]",
-      "BACK": "[!! Back to Jobs !!]",
-      "CANCEL": "[!! Cancel Job !!]",
-      "RETRY": "[!! Retry !!]",
-      "DOWNLOAD_ERRORS": "[!! Download Error Report !!]",
+      "TITLE": "[!! Ĵøøƀ Đëëŧààïïľš !!]",
+      "LOADING": "[!! Ŀøøààđïïñğ ĵøøƀ đëëŧààïïľš… !!]",
+      "BACK": "[!! Ɓààçķ ŧøø Ĵøøƀš !!]",
+      "CANCEL": "[!! Çààñçëëľ Ĵøøƀ !!]",
+      "RETRY": "[!! Ŕëëŧŕÿ !!]",
+      "DOWNLOAD_ERRORS": "[!! Đøøŵñľøøààđ ËËŕŕøøŕ Ŕëëṕøøŕŧ !!]",
       "ERROR": {
-        "LOAD": "[!! Unable to load job details. !!]",
-        "LOAD_AUDIT": "[!! Unable to load error records. !!]",
-        "CANCEL": "[!! Unable to cancel job. !!]",
-        "RETRY": "[!! Unable to retry job. !!]",
-        "CORRECTION": "[!! Failed to submit correction. Please try again. !!]"
+        "LOAD": "[!! ÜÜñààƀľëë ŧøø ľøøààđ ĵøøƀ đëëŧààïïľš. !!]",
+        "LOAD_AUDIT": "[!! ÜÜñààƀľëë ŧøø ľøøààđ ëëŕŕøøŕ ŕëëçøøŕđš. !!]",
+        "CANCEL": "[!! ÜÜñààƀľëë ŧøø çààñçëëľ ĵøøƀ. !!]",
+        "RETRY": "[!! ÜÜñààƀľëë ŧøø ŕëëŧŕÿ ĵøøƀ. !!]",
+        "CORRECTION": "[!! Ƒààïïľëëđ ŧøø šüüƀḿïïŧ çøøŕŕëëçŧïïøøñ. Ṕľëëààšëë ŧŕÿ ààğààïïñ. !!]"
       },
       "META": {
-        "ARIA_LABEL": "[!! Job metadata !!]",
-        "DOMAIN": "[!! Domain !!]",
-        "FILE": "[!! File !!]",
-        "STATUS": "[!! Status !!]",
-        "TOTAL_ROWS": "[!! Total Rows !!]",
-        "SUCCESS": "[!! Successful !!]",
-        "FAILURES": "[!! Failed Rows !!]"
+        "ARIA_LABEL": "[!! Ĵøøƀ ḿëëŧààđààŧàà !!]",
+        "DOMAIN": "[!! Đøøḿààïïñ !!]",
+        "FILE": "[!! Ƒïïľëë !!]",
+        "STATUS": "[!! Šŧààŧüüš !!]",
+        "TOTAL_ROWS": "[!! Ŧøøŧààľ Ŕøøŵš !!]",
+        "SUCCESS": "[!! Šüüççëëššƒüüľ !!]",
+        "FAILURES": "[!! Ƒààïïľëëđ Ŕøøŵš !!]"
       },
       "ERRORS": {
-        "ARIA_LABEL": "[!! Error records !!]",
-        "TITLE": "[!! Error Records !!]"
+        "ARIA_LABEL": "[!! ËËŕŕøøŕ ŕëëçøøŕđš !!]",
+        "TITLE": "[!! ËËŕŕøøŕ Ŕëëçøøŕđš !!]"
       }
     },
     "WIZARD": {
-      "LOADING": "[!! Loading… !!]",
-      "BACK": "[!! Back !!]",
+      "LOADING": "[!! Ŀøøààđïïñğ… !!]",
+      "BACK": "[!! Ɓààçķ !!]",
       "INVENTORY": {
-        "TITLE": "[!! Import Stock Inventory !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import stock inventory records. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Šŧøøçķ ÏÏñṽëëñŧøøŕÿ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ šŧøøçķ ïïñṽëëñŧøøŕÿ ŕëëçøøŕđš. !!]"
       },
       "LOCATION": {
-        "TITLE": "[!! Import Locations !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import location data. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ŀøøçààŧïïøøñš !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ľøøçààŧïïøøñ đààŧàà. !!]"
       },
       "CATALOG": {
-        "TITLE": "[!! Import Product Catalog !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import product catalog records. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ṕŕøøđüüçŧ Çààŧààľøøğ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ṕŕøøđüüçŧ çààŧààľøøğ ŕëëçøøŕđš. !!]"
       },
       "PRICE": {
-        "TITLE": "[!! Import Pricing !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import pricing data. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ṕŕïïçïïñğ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ṕŕïïçïïñğ đààŧàà. !!]"
       },
       "CUSTOMER": {
-        "TITLE": "[!! Import Customers !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import customer records. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Çüüšŧøøḿëëŕš !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ çüüšŧøøḿëëŕ ŕëëçøøŕđš. !!]"
       },
       "PEOPLE": {
-        "TITLE": "[!! Import People / HR !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import people and HR records. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ṕëëøøṕľëë / ĦŔ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ṕëëøøṕľëë ààñđ ĦŔ ŕëëçøøŕđš. !!]"
       },
       "VEHICLE_INVENTORY": {
-        "TITLE": "[!! Import Vehicle Inventory !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import vehicle inventory data. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ṽëëħïïçľëë ÏÏñṽëëñŧøøŕÿ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ṽëëħïïçľëë ïïñṽëëñŧøøŕÿ đààŧàà. !!]"
       },
       "VEHICLE_FITMENT": {
-        "TITLE": "[!! Import Vehicle Fitment !!]",
-        "SUBTITLE": "[!! Upload a CSV or XLSX file to bulk-import vehicle fitment data. !!]"
+        "TITLE": "[!! ÏÏḿṕøøŕŧ Ṽëëħïïçľëë Ƒïïŧḿëëñŧ !!]",
+        "SUBTITLE": "[!! ÜÜṕľøøààđ àà ÇŠṼ øøŕ ẌĿŠẌ ƒïïľëë ŧøø ƀüüľķ-ïïḿṕøøŕŧ ṽëëħïïçľëë ƒïïŧḿëëñŧ đààŧàà. !!]"
       },
       "ERROR": {
-        "LOAD": "[!! Unable to check active job status. !!]",
-        "UPLOAD": "[!! File upload failed. Please try again. !!]",
-        "CREATE_SESSION": "[!! Unable to start import session. !!]",
-        "LOAD_MAPPINGS": "[!! Unable to load column mappings. !!]",
-        "APPROVE_MAPPINGS": "[!! Unable to approve column mappings. !!]",
-        "RETRY": "[!! Unable to retry job. !!]",
-        "POLL": "[!! Failed to get import status. Please refresh. !!]"
+        "LOAD": "[!! ÜÜñààƀľëë ŧøø çħëëçķ ààçŧïïṽëë ĵøøƀ šŧààŧüüš. !!]",
+        "UPLOAD": "[!! Ƒïïľëë üüṕľøøààđ ƒààïïľëëđ. Ṕľëëààšëë ŧŕÿ ààğààïïñ. !!]",
+        "CREATE_SESSION": "[!! ÜÜñààƀľëë ŧøø šŧààŕŧ ïïḿṕøøŕŧ šëëššïïøøñ. !!]",
+        "LOAD_MAPPINGS": "[!! ÜÜñààƀľëë ŧøø ľøøààđ çøøľüüḿñ ḿààṕṕïïñğš. !!]",
+        "APPROVE_MAPPINGS": "[!! ÜÜñààƀľëë ŧøø ààṕṕŕøøṽëë çøøľüüḿñ ḿààṕṕïïñğš. !!]",
+        "RETRY": "[!! ÜÜñààƀľëë ŧøø ŕëëŧŕÿ ĵøøƀ. !!]",
+        "POLL": "[!! Ƒààïïľëëđ ŧøø ğëëŧ ïïḿṕøøŕŧ šŧààŧüüš. Ṕľëëààšëë ŕëëƒŕëëšħ. !!]"
       },
       "CONFLICT": {
-        "TITLE": "[!! Active Import in Progress !!]",
-        "MESSAGE": "[!! There is an active import job for another domain. Please wait for it to complete before starting a new import. !!]",
-        "VIEW_JOB": "[!! View Active Job !!]"
+        "TITLE": "[!! AAçŧïïṽëë ÏÏḿṕøøŕŧ ïïñ Ṕŕøøğŕëëšš !!]",
+        "MESSAGE": "[!! Ŧħëëŕëë ïïš ààñ ààçŧïïṽëë ïïḿṕøøŕŧ ĵøøƀ ƒøøŕ ààñøøŧħëëŕ đøøḿààïïñ. Ṕľëëààšëë ŵààïïŧ ƒøøŕ ïïŧ ŧøø çøøḿṕľëëŧëë ƀëëƒøøŕëë šŧààŕŧïïñğ àà ñëëŵ ïïḿṕøøŕŧ. !!]",
+        "VIEW_JOB": "[!! Ṽïïëëŵ AAçŧïïṽëë Ĵøøƀ !!]"
       },
       "STEP": {
         "UPLOAD": {
-          "ARIA_LABEL": "[!! Upload file step !!]",
-          "TITLE": "[!! Upload File !!]"
+          "ARIA_LABEL": "[!! ÜÜṕľøøààđ ƒïïľëë šŧëëṕ !!]",
+          "TITLE": "[!! ÜÜṕľøøààđ Ƒïïľëë !!]"
         },
         "UPLOADING": {
-          "ARIA_LABEL": "[!! File uploading !!]",
-          "TITLE": "[!! Uploading File !!]"
+          "ARIA_LABEL": "[!! Ƒïïľëë üüṕľøøààđïïñğ !!]",
+          "TITLE": "[!! ÜÜṕľøøààđïïñğ Ƒïïľëë !!]"
         },
         "MAPPING": {
-          "ARIA_LABEL": "[!! Column mapping review !!]",
-          "TITLE": "[!! Review Column Mappings !!]"
+          "ARIA_LABEL": "[!! Çøøľüüḿñ ḿààṕṕïïñğ ŕëëṽïïëëŵ !!]",
+          "TITLE": "[!! Ŕëëṽïïëëŵ Çøøľüüḿñ Ḿààṕṕïïñğš !!]"
         },
         "PROGRESS": {
-          "ARIA_LABEL": "[!! Import processing progress !!]",
-          "TITLE": "[!! Processing Import !!]",
-          "PROCESSED": "[!! Rows processed !!]",
-          "CANCEL": "[!! Cancel !!]"
+          "ARIA_LABEL": "[!! ÏÏḿṕøøŕŧ ṕŕøøçëëššïïñğ ṕŕøøğŕëëšš !!]",
+          "TITLE": "[!! Ṕŕøøçëëššïïñğ ÏÏḿṕøøŕŧ !!]",
+          "PROCESSED": "[!! Ŕøøŵš ṕŕøøçëëššëëđ !!]",
+          "CANCEL": "[!! Çààñçëëľ !!]"
         },
         "RESULTS": {
-          "ARIA_LABEL": "[!! Import results !!]"
+          "ARIA_LABEL": "[!! ÏÏḿṕøøŕŧ ŕëëšüüľŧš !!]"
         }
       }
     },
     "FILE_DROP": {
-      "ARIA_LABEL": "[!! File drop zone !!]",
-      "INSTRUCTION": "[!! Drag and drop a file here, or click to browse !!]",
-      "FORMATS": "[!! Accepted formats: .csv, .xlsx (max 100 MB) !!]",
-      "BROWSE_LABEL": "[!! Choose file !!]",
-      "BROWSE_BTN": "[!! Browse Files !!]",
-      "INPUT_ARIA": "[!! Select file to import !!]",
+      "ARIA_LABEL": "[!! Ƒïïľëë đŕøøṕ žøøñëë !!]",
+      "INSTRUCTION": "[!! Đŕààğ ààñđ đŕøøṕ àà ƒïïľëë ħëëŕëë, øøŕ çľïïçķ ŧøø ƀŕøøŵšëë !!]",
+      "FORMATS": "[!! AAççëëṕŧëëđ ƒøøŕḿààŧš: .çšṽ, .ẍľšẍ (ḿààẍ 100 ḾƁ) !!]",
+      "BROWSE_LABEL": "[!! Çħøøøøšëë ƒïïľëë !!]",
+      "BROWSE_BTN": "[!! Ɓŕøøŵšëë Ƒïïľëëš !!]",
+      "INPUT_ARIA": "[!! Šëëľëëçŧ ƒïïľëë ŧøø ïïḿṕøøŕŧ !!]",
       "ERROR": {
-        "INVALID_FORMAT": "[!! Invalid file format. Please upload a .csv or .xlsx file. !!]",
-        "TOO_LARGE": "[!! File is too large. Maximum allowed size is 100 MB. !!]"
+        "INVALID_FORMAT": "[!! ÏÏñṽààľïïđ ƒïïľëë ƒøøŕḿààŧ. Ṕľëëààšëë üüṕľøøààđ àà .çšṽ øøŕ .ẍľšẍ ƒïïľëë. !!]",
+        "TOO_LARGE": "[!! Ƒïïľëë ïïš ŧøøøø ľààŕğëë. Ḿààẍïïḿüüḿ ààľľøøŵëëđ šïïžëë ïïš 100 ḾƁ. !!]"
       }
     },
     "UPLOAD_PROGRESS": {
-      "ARIA_LABEL": "[!! Upload progress !!]",
-      "CANCEL": "[!! Cancel Upload !!]"
+      "ARIA_LABEL": "[!! ÜÜṕľøøààđ ṕŕøøğŕëëšš !!]",
+      "CANCEL": "[!! Çààñçëëľ ÜÜṕľøøààđ !!]"
     },
     "MAPPING": {
       "TABLE": {
-        "ARIA_LABEL": "[!! Column mapping table !!]",
-        "CAPTION": "[!! Column mappings from your file to system fields !!]"
+        "ARIA_LABEL": "[!! Çøøľüüḿñ ḿààṕṕïïñğ ŧààƀľëë !!]",
+        "CAPTION": "[!! Çøøľüüḿñ ḿààṕṕïïñğš ƒŕøøḿ ÿøøüüŕ ƒïïľëë ŧøø šÿšŧëëḿ ƒïïëëľđš !!]"
       },
       "COL": {
-        "SOURCE": "[!! Your Column !!]",
-        "TARGET": "[!! System Field !!]",
-        "CONFIDENCE": "[!! Match Confidence !!]"
+        "SOURCE": "[!! Ŷøøüüŕ Çøøľüüḿñ !!]",
+        "TARGET": "[!! Šÿšŧëëḿ Ƒïïëëľđ !!]",
+        "CONFIDENCE": "[!! Ḿààŧçħ Çøøñƒïïđëëñçëë !!]"
       },
-      "TARGET_LABEL_FOR": "[!! System field for column:  !!]",
+      "TARGET_LABEL_FOR": "[!! Šÿšŧëëḿ ƒïïëëľđ ƒøøŕ çøøľüüḿñ:  !!]",
       "TARGET_OPTION": {
-        "DO_NOT_IMPORT": "[!! Do Not Import !!]"
+        "DO_NOT_IMPORT": "[!! Đøø Ňøøŧ ÏÏḿṕøøŕŧ !!]"
       },
-      "APPROVE_BTN": "[!! Approve Mappings !!]",
+      "APPROVE_BTN": "[!! AAṕṕŕøøṽëë Ḿààṕṕïïñğš !!]",
       "CONFIDENCE": {
-        "HIGH": "[!! High !!]",
-        "MEDIUM": "[!! Medium !!]",
-        "LOW": "[!! Low !!]"
+        "HIGH": "[!! Ħïïğħ !!]",
+        "MEDIUM": "[!! Ḿëëđïïüüḿ !!]",
+        "LOW": "[!! Ŀøøŵ !!]"
       }
     },
     "LANDING": {
-      "ACTIVE_IMPORT": "[!! Active Import !!]"
+      "ACTIVE_IMPORT": "[!! AAçŧïïṽëë ÏÏḿṕøøŕŧ !!]"
     },
     "PROGRESS": {
       "STEPPER": {
-        "ARIA_LABEL": "[!! Import progress steps !!]"
+        "ARIA_LABEL": "[!! ÏÏḿṕøøŕŧ ṕŕøøğŕëëšš šŧëëṕš !!]"
       },
       "STEP": {
-        "UPLOAD": "[!! Upload !!]",
-        "DETECT": "[!! Detect !!]",
-        "MAPPING": "[!! Mapping !!]",
-        "DEDUP": "[!! Dedup !!]",
-        "PROCESS": "[!! Process !!]",
-        "DONE": "[!! Done !!]"
+        "UPLOAD": "[!! ÜÜṕľøøààđ !!]",
+        "DETECT": "[!! Đëëŧëëçŧ !!]",
+        "MAPPING": "[!! Ḿààṕṕïïñğ !!]",
+        "DEDUP": "[!! Đëëđüüṕ !!]",
+        "PROCESS": "[!! Ṕŕøøçëëšš !!]",
+        "DONE": "[!! Đøøñëë !!]"
       }
     },
     "RESULTS": {
-      "ARIA_LABEL": "[!! Import results summary !!]",
-      "TITLE": "[!! Import Complete !!]",
-      "TOTAL": "[!! Total Rows !!]",
-      "SUCCESS": "[!! Successful !!]",
-      "FAILURES": "[!! Failed !!]",
-      "DOWNLOAD_ERRORS": "[!! Download Error Report !!]",
-      "RETRY": "[!! Retry Failed Rows !!]"
+      "ARIA_LABEL": "[!! ÏÏḿṕøøŕŧ ŕëëšüüľŧš šüüḿḿààŕÿ !!]",
+      "TITLE": "[!! ÏÏḿṕøøŕŧ Çøøḿṕľëëŧëë !!]",
+      "TOTAL": "[!! Ŧøøŧààľ Ŕøøŵš !!]",
+      "SUCCESS": "[!! Šüüççëëššƒüüľ !!]",
+      "FAILURES": "[!! Ƒààïïľëëđ !!]",
+      "DOWNLOAD_ERRORS": "[!! Đøøŵñľøøààđ ËËŕŕøøŕ Ŕëëṕøøŕŧ !!]",
+      "RETRY": "[!! Ŕëëŧŕÿ Ƒààïïľëëđ Ŕøøŵš !!]"
     },
     "ERROR_RECORDS": {
-      "ARIA_LABEL": "[!! Error records !!]",
-      "EMPTY": "[!! No error records to display. !!]",
-      "SUBMIT": "[!! Submit Correction !!]",
-      "SUBMITTING": "[!! Saving… !!]",
+      "ARIA_LABEL": "[!! ËËŕŕøøŕ ŕëëçøøŕđš !!]",
+      "EMPTY": "[!! Ňøø ëëŕŕøøŕ ŕëëçøøŕđš ŧøø đïïšṕľààÿ. !!]",
+      "SUBMIT": "[!! Šüüƀḿïïŧ Çøøŕŕëëçŧïïøøñ !!]",
+      "SUBMITTING": "[!! Šààṽïïñğ… !!]",
       "TABLE": {
-        "CAPTION": "[!! Error records requiring review !!]"
+        "CAPTION": "[!! ËËŕŕøøŕ ŕëëçøøŕđš ŕëëqüüïïŕïïñğ ŕëëṽïïëëŵ !!]"
       },
       "COL": {
-        "ROW": "[!! Row !!]",
-        "REASONS": "[!! Reason(s) !!]",
-        "STATUS": "[!! Status !!]",
-        "CORRECTIONS": "[!! Corrections !!]",
-        "ACTIONS": "[!! Actions !!]"
+        "ROW": "[!! Ŕøøŵ !!]",
+        "REASONS": "[!! Ŕëëààšøøñ(š) !!]",
+        "STATUS": "[!! Šŧààŧüüš !!]",
+        "CORRECTIONS": "[!! Çøøŕŕëëçŧïïøøñš !!]",
+        "ACTIONS": "[!! AAçŧïïøøñš !!]"
       },
       "STATUS": {
-        "PENDING": "[!! Pending !!]",
-        "APPROVED": "[!! Approved !!]",
-        "REJECTED": "[!! Rejected !!]"
+        "PENDING": "[!! Ṕëëñđïïñğ !!]",
+        "APPROVED": "[!! AAṕṕŕøøṽëëđ !!]",
+        "REJECTED": "[!! Ŕëëĵëëçŧëëđ !!]"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Adds `InventoryRollupApiService`, a thin facade over the generated `@durion-sdk/inventory` `InventoryRollupService` client, normalizing query params and mapping transport errors to a discriminated `RollupError` union (`not-found | forbidden | validation | upstream-down | unknown`) so views never inspect HTTP details.
- Re-exports SDK payload types through `models/inventory-rollup.models.ts` so feature code never imports `@durion-sdk/inventory` directly; adds `SiteRollupOptions` / `LocationRollupOptions` view-side option types (spec §4.1 — hand-written payload parallels prohibited).
- Registers lazy `inventory/by-location` routes (overview, `:locationId`, `site/:siteId`) with placeholder pages; full screens land with stories F2/F3.
- Why: story F1 of CAP-218 (`domains/inventory/SPEC-inventory-location-rollup-frontend.md` §8) — unblocks parallel F2 (site tree) and F3 (location overview). Depends on F0 (SDK regen, done 2026-06-12; backend PRs #660/#661 merged).
- Guard note (spec open question 2): per module convention, no route-level role data is declared for read views; the backend enforces `inventory:on_hand:view` and a 403 maps to `kind: 'forbidden'`.

## Validation

- [x] `npm run build` (`ng build` green, 2026-06-12)
- [x] `ng test --no-watch --include src/app/features/inventory/services/inventory-rollup.service.spec.ts` — 10/10 pass (param pass-through, never sends `expand=tree`, error mapping for 404/403/400/422/503/network)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

N/A for this PR: only static placeholder pages (heading + paragraph, no interactive controls). Full a11y verification (treegrid keyboard nav, ARIA) lands with F2/F3.

## Notes / Follow-ups

- F2 (Site Inventory Tree) and F3 (Location Overview) are parallelizable on top of this branch — spec §8.
- Contract guide: `durion/domains/inventory/.business-rules/BACKEND_CONTRACT_GUIDE.md` (Story #658/#659 blocks); backend contract PRs: durion-positivity-backend#660, #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)