### PR TITLE
fix(people): align time-approval component with timekeeping API response shapes

### DIFF
--- a/src/app/features/people/pages/time-approval/time-approval-page.component.ts
+++ b/src/app/features/people/pages/time-approval/time-approval-page.component.ts
@@ -57,7 +57,7 @@ export class TimeApprovalPageComponent {
 
   readonly selectedPeriodStatus = computed<PeriodStatus | null>(() => {
     const periodId = this.selectionForm.getRawValue().timePeriodId;
-    const period = (this.periods() as Array<Record<string, unknown>>).find((p) => p['id'] === periodId);
+    const period = (this.periods() as Array<Record<string, unknown>>).find((p) => p['timePeriodId'] === periodId);
     return (period?.['status'] as PeriodStatus) ?? null;
   });
 
@@ -67,7 +67,7 @@ export class TimeApprovalPageComponent {
     if (this.detailLoading() || this.actionInFlight()) return false;
     if (this.entries().length === 0) return false;
     if (status === 'OPEN' || status === 'PAYROLL_CLOSED') return false;
-    const allPending = (this.entries() as Array<Record<string, unknown>>).every(e => e['status'] === 'PENDING_APPROVAL');
+    const allPending = (this.entries() as Array<Record<string, unknown>>).every(e => e['approvalStatus'] === 'PENDING_APPROVAL');
     return allPending;
   });
 
@@ -85,7 +85,7 @@ export class TimeApprovalPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (r) => {
-          this.people.set(Array.isArray(r['items']) ? r['items'] : []);
+          this.people.set(Array.isArray(r) ? r : []);
           this.peopleLoading.set(false);
         },
         error: () => {
@@ -101,7 +101,7 @@ export class TimeApprovalPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (r) => {
-          this.periods.set(Array.isArray(r['items']) ? r['items'] : []);
+          this.periods.set(Array.isArray(r) ? r : []);
           this.periodsLoading.set(false);
         },
         error: () => {
@@ -129,7 +129,7 @@ export class TimeApprovalPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (r) => {
-          this.entries.set(Array.isArray(r['items']) ? r['items'] : []);
+          this.entries.set(Array.isArray(r) ? r : []);
           this.detailLoading.set(false);
         },
         error: () => {
@@ -143,7 +143,7 @@ export class TimeApprovalPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (r) => {
-          this.approvalHistory.set(Array.isArray(r['items']) ? r['items'] : []);
+          this.approvalHistory.set(r ? [r] : []);
           this.historyLoading.set(false);
         },
         error: () => { this.historyLoading.set(false); },
@@ -190,8 +190,7 @@ export class TimeApprovalPageComponent {
     this.actionError.set(null);
     this.actionSuccess.set(null);
     const { comments } = this.rejectForm.getRawValue();
-    const body: Record<string, string> = {};
-    if (comments.trim()) body['comments'] = comments.trim();
+    const body: Record<string, string> = { reason: comments.trim() };
     this.peopleService.rejectTimePeriod(timePeriodId, personId, body)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/src/app/features/people/services/people.service.ts
+++ b/src/app/features/people/services/people.service.ts
@@ -27,7 +27,6 @@ export interface WorkSessionSubmitRequest {
 }
 
 type DisableEmployeeRequest = Parameters<EmployeeAPIService['disableEmployee']>[1];
-type TimekeepingCollectionResponse = Record<string, unknown>;
 
 @Injectable({ providedIn: 'root' })
 export class PeopleService {
@@ -100,23 +99,23 @@ export class PeopleService {
     return this.accessControlApi.revokeAssignment(personUuid, roleCode);
   }
 
-  listApprovalPeople(): Observable<TimekeepingCollectionResponse> {
-    return this.api.get<TimekeepingCollectionResponse>('/v1/people/timekeeping/approvals/people');
+  listApprovalPeople(): Observable<unknown[]> {
+    return this.api.get<unknown[]>('/v1/people/timekeeping/approvals/people');
   }
 
-  listTimePeriods(): Observable<TimekeepingCollectionResponse> {
-    return this.api.get<TimekeepingCollectionResponse>('/v1/people/timekeeping/time-periods');
+  listTimePeriods(): Observable<unknown[]> {
+    return this.api.get<unknown[]>('/v1/people/timekeeping/time-periods');
   }
 
-  listTimekeepingEntries(personId: string, timePeriodId: string): Observable<TimekeepingCollectionResponse> {
-    return this.api.get<TimekeepingCollectionResponse>(
+  listTimekeepingEntries(personId: string, timePeriodId: string): Observable<unknown[]> {
+    return this.api.get<unknown[]>(
       '/v1/people/timekeeping/timekeeping-entries',
       this.timekeepingParams(personId, timePeriodId),
     );
   }
 
-  listTimePeriodApprovals(personId: string, timePeriodId: string): Observable<TimekeepingCollectionResponse> {
-    return this.api.get<TimekeepingCollectionResponse>(
+  listTimePeriodApprovals(personId: string, timePeriodId: string): Observable<Record<string, unknown>> {
+    return this.api.get<Record<string, unknown>>(
       '/v1/people/timekeeping/time-period-approvals',
       this.timekeepingParams(personId, timePeriodId),
     );


### PR DESCRIPTION
## Summary

- Fix response unwrapping: API returns `ApprovalPersonDto[]`, `TimePeriodDto[]`, `TimekeepingEntryDto[]` as direct arrays — component was incorrectly reading `r['items']`
- Fix period approval response: `GET /time-period-approvals` returns a single `TimePeriodApprovalDto` object — wrapped as `[r]` in `approvalHistory` signal
- Fix field name mismatches: `p['id']` → `p['timePeriodId']`; `e['status']` → `e['approvalStatus']`
- Fix reject body: component was sending `{ comments }` but backend requires `{ reason }` (non-blank, validated)
- Update `PeopleService` return types: list methods now `Observable<unknown[]>`, approval summary `Observable<Record<string, unknown>>`

Fixes the "Failed to load employees" and "Failed to load time periods" errors on `/app/people/timekeeping/approval` introduced by durion-positivity-backend#664.

## Validation

- [ ] `npm run build`
- [ ] `npm run test` (or relevant targeted tests)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

## Notes / Follow-ups

- Backend implementation: louisburroughs/durion-positivity-backend#664