### PR TITLE
fix(location): source storage-locations page from the location service

### DIFF
--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
@@ -97,9 +97,7 @@
           data-testid="create-storage-type-select">
           <option value="">Select a storage type</option>
           @for (type of storageTypes(); track $index) {
-          <option [value]="$any(type).value ?? $any(type).storageType ?? $any(type).code">
-            {{ $any(type).label ?? $any(type).name ?? $any(type).value }}
-          </option>
+          <option [value]="$any(type).value">{{ $any(type).label }}</option>
           }
         </select>
         <span id="field-error-storage-type" role="alert" aria-live="polite" data-testid="field-error-storage-type">

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
@@ -44,8 +44,8 @@
       <thead>
         <tr>
           <th>Name</th>
-          <th>Code</th>
           <th>Type</th>
+          <th>Barcode</th>
           <th>Status</th>
           <th>Actions</th>
         </tr>
@@ -54,8 +54,8 @@
         @for (loc of storageLocations(); track $index) {
         <tr [attr.data-testid]="'storage-location-row-' + $index">
           <td>{{ $any(loc).name }}</td>
-          <td>{{ $any(loc).code }}</td>
-          <td>{{ $any(loc).storageType }}</td>
+          <td>{{ $any(loc).type }}</td>
+          <td>{{ $any(loc).barcode }}</td>
           <td>{{ $any(loc).status }}</td>
           <td>
             @if ($any(loc).status === 'ACTIVE') {
@@ -81,17 +81,6 @@
     <h2>New Storage Location</h2>
     <form class="form-grid" [formGroup]="createForm" (ngSubmit)="createStorageLocation()">
       <div class="field">
-        <label for="create-code">Code (required)</label>
-        <input id="create-code" type="text" formControlName="code" aria-describedby="field-error-code"
-          data-testid="create-code-input" />
-        <span id="field-error-code" role="alert" aria-live="polite" data-testid="field-error-code">
-          @if (createForm.controls.code.touched && createForm.controls.code.invalid) {
-          Code is required.
-          }
-        </span>
-      </div>
-
-      <div class="field">
         <label for="create-name">Name (required)</label>
         <input id="create-name" type="text" formControlName="name" aria-describedby="field-error-name"
           data-testid="create-name-input" />
@@ -108,8 +97,8 @@
           data-testid="create-storage-type-select">
           <option value="">Select a storage type</option>
           @for (type of storageTypes(); track $index) {
-          <option [value]="$any(type).storageType ?? $any(type).code ?? $any(type).name">
-            {{ $any(type).name ?? $any(type).storageType ?? $any(type).code }}
+          <option [value]="$any(type).value ?? $any(type).storageType ?? $any(type).code">
+            {{ $any(type).label ?? $any(type).name ?? $any(type).value }}
           </option>
           }
         </select>

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -240,12 +240,19 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
 
   it('should set requiresDestination when DESTINATION_REQUIRED error returned', async () => {
     await setup();
+    // Location service surfaces an RFC 9457 ProblemDetail (422, marker in `detail`),
+    // not the legacy inventory `{ status: 409, error: { code } }` envelope.
     locationServiceStub.deactivateStorageLocation.mockReturnValue(
       throwError(
         () =>
           new HttpErrorResponse({
-            status: 409,
-            error: { code: 'DESTINATION_REQUIRED', message: 'Destination required.' },
+            status: 422,
+            error: {
+              type: 'about:blank',
+              title: 'Unprocessable Content',
+              status: 422,
+              detail: 'DESTINATION_REQUIRED',
+            },
           }),
       ),
     );

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -5,32 +5,33 @@ import { By } from '@angular/platform-browser';
 import { HttpErrorResponse } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { StorageLocationsPageComponent } from './storage-locations-page.component';
-import { InventoryService } from '../../services/inventory.service';
 import { LocationService } from '../../services/location.service';
 
-const STORAGE_LOCATIONS = [
-  { storageLocationId: 'SL-1', name: 'Staging Area', code: 'STG', storageType: 'STAGING', status: 'ACTIVE' },
-  { storageLocationId: 'SL-2', name: 'Quarantine Bay', code: 'QRN', storageType: 'QUARANTINE', status: 'ACTIVE' },
-];
+// Location-service storage model: Spring page wrapper, `type`/`barcode`, no `code`.
+const STORAGE_PAGE = {
+  content: [
+    { id: 'SL-1', name: 'Staging Area', type: 'FLOOR', barcode: 'BC-1', status: 'ACTIVE' },
+    { id: 'SL-2', name: 'Quarantine Bay', type: 'CAGE', barcode: 'BC-2', status: 'ACTIVE' },
+  ],
+  totalElements: 2,
+};
 
-const STORAGE_TYPES = [
-  { storageType: 'STAGING', name: 'Staging' },
-  { storageType: 'QUARANTINE', name: 'Quarantine' },
-];
-
-const stubInventoryService = {
+const locationServiceStub = {
+  getAllLocations: vi.fn(),
   listStorageLocations: vi.fn(),
-  listStorageTypes: vi.fn(),
   createStorageLocation: vi.fn(),
   deactivateStorageLocation: vi.fn(),
 };
 
-const locationServiceStub = {
-  getAllLocations: vi.fn().mockReturnValue(of([
+function resetLocationStub() {
+  locationServiceStub.getAllLocations.mockReturnValue(of([
     { id: 'loc-1', name: 'Depot' },
     { id: 'LOC-001', name: 'Main Warehouse' },
-  ])),
-};
+  ]));
+  locationServiceStub.listStorageLocations.mockReturnValue(of({ content: [{ id: 's-1' }], totalElements: 1 }));
+  locationServiceStub.createStorageLocation.mockReturnValue(of({ id: 'SL-NEW' }));
+  locationServiceStub.deactivateStorageLocation.mockReturnValue(of({}));
+}
 
 describe('StorageLocationsPageComponent', () => {
   let fixture: ComponentFixture<StorageLocationsPageComponent>;
@@ -38,18 +39,12 @@ describe('StorageLocationsPageComponent', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    locationServiceStub.getAllLocations.mockReturnValue(of([
-      { id: 'loc-1', name: 'Depot' },
-      { id: 'LOC-001', name: 'Main Warehouse' },
-    ]));
-    stubInventoryService.listStorageLocations.mockReturnValue(of({ items: [{ id: 's-1' }] }));
-    stubInventoryService.listStorageTypes.mockReturnValue(of({ items: [] }));
+    resetLocationStub();
 
     await TestBed.configureTestingModule({
       imports: [StorageLocationsPageComponent, TranslateModule.forRoot()],
       providers: [
         provideRouter([]),
-        { provide: InventoryService, useValue: stubInventoryService },
         { provide: LocationService, useValue: locationServiceStub },
       ],
     }).compileComponents();
@@ -61,18 +56,29 @@ describe('StorageLocationsPageComponent', () => {
 
   it('does not load storage locations before a location is selected', () => {
     expect(component.locationId()).toBe('');
-    expect(stubInventoryService.listStorageLocations).not.toHaveBeenCalled();
+    expect(locationServiceStub.listStorageLocations).not.toHaveBeenCalled();
   });
 
   it('loads and writes the query param on selection', () => {
     const navSpy = vi.spyOn(TestBed.inject(Router), 'navigate');
     component.onLocationSelected('loc-1');
     expect(component.locationId()).toBe('loc-1');
-    expect(stubInventoryService.listStorageLocations).toHaveBeenCalledWith('loc-1', { pageSize: 50 });
+    expect(locationServiceStub.listStorageLocations).toHaveBeenCalledWith('loc-1', { pageSize: 50 });
     expect(navSpy).toHaveBeenCalledWith([], expect.objectContaining({
       queryParams: { locationId: 'loc-1' },
       queryParamsHandling: 'merge',
     }));
+  });
+
+  it('populates storage types from the client-side enum constant', () => {
+    component.onLocationSelected('loc-1');
+    expect(component.storageTypes()).toEqual([
+      { value: 'FLOOR', label: 'Floor' },
+      { value: 'SHELF', label: 'Shelf' },
+      { value: 'BIN', label: 'Bin' },
+      { value: 'CAGE', label: 'Cage' },
+      { value: 'TRUCK', label: 'Truck' },
+    ]);
   });
 
   it('resets on invalid id', () => {
@@ -87,12 +93,12 @@ describe('StorageLocationsPageComponent', () => {
 
   it('fetches storage locations exactly once on selection', () => {
     component.onLocationSelected('loc-1');
-    expect(stubInventoryService.listStorageLocations).toHaveBeenCalledTimes(1);
+    expect(locationServiceStub.listStorageLocations).toHaveBeenCalledTimes(1);
   });
 
   it('resets to the prompt state when the picker selection is cleared', () => {
     component.onLocationSelected('loc-1');
-    stubInventoryService.listStorageLocations.mockClear();
+    locationServiceStub.listStorageLocations.mockClear();
 
     component.onLocationSelected('');
 
@@ -100,7 +106,7 @@ describe('StorageLocationsPageComponent', () => {
     expect(component.locationId()).toBe('');
     expect(component.invalidId()).toBe(false);
     expect(component.createForm.controls.locationId.value).toBe('');
-    expect(stubInventoryService.listStorageLocations).not.toHaveBeenCalledWith('', expect.anything());
+    expect(locationServiceStub.listStorageLocations).not.toHaveBeenCalledWith('', expect.anything());
   });
 });
 
@@ -108,22 +114,15 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
   let fixture: ComponentFixture<StorageLocationsPageComponent>;
   let component: StorageLocationsPageComponent;
 
-  const setup = async () => {
+  const setup = async (listResponse: unknown = STORAGE_PAGE) => {
     vi.clearAllMocks();
-    locationServiceStub.getAllLocations.mockReturnValue(of([
-      { id: 'loc-1', name: 'Depot' },
-      { id: 'LOC-001', name: 'Main Warehouse' },
-    ]));
-    stubInventoryService.listStorageLocations.mockReturnValue(of(STORAGE_LOCATIONS));
-    stubInventoryService.listStorageTypes.mockReturnValue(of(STORAGE_TYPES));
-    stubInventoryService.createStorageLocation.mockReturnValue(of({ storageLocationId: 'SL-NEW' }));
-    stubInventoryService.deactivateStorageLocation.mockReturnValue(of({}));
+    resetLocationStub();
+    locationServiceStub.listStorageLocations.mockReturnValue(of(listResponse));
 
     await TestBed.configureTestingModule({
       imports: [StorageLocationsPageComponent, TranslateModule.forRoot()],
       providers: [
         provideRouter([]),
-        { provide: InventoryService, useValue: stubInventoryService },
         { provide: LocationService, useValue: locationServiceStub },
         {
           provide: ActivatedRoute,
@@ -147,44 +146,19 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
     expect(component).toBeTruthy();
   });
 
-  it('should render storage locations table with loaded data', async () => {
+  it('should render storage locations table from the page content wrapper', async () => {
     await setup();
     const table = fixture.debugElement.query(By.css('[data-testid="storage-locations-table"]'));
     expect(table).toBeTruthy();
     const rows = fixture.debugElement.queryAll(By.css('[data-testid^="storage-location-row-"]'));
     expect(rows.length).toBe(2);
     expect(rows[0].nativeElement.textContent).toContain('Staging Area');
+    expect(rows[0].nativeElement.textContent).toContain('FLOOR');
     expect(rows[1].nativeElement.textContent).toContain('Quarantine Bay');
   });
 
   it('should show empty state when no storage locations', async () => {
-    vi.clearAllMocks();
-    locationServiceStub.getAllLocations.mockReturnValue(of([
-      { id: 'loc-1', name: 'Depot' },
-      { id: 'LOC-001', name: 'Main Warehouse' },
-    ]));
-    stubInventoryService.listStorageLocations.mockReturnValue(of([]));
-    stubInventoryService.listStorageTypes.mockReturnValue(of(STORAGE_TYPES));
-    stubInventoryService.createStorageLocation.mockReturnValue(of({}));
-    stubInventoryService.deactivateStorageLocation.mockReturnValue(of({}));
-
-    await TestBed.configureTestingModule({
-      imports: [StorageLocationsPageComponent, TranslateModule.forRoot()],
-      providers: [
-        provideRouter([]),
-        { provide: InventoryService, useValue: stubInventoryService },
-        { provide: LocationService, useValue: locationServiceStub },
-        {
-          provide: ActivatedRoute,
-          useValue: { queryParams: of({ locationId: 'LOC-001' }) },
-        },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(StorageLocationsPageComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-
+    await setup({ content: [], totalElements: 0 });
     const emptyState = fixture.debugElement.query(By.css('[data-testid="empty-state"]'));
     expect(emptyState).toBeTruthy();
     expect(emptyState.nativeElement.textContent).toContain('No storage locations found.');
@@ -212,15 +186,16 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
     expect(section).toBeNull();
   });
 
-  it('should call createStorageLocation on form submit and show success', async () => {
+  it('maps the form to the location storage request (siteId + type, no code) and shows success', async () => {
     await setup();
     component.openCreateForm();
-    component.createForm.patchValue({ code: 'STG-1', name: 'Staging 1', storageType: 'STAGING' });
+    component.createForm.patchValue({ name: 'Staging 1', storageType: 'BIN', barcode: 'BC-9' });
     fixture.detectChanges();
     component.createStorageLocation();
     fixture.detectChanges();
-    expect(stubInventoryService.createStorageLocation).toHaveBeenCalledWith(
-      expect.objectContaining({ code: 'STG-1', name: 'Staging 1', storageType: 'STAGING' }),
+    expect(locationServiceStub.createStorageLocation).toHaveBeenCalledWith(
+      'LOC-001',
+      expect.objectContaining({ name: 'Staging 1', type: 'BIN', barcode: 'BC-9' }),
       expect.any(String),
     );
     expect(component.createSuccess()).toBe(true);
@@ -237,9 +212,23 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
     expect(dialog).toBeTruthy();
   });
 
+  it('deactivates via the location service with the site id', async () => {
+    await setup();
+    component.openDeactivateDialog({ id: 'SL-1', name: 'Staging Area', status: 'ACTIVE' });
+    fixture.detectChanges();
+    component.confirmDeactivate();
+    fixture.detectChanges();
+    expect(locationServiceStub.deactivateStorageLocation).toHaveBeenCalledWith(
+      'LOC-001',
+      'SL-1',
+      expect.any(Object),
+      expect.any(String),
+    );
+  });
+
   it('should cancel deactivate dialog', async () => {
     await setup();
-    component.openDeactivateDialog({ storageLocationId: 'SL-1', name: 'Staging Area', status: 'ACTIVE' });
+    component.openDeactivateDialog({ id: 'SL-1', name: 'Staging Area', status: 'ACTIVE' });
     fixture.detectChanges();
     expect(component.showDeactivateDialog()).toBe(true);
     component.cancelDeactivate();
@@ -251,7 +240,7 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
 
   it('should set requiresDestination when DESTINATION_REQUIRED error returned', async () => {
     await setup();
-    stubInventoryService.deactivateStorageLocation.mockReturnValue(
+    locationServiceStub.deactivateStorageLocation.mockReturnValue(
       throwError(
         () =>
           new HttpErrorResponse({
@@ -260,7 +249,7 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
           }),
       ),
     );
-    component.openDeactivateDialog({ storageLocationId: 'SL-1', name: 'Staging Area', status: 'ACTIVE' });
+    component.openDeactivateDialog({ id: 'SL-1', name: 'Staging Area', status: 'ACTIVE' });
     fixture.detectChanges();
     component.confirmDeactivate();
     fixture.detectChanges();

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
@@ -10,7 +10,7 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { v4 as uuidv4 } from 'uuid';
-import { InventoryService } from '../../services/inventory.service';
+import { LocationService, STORAGE_LOCATION_TYPES } from '../../services/location.service';
 import { LocationPickerComponent } from '../../components/location-picker/location-picker.component';
 
 @Component({
@@ -24,7 +24,7 @@ import { LocationPickerComponent } from '../../components/location-picker/locati
 export class StorageLocationsPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
-  private readonly inventoryService = inject(InventoryService);
+  private readonly locationService = inject(LocationService);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly locationId = signal('');
@@ -47,7 +47,6 @@ export class StorageLocationsPageComponent {
 
   readonly createForm = new FormGroup({
     locationId: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
-    code: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     name: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     storageType: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     parentStorageLocationId: new FormControl('', { nonNullable: true }),
@@ -113,7 +112,7 @@ export class StorageLocationsPageComponent {
     this.loading.set(true);
     this.storageLocationsError.set(null);
 
-    this.inventoryService.listStorageLocations(locationId, { pageSize: 50 })
+    this.locationService.listStorageLocations(locationId, { pageSize: 50 })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
@@ -128,17 +127,10 @@ export class StorageLocationsPageComponent {
   }
 
   loadStorageTypes(): void {
+    // The location service has no storage-types meta endpoint; the StorageLocationType
+    // enum is fixed, so the options are sourced from a client-side constant.
     this.storageTypesError.set(null);
-    this.inventoryService.listStorageTypes()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (response) => {
-          this.storageTypes.set(this.normalizeItems(response));
-        },
-        error: (err: unknown) => {
-          this.storageTypesError.set(this.errorMessage(err, 'Failed to load storage types.'));
-        },
-      });
+    this.storageTypes.set([...STORAGE_LOCATION_TYPES]);
   }
 
   openCreateForm(): void {
@@ -147,7 +139,6 @@ export class StorageLocationsPageComponent {
     this.createError.set(null);
     this.createForm.reset({
       locationId: this.locationId(),
-      code: '',
       name: '',
       storageType: '',
       parentStorageLocationId: '',
@@ -170,9 +161,15 @@ export class StorageLocationsPageComponent {
     this.createError.set(null);
     this.createSuccess.set(false);
 
-    const body = this.createForm.getRawValue();
+    const form = this.createForm.getRawValue();
+    const body = {
+      name: form.name,
+      type: form.storageType,
+      barcode: form.barcode,
+      parentStorageLocationId: form.parentStorageLocationId,
+    };
 
-    this.inventoryService.createStorageLocation(body, uuidv4())
+    this.locationService.createStorageLocation(this.locationId(), body, uuidv4())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
@@ -226,7 +223,7 @@ export class StorageLocationsPageComponent {
         : {}),
     };
 
-    this.inventoryService.deactivateStorageLocation(id, body, uuidv4())
+    this.locationService.deactivateStorageLocation(this.locationId(), id, body, uuidv4())
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: () => {
@@ -253,8 +250,8 @@ export class StorageLocationsPageComponent {
       return response;
     }
     const payload = this.toRecord(response);
-    const items = payload?.['items'];
-    return Array.isArray(items) ? items : [];
+    const content = payload?.['content'] ?? payload?.['items'];
+    return Array.isArray(content) ? content : [];
   }
 
   private isDestinationRequiredError(err: unknown): boolean {

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
@@ -255,23 +255,22 @@ export class StorageLocationsPageComponent {
   }
 
   private isDestinationRequiredError(err: unknown): boolean {
-    const code = this.toCode(err);
-    return code === 'DESTINATION_REQUIRED';
+    // The location service returns an RFC 9457 ProblemDetail
+    // ({ status: 422, detail: 'DESTINATION_REQUIRED' }); the marker is in
+    // `detail`. Legacy `code`/`errorCode` are also checked for safety.
+    const payload = this.toRecord(this.toRecord(err)?.['error']);
+    const marker = payload?.['detail'] ?? payload?.['code'] ?? payload?.['errorCode'];
+    return typeof marker === 'string' && marker.includes('DESTINATION_REQUIRED');
   }
 
   private errorMessage(err: unknown, fallback: string): string {
+    // ProblemDetail carries the message in `detail`; fall back to legacy `message`.
     const payload = this.toRecord(this.toRecord(err)?.['error']);
-    const message = payload?.['message'];
+    const message = payload?.['detail'] ?? payload?.['message'];
     return typeof message === 'string' && message.trim().length > 0 ? message : fallback;
   }
 
   private toRecord(value: unknown): Record<string, unknown> | null {
     return value !== null && typeof value === 'object' ? value as Record<string, unknown> : null;
-  }
-
-  private toCode(err: unknown): string | null {
-    const payload = this.toRecord(this.toRecord(err)?.['error']);
-    const code = payload?.['code'] ?? payload?.['errorCode'];
-    return typeof code === 'string' ? code : null;
   }
 }

--- a/src/app/features/location/services/location.service.ts
+++ b/src/app/features/location/services/location.service.ts
@@ -77,6 +77,10 @@ export class LocationService {
     return this.storageLocationApi.list2(siteId, pageable, undefined, status) as Observable<unknown>;
   }
 
+  // NOTE: idempotencyKey is accepted for parity with the other write methods on
+  // this service, but the location SDK's create2/patch2 expose no Idempotency-Key
+  // header hook, so it is not yet forwarded. Threading it via an HttpContext
+  // interceptor is a separate follow-up.
   createStorageLocation(
     siteId: string,
     body: Record<string, unknown>,

--- a/src/app/features/location/services/location.service.ts
+++ b/src/app/features/location/services/location.service.ts
@@ -15,7 +15,22 @@ import type {
   BayPatchRequest,
   MobileUnitRequest,
   SiteDefaultsRequest,
+  StorageLocationRequest,
+  StorageLocationPatchRequest,
 } from '@durion-sdk/location';
+
+/**
+ * Storage location types exposed by the location service
+ * (StorageLocationType enum). The location service has no meta endpoint, so the
+ * stable enum set is provided client-side for the create form.
+ */
+export const STORAGE_LOCATION_TYPES: ReadonlyArray<{ value: string; label: string }> = [
+  { value: 'FLOOR', label: 'Floor' },
+  { value: 'SHELF', label: 'Shelf' },
+  { value: 'BIN', label: 'Bin' },
+  { value: 'CAGE', label: 'Cage' },
+  { value: 'TRUCK', label: 'Truck' },
+];
 
 @Injectable({ providedIn: 'root' })
 export class LocationService {
@@ -60,6 +75,37 @@ export class LocationService {
     const pageable = { page: params?.pageIndex, size: params?.pageSize };
     const status = params?.status as 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'QUARANTINED' | undefined;
     return this.storageLocationApi.list2(siteId, pageable, undefined, status) as Observable<unknown>;
+  }
+
+  createStorageLocation(
+    siteId: string,
+    body: Record<string, unknown>,
+    idempotencyKey?: string,
+  ): Observable<unknown> {
+    const request: StorageLocationRequest = {
+      name: this.asOptionalString(body['name']),
+      type: this.asOptionalString(body['type']) as StorageLocationRequest['type'],
+      barcode: this.asOptionalString(body['barcode']),
+      parentStorageLocationId: this.asOptionalString(body['parentStorageLocationId']),
+    };
+    return this.storageLocationApi.create2(siteId, request) as Observable<unknown>;
+  }
+
+  /**
+   * Deactivates a storage location by patching its status to INACTIVE. An
+   * optional destination is forwarded for the relocate-on-deactivate flow.
+   */
+  deactivateStorageLocation(
+    siteId: string,
+    storageLocationId: string,
+    body: Record<string, unknown>,
+    idempotencyKey?: string,
+  ): Observable<unknown> {
+    const patch: StorageLocationPatchRequest = {
+      status: 'INACTIVE' as StorageLocationPatchRequest['status'],
+      destinationStorageLocationId: this.asOptionalString(body['destinationStorageLocationId']),
+    };
+    return this.storageLocationApi.patch2(siteId, storageLocationId, patch) as Observable<unknown>;
   }
 
   configureLocationDefaults(locationId: string, body: unknown, idempotencyKey?: string): Observable<unknown> {


### PR DESCRIPTION
## Summary

The storage-locations page rendered nothing because it called **inventory-service** endpoints that 404 on the gateway:
- `GET /api/v1/inventory/storage-locations` → 404
- `GET /api/v1/inventory/meta/storage-types` → 404

Storage locations are owned by the **location** service. This re-wires the page to it (decision from triage), pairing with backend fix #692 (which resolved the location storage finder 500).

## Changes

- **Service swap**: `InventoryService` → `LocationService` for list (`list2`), create (`create2`), and deactivate (`patch2`, status→`INACTIVE`).
- **Model adaptation**: the location storage model has no `code`. Dropped the `code` form field + table column; table now shows **Name / Type / Barcode / Status / Actions**; the form's `storageType` maps to the request `type`.
- **Storage types**: location service has no meta endpoint, so the fixed `StorageLocationType` set (FLOOR/SHELF/BIN/CAGE/TRUCK) is provided via a new client-side constant `STORAGE_LOCATION_TYPES`.
- **Page wrapper fix**: `normalizeItems` now reads the Spring page `content` (kept `items`/array fallback).
- **Spec rewrite**: storage page spec now uses `LocationService` + the location model; asserts the request mapping (siteId + `type`, no `code`), content-wrapper rendering, and deactivate-by-site.

## Validation

- [x] `npm run build` — PASS (only pre-existing inventory CSS-budget warning)
- [x] Location suite — **132/132 pass** (storage page + service specs included)

## Notes

- Depends on backend #692 (merged) being deployed for live data.
- Touches `location.service.ts` import block + storage section; PR #40 also edits that file (bays/mobile-unit unwrap) — trivial merge order, no logical overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
