### PR TITLE
Make customer table header sticky with vertical scroll

### DIFF
--- a/src/app/features/crm/pages/customer-list/customer-list.component.css
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.css
@@ -9,10 +9,10 @@
 .hint-text { margin: 0; font-size: 0.87rem; color: color-mix(in srgb, var(--currentTextColor) 72%, transparent); }
 .hint-text--warn { color: var(--functional-error-red); }
 .hint-text--error { color: var(--functional-error-red); }
-.table-wrap { overflow-x: auto; border: 1px solid var(--input-border); border-radius: var(--radius-lg); background: var(--cardBackground); }
+.table-wrap { overflow: auto; max-height: 70vh; border: 1px solid var(--input-border); border-radius: var(--radius-lg); background: var(--cardBackground); }
 .party-table { width: 100%; border-collapse: collapse; }
 .party-table th, .party-table td { padding: var(--space-3) var(--space-4); border-bottom: 1px solid color-mix(in srgb, var(--input-border) 72%, transparent); text-align: left; vertical-align: top; }
-.party-table thead tr th { font-size: 0.8125rem; font-weight: 600; color: color-mix(in srgb, var(--currentTextColor) 72%, transparent); text-transform: uppercase; letter-spacing: 0.04em; }
+.party-table thead tr th { position: sticky; top: 0; z-index: 1; background: var(--cardBackground); box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--input-border) 72%, transparent); font-size: 0.8125rem; font-weight: 600; color: color-mix(in srgb, var(--currentTextColor) 72%, transparent); text-transform: uppercase; letter-spacing: 0.04em; }
 .party-table tbody tr:last-child td { border-bottom: none; }
 .sort-btn { display: inline-flex; align-items: center; gap: var(--space-1); background: transparent; border: none; padding: 0; font-size: 0.8125rem; font-weight: 600; font-family: var(--font-body); color: color-mix(in srgb, var(--currentTextColor) 72%, transparent); text-transform: uppercase; letter-spacing: 0.04em; cursor: pointer; }
 .sort-btn:hover { color: var(--currentTextColor); }


### PR DESCRIPTION
## Summary

- Changed `.table-wrap` overflow from `overflow-x: auto` to `overflow: auto` and added `max-height: 70vh` to enable vertical scrolling within a constrained viewport
- Made table headers sticky by adding `position: sticky; top: 0; z-index: 1` to `.party-table thead tr th`
- Added `background: var(--cardBackground)` and `box-shadow: inset 0 -1px 0 ...` to table headers to maintain visual separation when scrolling

These changes improve the UX of the customer list by keeping column headers visible while scrolling through large customer datasets.

## Validation

- [ ] `npm run build`
- [ ] `npm run test` (or relevant targeted tests)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on customer list page:
  - [ ] All interactive controls (sort buttons, etc.) reachable using `Tab`/`Shift+Tab`
  - [ ] Visible focus indicator present on focused controls
  - [ ] No keyboard traps encountered
  - [ ] Table scrolling works with keyboard navigation
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on customer list page:
  - [ ] Table structure and headers announced correctly
  - [ ] Sticky header behavior does not cause duplicate announcements when scrolling
  - [ ] Sort button functionality announced properly

## Notes / Follow-ups

- None

https://claude.ai/code/session_01XmkuCUvWsS6nceVmms1uVi