### PR TITLE
feat(location): per-bin inventory count + expandable contents on storage page

### DIFF
--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
@@ -52,7 +52,7 @@
         </tr>
       </thead>
       <tbody>
-        @for (loc of storageLocations(); track $index) {
+        @for (loc of storageLocations(); track $any(loc).id ?? $index) {
         <tr [attr.data-testid]="'storage-location-row-' + $index">
           <td>{{ $any(loc).name }}</td>
           <td>{{ $any(loc).type }}</td>
@@ -62,6 +62,7 @@
             @if (inventoryCount($any(loc).id) > 0) {
             <button type="button" class="inventory-toggle"
               [attr.aria-expanded]="isExpanded($any(loc).id)"
+              [attr.aria-label]="(isExpanded($any(loc).id) ? 'Hide contents, ' : 'Show contents, ') + inventoryCount($any(loc).id) + ' on hand'"
               (click)="toggleExpand($any(loc).id)"
               [attr.data-testid]="'inventory-toggle-' + $index">
               {{ inventoryCount($any(loc).id) }} {{ isExpanded($any(loc).id) ? '▾' : '▸' }}

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.html
@@ -47,6 +47,7 @@
           <th>Type</th>
           <th>Barcode</th>
           <th>Status</th>
+          <th>Inventory</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -58,6 +59,18 @@
           <td>{{ $any(loc).barcode }}</td>
           <td>{{ $any(loc).status }}</td>
           <td>
+            @if (inventoryCount($any(loc).id) > 0) {
+            <button type="button" class="inventory-toggle"
+              [attr.aria-expanded]="isExpanded($any(loc).id)"
+              (click)="toggleExpand($any(loc).id)"
+              [attr.data-testid]="'inventory-toggle-' + $index">
+              {{ inventoryCount($any(loc).id) }} {{ isExpanded($any(loc).id) ? '▾' : '▸' }}
+            </button>
+            } @else {
+            <span data-testid="inventory-empty">0</span>
+            }
+          </td>
+          <td>
             @if ($any(loc).status === 'ACTIVE') {
             <button type="button" (click)="openDeactivateDialog(loc)" [attr.data-testid]="'deactivate-btn-' + $index">
               Deactivate
@@ -65,10 +78,29 @@
             }
           </td>
         </tr>
+        @if (isExpanded($any(loc).id)) {
+        <tr [attr.data-testid]="'inventory-contents-' + $index">
+          <td colspan="6">
+            <table class="inventory-contents">
+              <thead>
+                <tr><th>SKU</th><th>On hand</th></tr>
+              </thead>
+              <tbody>
+                @for (item of inventoryItems($any(loc).id); track item.stockItemId) {
+                <tr>
+                  <td>{{ item.stockItemId }}</td>
+                  <td>{{ item.onHandQuantity }}</td>
+                </tr>
+                }
+              </tbody>
+            </table>
+          </td>
+        </tr>
+        }
         }
         @empty {
         <tr>
-          <td colspan="5" data-testid="empty-state">No storage locations found.</td>
+          <td colspan="6" data-testid="empty-state">No storage locations found.</td>
         </tr>
         }
       </tbody>

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -366,4 +366,30 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
 
     expect(component.inventoryCount('SL-1')).toBe(0);
   });
+
+  it('clears inventory + expand state when the location is cleared', async () => {
+    await setup();
+    inventoryServiceStub.listLocationInventoryItems.mockImplementation((id: string) =>
+      of(id === 'SL-1' ? { items: [{ stockItemId: 'MICH-1', onHandQuantity: 9 }] } : { items: [] }));
+    component.loadStorageLocations();
+    component.toggleExpand('SL-1');
+    expect(component.inventoryByLocation()['SL-1']?.count).toBe(9);
+    expect(component.isExpanded('SL-1')).toBe(true);
+
+    component.onLocationSelected('');
+
+    expect(component.inventoryByLocation()).toEqual({});
+    expect(component.isExpanded('SL-1')).toBe(false);
+  });
+
+  it('re-fetches inventory for the new page on page change', async () => {
+    await setup({ content: [{ id: 'SL-1', name: 'A', type: 'BIN', status: 'ACTIVE' }], number: 0, totalPages: 3, totalElements: 45 });
+    locationServiceStub.listStorageLocations.mockReturnValue(
+      of({ content: [{ id: 'SL-9', name: 'Z', type: 'BIN', status: 'ACTIVE' }], number: 1, totalPages: 3, totalElements: 45 }));
+    inventoryServiceStub.listLocationInventoryItems.mockClear();
+
+    component.nextPage();
+
+    expect(inventoryServiceStub.listLocationInventoryItems).toHaveBeenCalledWith('SL-9');
+  });
 });

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.spec.ts
@@ -6,6 +6,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { TranslateModule } from '@ngx-translate/core';
 import { StorageLocationsPageComponent } from './storage-locations-page.component';
 import { LocationService } from '../../services/location.service';
+import { InventoryService } from '../../services/inventory.service';
 
 // Location-service storage model: Spring page wrapper, `type`/`barcode`, no `code`.
 const STORAGE_PAGE = {
@@ -23,6 +24,10 @@ const locationServiceStub = {
   deactivateStorageLocation: vi.fn(),
 };
 
+const inventoryServiceStub = {
+  listLocationInventoryItems: vi.fn(),
+};
+
 function resetLocationStub() {
   locationServiceStub.getAllLocations.mockReturnValue(of([
     { id: 'loc-1', name: 'Depot' },
@@ -31,6 +36,8 @@ function resetLocationStub() {
   locationServiceStub.listStorageLocations.mockReturnValue(of({ content: [{ id: 's-1' }], totalElements: 1 }));
   locationServiceStub.createStorageLocation.mockReturnValue(of({ id: 'SL-NEW' }));
   locationServiceStub.deactivateStorageLocation.mockReturnValue(of({}));
+  // default: empty inventory for any location
+  inventoryServiceStub.listLocationInventoryItems.mockReturnValue(of({ items: [] }));
 }
 
 describe('StorageLocationsPageComponent', () => {
@@ -46,6 +53,7 @@ describe('StorageLocationsPageComponent', () => {
       providers: [
         provideRouter([]),
         { provide: LocationService, useValue: locationServiceStub },
+        { provide: InventoryService, useValue: inventoryServiceStub },
       ],
     }).compileComponents();
 
@@ -124,6 +132,7 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
       providers: [
         provideRouter([]),
         { provide: LocationService, useValue: locationServiceStub },
+        { provide: InventoryService, useValue: inventoryServiceStub },
         {
           provide: ActivatedRoute,
           useValue: { queryParams: of({ locationId: 'LOC-001' }) },
@@ -316,5 +325,45 @@ describe('StorageLocationsPageComponent [CAP-214 #103] (location selected)', () 
 
     expect(component.pageIndex()).toBe(0);
     expect(locationServiceStub.listStorageLocations).not.toHaveBeenCalled();
+  });
+
+  it('shows the inventory count (sum of on-hand) per location from the items call', async () => {
+    await setup();
+    inventoryServiceStub.listLocationInventoryItems.mockImplementation((id: string) =>
+      of(id === 'SL-1'
+        ? { items: [{ stockItemId: 'MICH-1', onHandQuantity: 10 }, { stockItemId: 'MICH-2', onHandQuantity: 5 }] }
+        : { items: [] }));
+    component.loadStorageLocations();
+    fixture.detectChanges();
+
+    expect(component.inventoryCount('SL-1')).toBe(15);
+    const toggle = fixture.debugElement.query(By.css('[data-testid="inventory-toggle-0"]'));
+    expect(toggle.nativeElement.textContent).toContain('15');
+  });
+
+  it('expands to show location contents (sku + qty) on toggle', async () => {
+    await setup();
+    inventoryServiceStub.listLocationInventoryItems.mockImplementation((id: string) =>
+      of(id === 'SL-1' ? { items: [{ stockItemId: 'MICH-XC2-0001', onHandQuantity: 24 }] } : { items: [] }));
+    component.loadStorageLocations();
+    fixture.detectChanges();
+
+    expect(fixture.debugElement.query(By.css('[data-testid="inventory-contents-0"]'))).toBeNull();
+    component.toggleExpand('SL-1');
+    fixture.detectChanges();
+
+    const contents = fixture.debugElement.query(By.css('[data-testid="inventory-contents-0"]'));
+    expect(contents).toBeTruthy();
+    expect(contents.nativeElement.textContent).toContain('MICH-XC2-0001');
+    expect(contents.nativeElement.textContent).toContain('24');
+  });
+
+  it('falls back to count 0 when the inventory call fails', async () => {
+    await setup();
+    inventoryServiceStub.listLocationInventoryItems.mockReturnValue(throwError(() => new Error('boom')));
+    component.loadStorageLocations();
+    fixture.detectChanges();
+
+    expect(component.inventoryCount('SL-1')).toBe(0);
   });
 });

--- a/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
+++ b/src/app/features/location/pages/storage-locations/storage-locations-page.component.ts
@@ -10,9 +10,17 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { forkJoin, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 import { LocationService, STORAGE_LOCATION_TYPES } from '../../services/location.service';
+import { InventoryService } from '../../services/inventory.service';
 import { LocationPickerComponent } from '../../components/location-picker/location-picker.component';
+
+interface LocationInventory {
+  count: number;
+  items: { stockItemId: string; onHandQuantity: number }[];
+}
 
 @Component({
   selector: 'app-storage-locations-page',
@@ -26,6 +34,7 @@ export class StorageLocationsPageComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly locationService = inject(LocationService);
+  private readonly inventoryService = inject(InventoryService);
   private readonly destroyRef = inject(DestroyRef);
 
   private static readonly PAGE_SIZE = 20;
@@ -42,6 +51,8 @@ export class StorageLocationsPageComponent {
   readonly canNextPage = computed(() => this.pageIndex() + 1 < this.totalPages());
   readonly storageLocationsError = signal<string | null>(null);
   readonly storageTypesError = signal<string | null>(null);
+  readonly inventoryByLocation = signal<Record<string, LocationInventory>>({});
+  readonly expandedLocations = signal<Set<string>>(new Set());
   readonly showCreateForm = signal(false);
   readonly creating = signal(false);
   readonly createError = signal<string | null>(null);
@@ -105,6 +116,8 @@ export class StorageLocationsPageComponent {
     this.locationId.set('');
     this.storageLocations.set([]);
     this.storageTypes.set([]);
+    this.inventoryByLocation.set({});
+    this.expandedLocations.set(new Set());
     this.pageIndex.set(0);
     this.totalPages.set(0);
     this.totalElements.set(0);
@@ -133,15 +146,85 @@ export class StorageLocationsPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (response) => {
-          this.storageLocations.set(this.normalizeItems(response));
+          const rows = this.normalizeItems(response);
+          this.storageLocations.set(rows);
           this.applyPageMeta(response);
           this.loading.set(false);
+          this.loadInventory(rows);
         },
         error: (err: unknown) => {
           this.storageLocationsError.set(this.errorMessage(err, 'Failed to load storage locations.'));
           this.loading.set(false);
         },
       });
+  }
+
+  /**
+   * Fetches on-hand contents for each storage location on the current page in
+   * parallel, so the row count and the expandable contents are ready together.
+   */
+  private loadInventory(rows: unknown[]): void {
+    this.inventoryByLocation.set({});
+    this.expandedLocations.set(new Set());
+    const ids = rows
+      .map(r => String(this.toRecord(r)?.['id'] ?? ''))
+      .filter(id => id.length > 0);
+    if (ids.length === 0) {
+      return;
+    }
+
+    const calls = ids.map(id =>
+      this.inventoryService.listLocationInventoryItems(id).pipe(
+        map(resp => ({ id, inv: this.toLocationInventory(resp) })),
+        catchError(() => of({ id, inv: { count: 0, items: [] } as LocationInventory })),
+      ),
+    );
+
+    forkJoin(calls)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(results => {
+        const map: Record<string, LocationInventory> = {};
+        for (const { id, inv } of results) {
+          map[id] = inv;
+        }
+        this.inventoryByLocation.set(map);
+      });
+  }
+
+  private toLocationInventory(resp: unknown): LocationInventory {
+    const payload = this.toRecord(resp);
+    const rawItems = Array.isArray(payload?.['items']) ? (payload?.['items'] as unknown[]) : [];
+    const items = rawItems.map(it => {
+      const rec = this.toRecord(it);
+      return {
+        stockItemId: String(rec?.['stockItemId'] ?? ''),
+        onHandQuantity: Number(rec?.['onHandQuantity'] ?? 0),
+      };
+    });
+    const count = items.reduce((sum, it) => sum + (Number.isFinite(it.onHandQuantity) ? it.onHandQuantity : 0), 0);
+    return { count, items };
+  }
+
+  inventoryCount(locationId: string): number {
+    return this.inventoryByLocation()[locationId]?.count ?? 0;
+  }
+
+  inventoryItems(locationId: string): { stockItemId: string; onHandQuantity: number }[] {
+    return this.inventoryByLocation()[locationId]?.items ?? [];
+  }
+
+  isExpanded(locationId: string): boolean {
+    return this.expandedLocations().has(locationId);
+  }
+
+  toggleExpand(locationId: string): void {
+    const next = new Set(this.expandedLocations());
+    if (next.has(locationId)) {
+      next.delete(locationId);
+    } else {
+      next.add(locationId);
+    }
+    this.expandedLocations.set(next);
   }
 
   goToPage(index: number): void {

--- a/src/app/features/location/services/inventory.service.ts
+++ b/src/app/features/location/services/inventory.service.ts
@@ -58,6 +58,14 @@ export class InventoryService {
     return this.api.get<unknown>(`${InventoryService.BASE}/meta/storage-types`);
   }
 
+  /**
+   * On-hand stock items at a single storage location:
+   * { locationId, items: [{ stockItemId, onHandQuantity }] }.
+   */
+  listLocationInventoryItems(locationId: string): Observable<unknown> {
+    return this.api.get<unknown>(`${InventoryService.BASE}/locations/${locationId}/inventory-items`);
+  }
+
   listSyncLogs(params?: { pageIndex?: number; pageSize?: number; outcome?: string }): Observable<unknown> {
     const httpParams = this.toHttpParams(params);
     return this.api.get<unknown>(`${InventoryService.BASE}/sync-logs`, httpParams);


### PR DESCRIPTION
## Summary

Displays inventory on the storage-locations page (the page's count was previously hardcoded/absent). Each row shows an **on-hand count**; clicking it **expands** to list the products (SKU + quantity) in that storage location.

## How it works

- `InventoryService.listLocationInventoryItems(id)` → `GET /v1/inventory/locations/{id}/inventory-items` (new backend endpoint), via the existing api-base client (no SDK regen).
- On load (and on page change), the page fetches contents for each visible row in parallel (`forkJoin`); count = sum of on-hand. Failures fall back to 0.
- New **Inventory** column with a toggle; an expandable contents sub-row lists SKU + on-hand qty. State: `inventoryByLocation`, `expandedLocations` signals; reset on location clear.

## Validation

- [x] `npm run build` — PASS (only pre-existing inventory CSS-budget warning)
- [x] Location suite — **143/143** (added: count sum, expand contents, error fallback)

## Dependencies

- Backend: inventory-items endpoint (durion-positivity-backend #694) + bin-level seed (#693). UI shows live data once those deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
