### PR TITLE
feat(location): add pagination controls to storage-locations page

### DIFF
--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
@@ -73,6 +73,20 @@
         }
       </tbody>
     </table>
+
+    @if (totalPages() > 1) {
+    <nav class="pagination" aria-label="Storage locations pagination" data-testid="storage-pagination">
+      <button type="button" (click)="prevPage()" [disabled]="!canPrevPage()" data-testid="page-prev">
+        Previous
+      </button>
+      <span aria-live="polite" data-testid="page-status">
+        Page {{ pageIndex() + 1 }} of {{ totalPages() }} ({{ totalElements() }} total)
+      </span>
+      <button type="button" (click)="nextPage()" [disabled]="!canNextPage()" data-testid="page-next">
+        Next
+      </button>
+    </nav>
+    }
   </section>
   }
 

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -63,7 +63,7 @@ describe('StorageLocationsPageComponent', () => {
     const navSpy = vi.spyOn(TestBed.inject(Router), 'navigate');
     component.onLocationSelected('loc-1');
     expect(component.locationId()).toBe('loc-1');
-    expect(locationServiceStub.listStorageLocations).toHaveBeenCalledWith('loc-1', { pageSize: 50 });
+    expect(locationServiceStub.listStorageLocations).toHaveBeenCalledWith('loc-1', { pageIndex: 0, pageSize: 20 });
     expect(navSpy).toHaveBeenCalledWith([], expect.objectContaining({
       queryParams: { locationId: 'loc-1' },
       queryParamsHandling: 'merge',
@@ -263,5 +263,40 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
     expect(component.requiresDestination()).toBe(true);
     const input = fixture.debugElement.query(By.css('[data-testid="destination-input"]'));
     expect(input).toBeTruthy();
+  });
+
+  it('hides pagination when there is a single page', async () => {
+    await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], totalPages: 1, totalElements: 1 });
+    expect(fixture.debugElement.query(By.css('[data-testid="storage-pagination"]'))).toBeNull();
+  });
+
+  it('renders pagination and reflects page metadata for a multi-page result', async () => {
+    await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], number: 0, totalPages: 3, totalElements: 45 });
+    expect(component.totalPages()).toBe(3);
+    expect(component.canPrevPage()).toBe(false);
+    expect(component.canNextPage()).toBe(true);
+    const status = fixture.debugElement.query(By.css('[data-testid="page-status"]'));
+    expect(status.nativeElement.textContent).toContain('Page 1 of 3');
+    expect(status.nativeElement.textContent).toContain('45 total');
+  });
+
+  it('advances to the next page and requests it from the service', async () => {
+    await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], number: 0, totalPages: 3, totalElements: 45 });
+    locationServiceStub.listStorageLocations.mockClear();
+
+    component.nextPage();
+
+    expect(component.pageIndex()).toBe(1);
+    expect(locationServiceStub.listStorageLocations).toHaveBeenCalledWith('LOC-001', { pageIndex: 1, pageSize: 20 });
+  });
+
+  it('does not page before the first page', async () => {
+    await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], number: 0, totalPages: 3, totalElements: 45 });
+    locationServiceStub.listStorageLocations.mockClear();
+
+    component.prevPage();
+
+    expect(component.pageIndex()).toBe(0);
+    expect(locationServiceStub.listStorageLocations).not.toHaveBeenCalled();
   });
 });

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -290,6 +290,24 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
     expect(locationServiceStub.listStorageLocations).toHaveBeenCalledWith('LOC-001', { pageIndex: 1, pageSize: 20 });
   });
 
+  it('clamps to the last valid page when the current page falls out of range', async () => {
+    // Land on page 2 (index 2) of a 3-page result.
+    await setup({ content: [{ id: 'SL-9', name: 'Z', type: 'BIN', status: 'ACTIVE' }], number: 2, totalPages: 3, totalElements: 41 });
+    component.goToPage(2);
+    expect(component.pageIndex()).toBe(2);
+
+    // Next reload (e.g. after deactivating the last row) returns fewer pages.
+    locationServiceStub.listStorageLocations.mockClear();
+    locationServiceStub.listStorageLocations
+      .mockReturnValueOnce(of({ content: [], number: 2, totalPages: 2, totalElements: 40 }))
+      .mockReturnValueOnce(of({ content: [{ id: 'SL-8' }], number: 1, totalPages: 2, totalElements: 40 }));
+
+    component.loadStorageLocations();
+
+    expect(component.pageIndex()).toBe(1);
+    expect(locationServiceStub.listStorageLocations).toHaveBeenLastCalledWith('LOC-001', { pageIndex: 1, pageSize: 20 });
+  });
+
   it('does not page before the first page', async () => {
     await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], number: 0, totalPages: 3, totalElements: 45 });
     locationServiceStub.listStorageLocations.mockClear();

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
@@ -168,8 +168,16 @@ export class StorageLocationsPageComponent {
     const page = this.toRecord(response);
     const totalPages = Number(page?.['totalPages']);
     const totalElements = Number(page?.['totalElements']);
-    this.totalPages.set(Number.isFinite(totalPages) ? totalPages : 0);
+    const pages = Number.isFinite(totalPages) ? totalPages : 0;
+    this.totalPages.set(pages);
     this.totalElements.set(Number.isFinite(totalElements) ? totalElements : 0);
+
+    // If the current page fell out of range (e.g. deactivating the last row of
+    // the last page), clamp to the last valid page and reload once.
+    if (pages > 0 && this.pageIndex() >= pages) {
+      this.pageIndex.set(pages - 1);
+      this.loadStorageLocations();
+    }
   }
 
   loadStorageTypes(): void {

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  computed,
   inject,
   signal,
 } from '@angular/core';
@@ -27,11 +28,18 @@ export class StorageLocationsPageComponent {
   private readonly locationService = inject(LocationService);
   private readonly destroyRef = inject(DestroyRef);
 
+  private static readonly PAGE_SIZE = 20;
+
   readonly locationId = signal('');
   readonly invalidId = signal(false);
   readonly storageLocations = signal<unknown[]>([]);
   readonly storageTypes = signal<unknown[]>([]);
   readonly loading = signal(false);
+  readonly pageIndex = signal(0);
+  readonly totalPages = signal(0);
+  readonly totalElements = signal(0);
+  readonly canPrevPage = computed(() => this.pageIndex() > 0);
+  readonly canNextPage = computed(() => this.pageIndex() + 1 < this.totalPages());
   readonly storageLocationsError = signal<string | null>(null);
   readonly storageTypesError = signal<string | null>(null);
   readonly showCreateForm = signal(false);
@@ -67,6 +75,7 @@ export class StorageLocationsPageComponent {
           this.storageLocations.set([]);
           return;
         }
+        this.pageIndex.set(0);
         this.loadStorageLocations();
         this.loadStorageTypes();
       });
@@ -82,6 +91,7 @@ export class StorageLocationsPageComponent {
     this.locationId.set(locationId);
     this.createForm.controls.locationId.setValue(locationId);
     this.router.navigate([], { queryParams: { locationId }, queryParamsHandling: 'merge' });
+    this.pageIndex.set(0);
     this.loadStorageLocations();
     this.loadStorageTypes();
   }
@@ -95,6 +105,9 @@ export class StorageLocationsPageComponent {
     this.locationId.set('');
     this.storageLocations.set([]);
     this.storageTypes.set([]);
+    this.pageIndex.set(0);
+    this.totalPages.set(0);
+    this.totalElements.set(0);
     this.createSuccess.set(false);
     this.showCreateForm.set(false);
     this.storageLocationsError.set(null);
@@ -112,11 +125,16 @@ export class StorageLocationsPageComponent {
     this.loading.set(true);
     this.storageLocationsError.set(null);
 
-    this.locationService.listStorageLocations(locationId, { pageSize: 50 })
+    this.locationService
+      .listStorageLocations(locationId, {
+        pageIndex: this.pageIndex(),
+        pageSize: StorageLocationsPageComponent.PAGE_SIZE,
+      })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
           this.storageLocations.set(this.normalizeItems(response));
+          this.applyPageMeta(response);
           this.loading.set(false);
         },
         error: (err: unknown) => {
@@ -124,6 +142,34 @@ export class StorageLocationsPageComponent {
           this.loading.set(false);
         },
       });
+  }
+
+  goToPage(index: number): void {
+    if (index < 0 || index === this.pageIndex() || (this.totalPages() > 0 && index >= this.totalPages())) {
+      return;
+    }
+    this.pageIndex.set(index);
+    this.loadStorageLocations();
+  }
+
+  prevPage(): void {
+    if (this.canPrevPage()) {
+      this.goToPage(this.pageIndex() - 1);
+    }
+  }
+
+  nextPage(): void {
+    if (this.canNextPage()) {
+      this.goToPage(this.pageIndex() + 1);
+    }
+  }
+
+  private applyPageMeta(response: unknown): void {
+    const page = this.toRecord(response);
+    const totalPages = Number(page?.['totalPages']);
+    const totalElements = Number(page?.['totalElements']);
+    this.totalPages.set(Number.isFinite(totalPages) ? totalPages : 0);
+    this.totalElements.set(Number.isFinite(totalElements) ? totalElements : 0);
   }
 
   loadStorageTypes(): void {


### PR DESCRIPTION
## Summary

Adds pagination to the storage-locations page. Storage sites can hold more rows than one page (CLT-MAIN has ~60), and the prior fixed `pageSize: 50` silently hid the tail (e.g. the tire racks).

## Changes

- **Previous / Next controls** + a `Page X of Y (N total)` status, driven by the Spring page metadata (`totalPages` / `totalElements`) captured from the list response.
- `pageSize` 20; `pageIndex` resets to 0 on location change/clear.
- `canPrevPage` / `canNextPage` computed signals gate the buttons; the nav is hidden when there is a single page.
- `aria-label` on the nav + `aria-live="polite"` on the status for screen-reader updates.

## Validation

- [x] `npm run build` — PASS (only pre-existing inventory CSS-budget warning)
- [x] Storage page spec — **20 pass** (added: load args, single-page hidden, multi-page metadata render, next-page service request, no-page-before-first)

## Notes

- Pagination copy uses plain text to match the page's existing table headers / action labels (a broader i18n sweep of this page is out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
