### PR TITLE
fix(location): unwrap Spring page content in bays + mobile-unit lists

### DIFF
--- a/src/app/features/location/services/location.service.spec.ts
+++ b/src/app/features/location/services/location.service.spec.ts
@@ -81,6 +81,38 @@ describe('LocationService', () => {
     });
   });
 
+  it('unwraps the Spring page content array from listBays', () => {
+    const bay = { id: 'bay-1', name: 'Bay 01' };
+    bayApiStub.listBays.mockReturnValueOnce(of({ content: [bay], totalElements: 1 }));
+
+    let result: unknown[] | undefined;
+    service.listBays('loc-01').subscribe(r => (result = r));
+
+    expect(result).toEqual([bay]);
+  });
+
+  it('unwraps the Spring page content array from listMobileUnits', () => {
+    const unit = { id: 'mu-1', name: 'Truck 1' };
+    mobileUnitApiStub.listMobileUnits.mockReturnValueOnce(of({ content: [unit], totalElements: 1 }));
+
+    let result: unknown[] | undefined;
+    service.listMobileUnits().subscribe(r => (result = r));
+
+    expect(result).toEqual([unit]);
+  });
+
+  it('returns a bare array unchanged and empty for a missing page body', () => {
+    bayApiStub.listBays.mockReturnValueOnce(of([{ id: 'bay-1' }]));
+    let asArray: unknown[] | undefined;
+    service.listBays('loc-01').subscribe(r => (asArray = r));
+    expect(asArray).toEqual([{ id: 'bay-1' }]);
+
+    mobileUnitApiStub.listMobileUnits.mockReturnValueOnce(of({}));
+    let asEmpty: unknown[] | undefined;
+    service.listMobileUnits().subscribe(r => (asEmpty = r));
+    expect(asEmpty).toEqual([]);
+  });
+
   it('maps mobile-unit coverageRules through the typed request mapper', () => {
     mobileUnitApiStub.createMobileUnit.mockReturnValueOnce(of({ mobileUnitId: 'mu-001' }));
 

--- a/src/app/features/location/services/location.service.ts
+++ b/src/app/features/location/services/location.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import {
   BayAPIService,
   LocationAPIService,
@@ -69,7 +69,7 @@ export class LocationService {
   // ── Bays ─────────────────────────────────────────────────────────────────
 
   listBays(locationId: string): Observable<unknown[]> {
-    return this.bayApi.listBays(locationId) as Observable<unknown[]>;
+    return (this.bayApi.listBays(locationId) as Observable<unknown>).pipe(map(toContentArray));
   }
 
   createBay(locationId: string, body: Record<string, unknown>, idempotencyKey?: string): Observable<unknown> {
@@ -90,7 +90,7 @@ export class LocationService {
   listMobileUnits(params?: Record<string, string>): Observable<unknown[]> {
     const page = params?.['page'] ? Number(params['page']) : undefined;
     const size = params?.['size'] ? Number(params['size']) : undefined;
-    return this.mobileUnitApi.listMobileUnits(page, size) as Observable<unknown[]>;
+    return (this.mobileUnitApi.listMobileUnits(page, size) as Observable<unknown>).pipe(map(toContentArray));
   }
 
   createMobileUnit(body: Record<string, unknown>, idempotencyKey?: string): Observable<unknown> {
@@ -228,4 +228,17 @@ export class LocationService {
   private isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
   }
+}
+
+/**
+ * Unwraps a list response into a plain array. Backend list endpoints return a
+ * Spring Data page (`{ content: [...] }`); some return `{ items: [...] }` or a
+ * bare array. Normalizes all three so callers always receive an array.
+ */
+function toContentArray(response: unknown): unknown[] {
+  if (Array.isArray(response)) {
+    return response;
+  }
+  const page = response as { content?: unknown[]; items?: unknown[] } | null;
+  return page?.content ?? page?.items ?? [];
 }


### PR DESCRIPTION
## Summary

The **bays** and **mobile-units** location pages rendered "No bays/units found" even when the backend had data.

**Root cause:** the location list endpoints return a Spring Data page (`{ "content": [...], "totalElements": n }`), but `LocationService.listBays` / `listMobileUnits` cast the response directly to `Observable<unknown[]>` without unwrapping. The component then called `bays.set(pageObject)` and the template iterated a non-array → nothing shown. (Mobile-units additionally looked for `.items`, which the backend never sends.) Storage locations were unaffected — that page normalizes via its own helper.

Diagnosed live on alpha: `GET /api/location/v1/locations/01960003-0000-7000-8000-000000000001/bays` returns **8 bays** inside a `content` page, but the UI showed none.

## Fix

- Add `toContentArray()` normalizer (handles `content`, legacy `items`, and bare arrays).
- Pipe `listBays` and `listMobileUnits` through it so callers always receive an array.

## Validation

- [x] `npm run build` — PASS (only pre-existing inventory CSS-budget warning)
- [x] `npm run test` — location service + page specs pass (added 3 service specs covering the page-unwrap paths)

## Notes

- Pre-existing bug, not introduced by #38. Bays 01–04 date from April; the page has been broken since the SDK list responses became paginated.
- Backend seed (8 bays for CLT-MAIN, plus SOUTH/NORTH bays/mobile-units/storage) is already live on alpha; this unblocks the UI from displaying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
