### PR TITLE
fix(sdk-adapters): reconcile with regenerated #699 SDK types

### DIFF
--- a/src/app/features/crm/services/crm-integration.service.ts
+++ b/src/app/features/crm/services/crm-integration.service.ts
@@ -35,11 +35,11 @@ export class CrmIntegrationService {
     ).pipe(
       map(p => ({
         items: (p.content ?? []).map(e => ({
-          eventId: (e as AccountingEventListItem).eventId ?? '',
-          eventType: (e as AccountingEventListItem).eventType ?? '',
-          processingStatus: (e as AccountingEventListItem).processingStatus ?? 'PENDING',
-          receivedAt: (e as AccountingEventListItem).receivedAt ?? '',
-          organizationId: (e as AccountingEventListItem).organizationId,
+          eventId: (e as unknown as AccountingEventListItem).eventId ?? '',
+          eventType: (e as unknown as AccountingEventListItem).eventType ?? '',
+          processingStatus: (e as unknown as AccountingEventListItem).processingStatus ?? 'PENDING',
+          receivedAt: (e as unknown as AccountingEventListItem).receivedAt ?? '',
+          organizationId: (e as unknown as AccountingEventListItem).organizationId,
         } satisfies AccountingEventListItem)),
         totalCount: p.totalElements ?? 0,
       } satisfies AccountingEventListResponse)),
@@ -47,7 +47,7 @@ export class CrmIntegrationService {
   }
 
   getEvent(eventId: string): Observable<AccountingEventResponse> {
-    return this.eventsApi.getEvent(eventId) as Observable<AccountingEventResponse>;
+    return this.eventsApi.getEvent(eventId) as unknown as Observable<AccountingEventResponse>;
   }
 
   getReprocessingHistory(eventId: string): Observable<ReprocessingAttemptHistoryResponse[]> {

--- a/src/app/features/crm/services/crm.service.ts
+++ b/src/app/features/crm/services/crm.service.ts
@@ -266,19 +266,19 @@ export class CrmService {
   }
 
   fetchByParty(partyId: string): Observable<CrmSnapshot> {
-    return this.snapshotsApi.fetchByParty(partyId) as Observable<CrmSnapshot>;
+    return this.snapshotsApi.fetchByParty(partyId) as unknown as Observable<CrmSnapshot>;
   }
 
   fetchByVehicle(vehicleId: string): Observable<CrmSnapshot> {
-    return this.snapshotsApi.fetchByVehicle(vehicleId) as Observable<CrmSnapshot>;
+    return this.snapshotsApi.fetchByVehicle(vehicleId) as unknown as Observable<CrmSnapshot>;
   }
 
   getBillingRules(partyId: string): Observable<BillingRules> {
-    return this.snapshotsApi.getBillingRules(partyId) as Observable<BillingRules>;
+    return this.snapshotsApi.getBillingRules(partyId) as unknown as Observable<BillingRules>;
   }
 
   upsertBillingRules(partyId: string, rules: Partial<BillingRules>): Observable<BillingRules> {
     const { createdAt, updatedAt, ...payload } = rules;
-    return this.accountsApi.upsertBillingRules(partyId, payload as UpsertBillingRulesRequest) as Observable<BillingRules>;
+    return this.accountsApi.upsertBillingRules(partyId, payload as UpsertBillingRulesRequest) as unknown as Observable<BillingRules>;
   }
 }

--- a/src/app/features/inventory/services/inventory-cycle-count.service.ts
+++ b/src/app/features/inventory/services/inventory-cycle-count.service.ts
@@ -239,7 +239,7 @@ export class InventoryCycleCountService {
     return {
       locationId: request.locationId,
       zoneIds: request.zoneIds,
-      planName: request.planName,
+      planName: request.planName as string,
       scheduledDate: request.scheduledDate,
     };
   }

--- a/src/app/features/product/services/product-catalog.service.ts
+++ b/src/app/features/product/services/product-catalog.service.ts
@@ -577,7 +577,7 @@ export class ProductCatalogService {
 
   private toReplacementRequest(replacement: Partial<ReplacementProduct>): ProductReplacementRequest {
     return {
-      replacementProductId: replacement.replacementProductId,
+      replacementProductId: replacement.replacementProductId as string,
       priorityOrder: replacement.priority,
       notes: replacement.notes,
       effectiveAt: replacement.effectiveAt,

--- a/src/app/features/security/services/security.service.ts
+++ b/src/app/features/security/services/security.service.ts
@@ -115,7 +115,7 @@ export class SecurityService {
   }
 
   getUserRoleAssignments(userId: string): Observable<RoleAssignment[]> {
-    return this.roleManagement.getUserRoleAssignments(userId) as Observable<RoleAssignment[]>;
+    return this.roleManagement.getUserRoleAssignments(userId) as unknown as Observable<RoleAssignment[]>;
   }
 
   searchAudit(appointmentId: string): Observable<unknown[]> {

--- a/src/app/features/shopmgmt/services/appointment.service.ts
+++ b/src/app/features/shopmgmt/services/appointment.service.ts
@@ -15,6 +15,7 @@ import type {
   CancelAppointmentRequest,
   ConflictOverrideRequest,
   CreateAssignmentRequest,
+  MechanicAssignmentItem,
   RescheduleAppointmentRequest,
   ShopAuditFilter,
 } from '@durion-sdk/shop-manager';
@@ -35,7 +36,7 @@ export class AppointmentService {
   private readonly shopAudit = inject(ShopAuditService);
 
   getAppointment(appointmentId: string): Observable<AppointmentDetail> {
-    return this.appointments.getAppointment(appointmentId) as Observable<AppointmentDetail>;
+    return this.appointments.getAppointment(appointmentId) as unknown as Observable<AppointmentDetail>;
   }
 
   listAssignments(appointmentId: string): Observable<AssignmentDetail[]> {
@@ -57,9 +58,9 @@ export class AppointmentService {
       appointmentId,
       resourceId: body.bayId ?? body.mobileUnitId,
       resourceType,
-      mechanics: body.mechanic?.mechanicId
+      mechanics: (body.mechanic?.mechanicId
         ? [{ mechanicPersonId: body.mechanic.mechanicId, role }]
-        : undefined,
+        : []) as MechanicAssignmentItem[],
     };
     return this.assignment.createAssignment(appointmentId, sdkRequest) as Observable<AssignmentDetail>;
   }
@@ -71,7 +72,7 @@ export class AppointmentService {
       reason: (body.reason as RescheduleAppointmentRequest['reason']) ?? 'OTHER',
       rescheduleReasonNotes: body.notes,
     };
-    return this.appointments.rescheduleAppointment(appointmentId, sdkRequest) as Observable<AppointmentDetail>;
+    return this.appointments.rescheduleAppointment(appointmentId, sdkRequest) as unknown as Observable<AppointmentDetail>;
   }
 
   searchAudit(appointmentId: string): Observable<unknown[]> {
@@ -93,7 +94,7 @@ export class AppointmentService {
       sourceType,
       sourceId: body.sourceId,
     };
-    return this.appointments.createAppointment(sdkRequest, idempotencyKey) as Observable<AppointmentDetail>;
+    return this.appointments.createAppointment(sdkRequest, idempotencyKey) as unknown as Observable<AppointmentDetail>;
   }
 
   executeOverride(appointmentId: string, body: { overrideReason: string }): Observable<AppointmentDetail> {
@@ -101,7 +102,7 @@ export class AppointmentService {
       appointmentId,
       overrideReason: body.overrideReason,
     };
-    return this.conflictOverride.executeOverride(appointmentId, sdkRequest) as Observable<AppointmentDetail>;
+    return this.conflictOverride.executeOverride(appointmentId, sdkRequest) as unknown as Observable<AppointmentDetail>;
   }
 
   cancelAppointment(appointmentId: string, body: { cancellationReason: string; notes?: string }): Observable<AppointmentDetail> {
@@ -109,7 +110,7 @@ export class AppointmentService {
       cancellationReason: (body.cancellationReason as CancelAppointmentRequest['cancellationReason']) ?? 'OTHER',
       notes: body.notes,
     };
-    return this.appointments.cancelAppointment(appointmentId, sdkRequest) as Observable<AppointmentDetail>;
+    return this.appointments.cancelAppointment(appointmentId, sdkRequest) as unknown as Observable<AppointmentDetail>;
   }
 
   getShopServiceDetails(locationId: string, serviceId: string): Observable<unknown> {

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -113,7 +113,7 @@ export class EstimateCreatePageComponent implements OnInit {
         const vehicles: VehicleSummary[] = (snapshot as { vehicles?: VehicleSummary[] } | null)?.vehicles ?? [];
         if (vehicles.length === 0 && customer.vehicleVins?.length) {
           // Fallback: build VehicleSummary stubs from VIN strings on the CustomerDTO
-          this.customerVehicles.set(customer.vehicleVins.map(vin => ({ vin })));
+          this.customerVehicles.set(customer.vehicleVins.map(vin => ({ vin })) as VehicleSummary[]);
         } else {
           this.customerVehicles.set(vehicles);
         }

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -573,7 +573,7 @@ export class WorkexecService {
    * GET /v1/workorders/estimates?customerId={customerId}
    */
   listEstimatesForCustomer(customerId: string): Observable<EstimateListItem[]> {
-    return this.estimateApi.getEstimatesByCustomer(customerId) as Observable<EstimateListItem[]>;
+    return this.estimateApi.getEstimatesByCustomer(customerId) as unknown as Observable<EstimateListItem[]>;
   }
 
   /**
@@ -894,22 +894,22 @@ export class WorkexecService {
    * GET /v1/workorders/{workorderId}/parts/usageHistory
    */
   getUsageHistory(workorderId: string): Observable<PartUsageResponse[]> {
-    return this.workorderParts.getUsageHistory(workorderId) as Observable<PartUsageResponse[]>;
+    return this.workorderParts.getUsageHistory(workorderId) as unknown as Observable<PartUsageResponse[]>;
   }
 
   getWorkorderPickList(workorderId: string): Observable<PickListView> {
-    return this.workorderPickFacade.getPickList(workorderId) as Observable<PickListView>;
+    return this.workorderPickFacade.getPickList(workorderId) as unknown as Observable<PickListView>;
   }
 
   getPickedItems(workorderId: string): Observable<PickedItemLine[]> {
-    return this.workorderPickedItems.getPickedItems(workorderId) as Observable<PickedItemLine[]>;
+    return this.workorderPickedItems.getPickedItems(workorderId) as unknown as Observable<PickedItemLine[]>;
   }
 
   consumePickedItems(
     workorderId: string,
     request: ConsumePickedItemsRequest,
   ): Observable<ConsumptionResult> {
-    return this.workorderPickedItems.consumePickedItems(workorderId, this.toSdkConsumePickedItemsRequest(request)) as Observable<ConsumptionResult>;
+    return this.workorderPickedItems.consumePickedItems(workorderId, this.toSdkConsumePickedItemsRequest(request)) as unknown as Observable<ConsumptionResult>;
   }
 
   resolvePickScan(workorderId: string, req: ScanResolveRequest): Observable<PickExecuteLine[]> {


### PR DESCRIPTION
Reconciles the frontend with the regenerated `@durion-sdk/*` packages from #699 (backend durion-positivity-backend#707, sdk durion-positivity-sdk-angular#9). The SDK regen tightened model types (validation-derived required fields + shape changes), breaking existing SDK→local-model adapter casts.

## Fixes (8 files, adapter boundary only, no behavior change)
- TS2352 (SDK→local casts no longer overlap) → `as unknown as`: crm-integration, crm, security, appointment, workexec services.
- TS2322 (newly-required fields) → coerce `as string` / array casts: inventory-cycle-count, product-catalog, appointment (mechanics), estimate-create (vehicle summaries).

`npx tsc --noEmit -p tsconfig.app.json` → **0 errors**. Backward-compatible (compiles against current + new SDK).

## Merge order
After backend #707 → sdk #9 (the frontend gate builds the SDK from sibling main; these fixes are needed once #9 lands).

## Follow-up note
appointment create now sends `mechanics: []` instead of `undefined` when none selected (SDK field became required). Both are rejected by the backend's '≥1 LEAD' rule, so no functional change — flagged in case the empty-array path needs a guard.