### PR TITLE
feat(crm): server-side paging for customer directory via infinite scroll

### DIFF
--- a/src/app/features/crm/pages/customer-list/customer-list.component.html
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.html
@@ -30,7 +30,8 @@
   </form>
 
   <!-- Results -->
-  <div id="search-results" aria-live="polite" aria-atomic="true">
+  <!-- aria-atomic=false: incremental page appends announce only added rows/status, not the whole table -->
+  <div id="search-results" aria-live="polite" aria-atomic="false">
 
     @if (state() === 'loading') {
       <p class="hint-text" aria-busy="true">Searching…</p>

--- a/src/app/features/crm/pages/customer-list/customer-list.component.html
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.html
@@ -102,6 +102,20 @@
           </tbody>
         </table>
       </div>
+
+      @if (hasMore()) {
+        <div #loadSentinel class="load-sentinel" aria-hidden="true"></div>
+      }
+
+      @if (loadingMore()) {
+        <p class="hint-text" aria-busy="true">Loading more…</p>
+      }
+
+      @if (totalCount()) {
+        <p class="hint-text result-count" aria-live="polite">
+          Showing {{ parties().length }} of {{ totalCount() }}
+        </p>
+      }
     }
   </div>
 

--- a/src/app/features/crm/pages/customer-list/customer-list.component.spec.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { of, throwError } from 'rxjs';
+import { of, throwError, Subject } from 'rxjs';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CustomerListComponent } from './customer-list.component';
 import { CrmService } from '../../services/crm.service';
@@ -10,13 +10,21 @@ const crmServiceStub = {
   searchParties: vi.fn(),
 };
 
+const party = (id: string) => ({ partyId: id, legalName: id });
+const partyPage = (parties: ReturnType<typeof party>[], totalCount: number) => ({
+  parties,
+  totalCount,
+  pageNumber: 0,
+  pageSize: 25,
+});
+
 describe('CustomerListComponent', () => {
   let fixture: ComponentFixture<CustomerListComponent>;
   let component: CustomerListComponent;
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    crmServiceStub.browseParties.mockReturnValue(of({ parties: [] }));
+    crmServiceStub.browseParties.mockReturnValue(of(partyPage([], 0)));
     crmServiceStub.searchParties.mockReturnValue(of({ parties: [] }));
 
     await TestBed.configureTestingModule({
@@ -67,5 +75,52 @@ describe('CustomerListComponent', () => {
 
     expect(component.state()).toBe('error');
     expect(component.error()).toBe('Search failed.');
+  });
+
+  it('accumulates browse pages across loadMore and stops at the last page', () => {
+    crmServiceStub.browseParties
+      .mockReturnValueOnce(of(partyPage([party('a'), party('b')], 3)))
+      .mockReturnValueOnce(of(partyPage([party('c')], 3)));
+
+    fixture.detectChanges(); // ngOnInit -> first browse page
+    expect(component.parties().length).toBe(2);
+    expect(component.totalCount()).toBe(3);
+    expect(component.hasMore()).toBe(true);
+
+    component.loadMore();
+    expect(component.parties().map(p => p.partyId)).toEqual(['a', 'b', 'c']);
+    expect(component.hasMore()).toBe(false);
+
+    crmServiceStub.browseParties.mockClear();
+    component.loadMore(); // no more pages -> guarded
+    expect(crmServiceStub.browseParties).not.toHaveBeenCalled();
+  });
+
+  it('does not load browse pages while in search mode', () => {
+    fixture.detectChanges();
+    component.search('acme'); // searching = true
+    crmServiceStub.browseParties.mockClear();
+
+    component.loadMore();
+
+    expect(crmServiceStub.browseParties).not.toHaveBeenCalled();
+  });
+
+  it('discards a browse page that resolves after a newer search', () => {
+    const pending = new Subject<unknown>();
+    crmServiceStub.browseParties.mockReturnValueOnce(pending.asObservable());
+
+    fixture.detectChanges(); // first browse page in flight (unresolved)
+
+    crmServiceStub.searchParties.mockReturnValueOnce(of({ parties: [party('search-hit')] }));
+    component.search('acme'); // new generation; search results applied
+
+    // stale browse page now resolves — must be ignored, not appended
+    pending.next(partyPage([party('stale')], 99));
+    pending.complete();
+
+    expect(component.parties().map(p => p.partyId)).toEqual(['search-hit']);
+    expect(component.totalCount()).toBe(0);
+    expect(component.state()).toBe('ready');
   });
 });

--- a/src/app/features/crm/pages/customer-list/customer-list.component.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.ts
@@ -35,6 +35,13 @@ export class CustomerListComponent implements OnInit, OnDestroy {
   private page = 0;
   /** True while showing search results, which are returned unpaged. */
   private searching = false;
+  /**
+   * Generation token. Incremented on every new search/browse reset so that a
+   * slow in-flight request that resolves after the user has moved on (e.g. a
+   * browse page landing after a search started) is discarded instead of
+   * corrupting the list.
+   */
+  private loadSeq = 0;
 
   /** More browse pages remain to load (not in search mode). */
   readonly hasMore = computed(() => !this.searching && this.parties().length < this.totalCount());
@@ -88,25 +95,31 @@ export class CustomerListComponent implements OnInit, OnDestroy {
 
   search(q: string): void {
     const query = q.trim();
+    const seq = ++this.loadSeq;
     this.state.set('loading');
     this.error.set(null);
     this.page = 0;
     this.parties.set([]);
     this.totalCount.set(0);
+    this.loadingMore.set(false);
 
     if (query) {
       // Search results are returned unpaged.
       this.searching = true;
-      this.crm.searchParties(query).subscribe({
+      this.crm.searchParties(query).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
         next: res => {
+          if (seq !== this.loadSeq) return;
           this.parties.set(res.parties ?? []);
           this.state.set(res.parties?.length ? 'ready' : 'empty');
         },
-        error: err => this.handleError(err),
+        error: err => {
+          if (seq !== this.loadSeq) return;
+          this.handleError(err);
+        },
       });
     } else {
       this.searching = false;
-      this.loadBrowsePage(true);
+      this.loadBrowsePage(true, seq);
     }
   }
 
@@ -116,27 +129,32 @@ export class CustomerListComponent implements OnInit, OnDestroy {
       return;
     }
     this.page += 1;
-    this.loadBrowsePage(false);
+    this.loadBrowsePage(false, this.loadSeq);
   }
 
-  private loadBrowsePage(first: boolean): void {
+  private loadBrowsePage(first: boolean, seq: number): void {
     if (first) {
       this.state.set('loading');
     } else {
       this.loadingMore.set(true);
     }
-    this.crm.browseParties(this.page, CustomerListComponent.PAGE_SIZE).subscribe({
-      next: res => {
-        this.parties.update(current => (first ? res.parties : [...current, ...res.parties]));
-        this.totalCount.set(res.totalCount);
-        this.loadingMore.set(false);
-        this.state.set(this.parties().length ? 'ready' : 'empty');
-      },
-      error: err => {
-        this.loadingMore.set(false);
-        this.handleError(err);
-      },
-    });
+    this.crm.browseParties(this.page, CustomerListComponent.PAGE_SIZE)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: res => {
+          // Discard a page that resolved after a newer search/browse reset.
+          if (seq !== this.loadSeq) return;
+          this.parties.update(current => (first ? res.parties : [...current, ...res.parties]));
+          this.totalCount.set(res.totalCount);
+          this.loadingMore.set(false);
+          this.state.set(this.parties().length ? 'ready' : 'empty');
+        },
+        error: err => {
+          if (seq !== this.loadSeq) return;
+          this.loadingMore.set(false);
+          this.handleError(err);
+        },
+      });
   }
 
   private handleError(err: { status?: number; error?: { message?: string } }): void {

--- a/src/app/features/crm/pages/customer-list/customer-list.component.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit, DestroyRef } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, OnDestroy, DestroyRef, ViewChild, ElementRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
@@ -18,15 +18,37 @@ type SortDir   = 'asc' | 'desc';
   templateUrl: './customer-list.component.html',
   styleUrl: './customer-list.component.css',
 })
-export class CustomerListComponent implements OnInit {
+export class CustomerListComponent implements OnInit, OnDestroy {
   private readonly crm       = inject(CrmService);
   private readonly router    = inject(Router);
   private readonly fb        = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
 
+  private static readonly PAGE_SIZE = 25;
+
   readonly state   = signal<PageState>('loading');
   readonly parties = signal<PartyDetail[]>([]);
   readonly error   = signal<string | null>(null);
+
+  readonly totalCount  = signal(0);
+  readonly loadingMore = signal(false);
+  private page = 0;
+  /** True while showing search results, which are returned unpaged. */
+  private searching = false;
+
+  /** More browse pages remain to load (not in search mode). */
+  readonly hasMore = computed(() => !this.searching && this.parties().length < this.totalCount());
+
+  private observer?: IntersectionObserver;
+
+  /** Sentinel at the bottom of the list; loads the next page when scrolled into view. */
+  @ViewChild('loadSentinel')
+  set loadSentinel(el: ElementRef<HTMLElement> | undefined) {
+    this.observer?.disconnect();
+    if (el?.nativeElement) {
+      this.observer?.observe(el.nativeElement);
+    }
+  }
 
   readonly sortField = signal<SortField>('name');
   readonly sortDir   = signal<SortDir>('asc');
@@ -45,6 +67,13 @@ export class CustomerListComponent implements OnInit {
   readonly searchForm = this.fb.nonNullable.group({ query: [''] });
 
   ngOnInit(): void {
+    if (typeof IntersectionObserver !== 'undefined') {
+      this.observer = new IntersectionObserver(entries => {
+        if (entries.some(e => e.isIntersecting)) {
+          this.loadMore();
+        }
+      });
+    }
     this.searchForm.controls.query.valueChanges.pipe(
       debounceTime(350),
       distinctUntilChanged(),
@@ -53,21 +82,66 @@ export class CustomerListComponent implements OnInit {
     this.search('');
   }
 
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+  }
+
   search(q: string): void {
     const query = q.trim();
-    const request$ = query ? this.crm.searchParties(query) : this.crm.browseParties();
     this.state.set('loading');
     this.error.set(null);
-    request$.subscribe({
+    this.page = 0;
+    this.parties.set([]);
+    this.totalCount.set(0);
+
+    if (query) {
+      // Search results are returned unpaged.
+      this.searching = true;
+      this.crm.searchParties(query).subscribe({
+        next: res => {
+          this.parties.set(res.parties ?? []);
+          this.state.set(res.parties?.length ? 'ready' : 'empty');
+        },
+        error: err => this.handleError(err),
+      });
+    } else {
+      this.searching = false;
+      this.loadBrowsePage(true);
+    }
+  }
+
+  /** Load the next browse page (invoked by the scroll sentinel). */
+  loadMore(): void {
+    if (this.searching || this.loadingMore() || !this.hasMore()) {
+      return;
+    }
+    this.page += 1;
+    this.loadBrowsePage(false);
+  }
+
+  private loadBrowsePage(first: boolean): void {
+    if (first) {
+      this.state.set('loading');
+    } else {
+      this.loadingMore.set(true);
+    }
+    this.crm.browseParties(this.page, CustomerListComponent.PAGE_SIZE).subscribe({
       next: res => {
-        this.parties.set(res.parties ?? []);
-        this.state.set(res.parties?.length ? 'ready' : 'empty');
+        this.parties.update(current => (first ? res.parties : [...current, ...res.parties]));
+        this.totalCount.set(res.totalCount);
+        this.loadingMore.set(false);
+        this.state.set(this.parties().length ? 'ready' : 'empty');
       },
       error: err => {
-        this.state.set(err?.status === 403 ? 'access-denied' : 'error');
-        this.error.set(err?.error?.message ?? 'Search failed.');
+        this.loadingMore.set(false);
+        this.handleError(err);
       },
     });
+  }
+
+  private handleError(err: { status?: number; error?: { message?: string } }): void {
+    this.state.set(err?.status === 403 ? 'access-denied' : 'error');
+    this.error.set(err?.error?.message ?? 'Search failed.');
   }
 
   sort(field: SortField): void {

--- a/src/app/features/crm/services/crm.service.spec.ts
+++ b/src/app/features/crm/services/crm.service.spec.ts
@@ -10,7 +10,7 @@ import {
   CRMSnapshotsService,
   CRMVehiclesService,
 } from '@durion-sdk/customer';
-import { CrmService } from './crm.service';
+import { CrmService, PartyPage } from './crm.service';
 import type { BillingRules, CrmSnapshot, PartyDetail } from '../models/crm.models';
 import type { Pageable } from '@durion-sdk/customer';
 
@@ -171,20 +171,25 @@ describe('CrmService', () => {
   });
 
   describe('browseParties()', () => {
-    it('calls crmAccounts.browseParties with default pageable and maps results into parties', () => {
+    it('requests the first page and maps results plus paging metadata', () => {
       crmAccountsStub.browseParties.mockReturnValueOnce(
         of({ results: [browseParty], totalCount: 1, pageNumber: 0, pageSize: 20 }),
       );
 
-      let result: { parties: PartyDetail[] } | undefined;
+      let result: PartyPage | undefined;
       service.browseParties().subscribe(value => {
         result = value;
       });
 
-      const expectedPageable: Pageable = {};
+      const expectedPageable: Pageable = { page: 0, size: 25 };
 
       expect(crmAccountsStub.browseParties).toHaveBeenCalledWith(expectedPageable);
-      expect(result).toEqual({ parties: [browseParty] });
+      expect(result).toEqual({
+        parties: [browseParty],
+        totalCount: 1,
+        pageNumber: 0,
+        pageSize: 20,
+      });
     });
   });
 

--- a/src/app/features/crm/services/crm.service.ts
+++ b/src/app/features/crm/services/crm.service.ts
@@ -45,6 +45,14 @@ import {
   VehicleRef,
 } from '../models/crm.models';
 
+/** One server-side page of the customer directory. */
+export interface PartyPage {
+  parties: PartyDetail[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize: number;
+}
+
 @Injectable({ providedIn: 'root' })
 export class CrmService {
   private readonly accountsApi = inject(CRMAccountsService);
@@ -91,11 +99,21 @@ export class CrmService {
     return this.accountsApi.getParty(partyId) as Observable<PartyDetail>;
   }
 
-  browseParties(): Observable<{ parties: PartyDetail[] }> {
-    const sdkPageable: SdkPageable = {};
+  /**
+   * Browse customers one server-side page at a time. The directory loads pages
+   * incrementally as the user scrolls (see CustomerListComponent), so paging metadata
+   * (totalCount, pageNumber, pageSize) is returned alongside the page contents.
+   */
+  browseParties(page = 0, size = 25): Observable<PartyPage> {
+    const sdkPageable: SdkPageable = { page, size };
 
     return this.accountsApi.browseParties(sdkPageable).pipe(
-      map(response => ({ parties: (response.results ?? []) as PartyDetail[] })),
+      map(response => ({
+        parties: (response.results ?? []) as PartyDetail[],
+        totalCount: response.totalCount ?? 0,
+        pageNumber: response.pageNumber ?? page,
+        pageSize: response.pageSize ?? size,
+      })),
     );
   }
 


### PR DESCRIPTION
## Summary

Implements real incremental server-side paging for the customer directory at `/app/crm/customers`, so the full directory is reachable by scrolling.

**Why:** The directory previously only rendered backend page 0 (customers A–D of 70) because the frontend sent an empty pageable and showed a single unpaged page. This change adds infinite-scroll paging backed by the existing backend `browseParties` pageable contract.

**What changed:**

- `crm.service.ts` — `CrmService.browseParties(page, size)` now returns a `PartyPage` interface (`parties` + `totalCount`, `pageNumber`, `pageSize`) instead of a single unpaged list.
- `customer-list.component.ts` — `CustomerListComponent` accumulates pages (`PAGE_SIZE = 25`) and loads the next page when an `IntersectionObserver` sentinel scrolls into view. Search results remain unpaged.
- `customer-list.component.html` — adds the scroll sentinel, a "Loading more…" indicator, and a "Showing X of Y" count.
- `crm.service.spec.ts` — specs updated for the paged `browseParties` contract.

**Domain:** crm

## Validation

- [ ] `npm run build`
- [x] `npm run test` (or relevant targeted tests)

Targeted tests run:

```
ng test --include="src/app/features/crm/services/crm.service.spec.ts" --include="src/app/features/crm/pages/customer-list/customer-list.component.spec.ts"
```

Result: 10/10 pass.

Risk level: low. Rollback: revert commit `173f7d4`; no backend/schema changes (backend `browseParties` pageable already supported).

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

## Notes / Follow-ups

- Known limitation: `sortedParties()` computed still sorts client-side over the accumulated/loaded rows only, not the full server set. Acceptable for now; a server-side global sort is a possible follow-up.
