### PR TITLE
fix(crm): render primary contact in customer directory

### DIFF
--- a/src/app/features/crm/models/crm.models.ts
+++ b/src/app/features/crm/models/crm.models.ts
@@ -185,10 +185,19 @@ export interface PartyDetail {
   taxId?: string;
   defaultBillingTermsId?: string;
   contacts?: Contact[];
+  /** Directory-row primary contact, supplied by browse/search responses. */
+  primaryContact?: PrimaryContact;
   vehicles?: VehicleRef[];
   mergedIntoPartyId?: string;
   readonly createdAt?: string;
   readonly createdBy?: string;
+}
+
+/** Lightweight primary-contact projection returned with party summaries. */
+export interface PrimaryContact {
+  name?: string;
+  email?: string;
+  phone?: string;
 }
 
 export interface CrmSnapshot {

--- a/src/app/features/crm/pages/customer-list/customer-list.component.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { CrmService } from '../../services/crm.service';
-import { Contact, PartyDetail } from '../../models/crm.models';
+import { PartyDetail, PrimaryContact } from '../../models/crm.models';
 
 type PageState = 'loading' | 'empty' | 'ready' | 'error' | 'access-denied';
 type SortField = 'name' | 'vehicles';
@@ -171,8 +171,8 @@ export class CustomerListComponent implements OnInit, OnDestroy {
     }
   }
 
-  primaryContact(party: PartyDetail): Contact | undefined {
-    return party.contacts?.find(c => c.roles.includes('PRIMARY')) ?? party.contacts?.[0];
+  primaryContact(party: PartyDetail): PrimaryContact | undefined {
+    return party.primaryContact?.name ? party.primaryContact : undefined;
   }
 
   openParty(partyId: string): void {


### PR DESCRIPTION
## Summary
The customer directory (`/app/crm/customers`) showed no primary contact. After server-side paging (#33), the browse/search endpoints return `PartySummary` without a `contacts` array, so `primaryContact()` always resolved to nothing.

## Changes
- `crm.models.ts` — add `PrimaryContact` interface and `PartyDetail.primaryContact`.
- `customer-list.component.ts` — `primaryContact()` reads `party.primaryContact` instead of the absent `contacts` array.
- Template unchanged (already renders `contact.name` / `contact.email`).

## Depends on
Backend PR louisburroughs/durion-positivity-backend#689, which adds `primaryContact` to the party summary payload.

## Verification
`npm run build -- --configuration alpha` → `Application bundle generation complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)