### PR TITLE
fix(people): work-session submit endpoint path (#687)

### DIFF
--- a/src/app/features/people/services/people.service.spec.ts
+++ b/src/app/features/people/services/people.service.spec.ts
@@ -343,7 +343,7 @@ describe('PeopleService', () => {
     service.submitWorkSession('session/1', request).subscribe();
 
     expect(apiBaseStub.post).toHaveBeenCalledWith(
-      '/v1/people/workSessions/session%2F1/submit',
+      '/people/v1/people/workSessions/session%2F1/submit',
       request,
     );
   });

--- a/src/app/features/people/services/people.service.ts
+++ b/src/app/features/people/services/people.service.ts
@@ -153,7 +153,7 @@ export class PeopleService {
 
   submitWorkSession(sessionId: string, request: WorkSessionSubmitRequest): Observable<Record<string, unknown> | null> {
     return this.api.post<Record<string, unknown> | null>(
-      `/v1/people/workSessions/${encodeURIComponent(sessionId)}/submit`,
+      `/people/v1/people/workSessions/${encodeURIComponent(sessionId)}/submit`,
       request,
     );
   }


### PR DESCRIPTION
Re-points `PeopleService.submitWorkSession` to `/people/v1/people/workSessions/{id}/submit` (was missing the `/people` gateway prefix, so it 404'd). Pairs with backend durion-positivity-backend#698 and sdk durion-positivity-sdk-angular#7.

The submit call uses the raw `ApiBaseService` (not the generated SDK), so no SDK import change here; the prefix now matches the sibling timekeeping calls.

- people.service.spec path assertion updated. people.service spec 23/23.

Closes #687 once backend #698 deploys (live verify on the work-session submit page).