### PR TITLE
fix(workexec): drop CustomerDTO.email refs after SDK update

### DIFF
--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
@@ -31,7 +31,7 @@
           [attr.aria-expanded]="showCustomerSuggestions() && customerSuggestions().length > 0"
           aria-autocomplete="list"
           aria-haspopup="listbox"
-          placeholder="Search by name or email…"
+          placeholder="Search by name or customer number…"
           aria-required="true"
         />
         @if (showCustomerSuggestions() && customerSuggestions().length > 0) {
@@ -39,8 +39,8 @@
             @for (c of customerSuggestions(); track c.id) {
               <li class="typeahead-item" role="option" (mousedown)="selectCustomer(c)">
                 <span class="suggestion-primary">{{ c.firstName }} {{ c.lastName }}</span>
-                @if (c.email) {
-                  <span class="suggestion-secondary">{{ c.email }}</span>
+                @if (c.customerNumber) {
+                  <span class="suggestion-secondary">{{ c.customerNumber }}</span>
                 }
               </li>
             }

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -43,8 +43,8 @@ export class EstimateCreatePageComponent implements OnInit {
     if (!q) return all.slice(0, MAX_SUGGESTIONS);
     return all.filter(c => {
       const name = `${c.firstName ?? ''} ${c.lastName ?? ''}`.toLowerCase();
-      const email = (c.email ?? '').toLowerCase();
-      return name.includes(q) || email.includes(q);
+      const customerNumber = (c.customerNumber ?? '').toLowerCase();
+      return name.includes(q) || customerNumber.includes(q);
     }).slice(0, MAX_SUGGESTIONS);
   });
 


### PR DESCRIPTION
## Summary
SDK update removed `email` from `CustomerDTO`, breaking the frontend build (`TS2339: Property 'email' does not exist on type 'CustomerDTO'`) in `EstimateCreatePageComponent`.

## Changes
- `estimate-create-page.component.ts` — typeahead filter matches `customerNumber` instead of `email`
- `estimate-create-page.component.html` — suggestion secondary line + placeholder use `customerNumber`

## Verification
`npm run build -- --configuration alpha` → `Application bundle generation complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)