### PR TITLE
chore(test): reconcile spec fixtures with #699 SDK types

### DIFF
--- a/src/app/features/billing/services/billing-transport.service.spec.ts
+++ b/src/app/features/billing/services/billing-transport.service.spec.ts
@@ -13,6 +13,7 @@ import {
   PaymentReversalService,
   PaymentService,
   ReceiptResponse,
+  ReceiptResponseStatusEnum,
   ReceiptService,
   RefundPaymentRequestReasonEnum,
   VoidPaymentRequestReasonEnum,
@@ -252,6 +253,7 @@ describe('BillingTransportService', () => {
   it('generates receipts through the receipt SDK client', () => {
     const receiptResponse: ReceiptResponse = {
       receiptId: 'rcpt-001',
+      status: ReceiptResponseStatusEnum.Generated,
     };
     receiptServiceStub.generateReceipt.mockReturnValueOnce(of(receiptResponse));
 
@@ -306,6 +308,7 @@ describe('BillingTransportService', () => {
     const receiptResponse: ReceiptResponse = {
       receiptId: 'rcpt-001',
       reference: 'R-1001',
+      status: ReceiptResponseStatusEnum.Generated,
     };
     receiptServiceStub.reprintReceipt.mockReturnValueOnce(of(receiptResponse));
 

--- a/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.spec.ts
+++ b/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.spec.ts
@@ -405,7 +405,7 @@ describe('location picker', () => {
       parentLocation('b1', 'Main Building', 'Building'),
       parentLocation('p1', 'City Plaza', 'Place'),
       parentLocation('s1', 'Site A', 'Site'), // should be excluded
-      { id: 'x1', name: 'No Type', type: undefined }, // should be excluded
+      { id: 'x1', name: 'No Type', type: undefined, active: true }, // should be excluded
     ];
     locationServiceStub.getAllLocations.mockReturnValue(of(locs));
     rollupServiceStub.getLocationRollup.mockReturnValue(of(locationResponse([])));

--- a/src/app/features/order/pages/order-cancel/order-cancel-page.component.spec.ts
+++ b/src/app/features/order/pages/order-cancel/order-cancel-page.component.spec.ts
@@ -21,6 +21,7 @@ const orderLineFixture: SalesOrderLineResponse = {
 
 const orderFixture: SalesOrderResponse = {
   orderId: 'ord-1',
+  status: 'OPEN',
   subtotal: 100,
   lines: [orderLineFixture],
 };

--- a/src/app/features/order/pages/order-cart/order-cart-page.component.spec.ts
+++ b/src/app/features/order/pages/order-cart/order-cart-page.component.spec.ts
@@ -17,6 +17,7 @@ const orderLineFixture: SalesOrderLineResponse = {
 
 const orderFixture: SalesOrderResponse = {
   orderId: 'ord-1',
+  status: 'OPEN',
   subtotal: 100,
   lines: [orderLineFixture],
 };

--- a/src/app/features/order/pages/price-override/price-override-page.component.spec.ts
+++ b/src/app/features/order/pages/price-override/price-override-page.component.spec.ts
@@ -20,6 +20,7 @@ const orderLineFixture: SalesOrderLineResponse = {
 
 const orderFixture: SalesOrderResponse = {
   orderId: 'ord-1',
+  status: 'OPEN',
   subtotal: 178,
   lines: [orderLineFixture],
 };
@@ -29,9 +30,17 @@ const overridesFixture: PriceOverrideDetail[] = [
     overrideId: 'ov-1',
     orderId: 'ord-1',
     orderLineId: 'line-1',
+    productId: 'SKU-1',
     overridePrice: 75,
     reasonCode: 'PRICE_MATCH',
     originalPrice: 89,
+    discountAmount: 14,
+    discountPercentage: 15.73,
+    status: 'PENDING',
+    requiresApproval: true,
+    affectsCommission: false,
+    requestedByUserId: 'user-1',
+    createdAt: '2026-05-01T00:00:00Z',
   },
 ];
 

--- a/src/app/features/order/services/order.service.spec.ts
+++ b/src/app/features/order/services/order.service.spec.ts
@@ -49,7 +49,7 @@ describe('OrderService', () => {
   });
 
   it('getOrder() delegates to SalesOrdersService.getOrder', () => {
-    const response: SalesOrderResponse = { orderId: 'ord-1' };
+    const response: SalesOrderResponse = { orderId: 'ord-1', status: 'OPEN' };
     salesOrdersApiStub.getOrder.mockReturnValue(of(response));
 
     service.getOrder('ord-1').subscribe(result => expect(result).toEqual(response));
@@ -59,7 +59,7 @@ describe('OrderService', () => {
 
   it('createCart() delegates to SalesOrdersService.createCart', () => {
     const request: CreateCartRequest = { clerkId: 'user-1', terminalId: 'TERM-1' };
-    const response: SalesOrderResponse = { orderId: 'ord-1' };
+    const response: SalesOrderResponse = { orderId: 'ord-1', status: 'OPEN' };
     salesOrdersApiStub.createCart.mockReturnValue(of(response));
 
     service.createCart(request).subscribe(result => expect(result).toEqual(response));
@@ -97,7 +97,7 @@ describe('OrderService', () => {
   });
 
   it('getOverridesByOrder() delegates to PriceOverridesService.getOverridesByOrder', () => {
-    const response: PriceOverrideDetail[] = [{ overrideId: 'ov-1', orderId: 'ord-1', orderLineId: 'line-1', originalPrice: 100, overridePrice: 90, reasonCode: 'PRICE_MATCH' }];
+    const response: PriceOverrideDetail[] = [{ overrideId: 'ov-1', orderId: 'ord-1', orderLineId: 'line-1', productId: 'SKU-1', originalPrice: 100, overridePrice: 90, reasonCode: 'PRICE_MATCH', discountAmount: 10, discountPercentage: 10, status: 'PENDING', requiresApproval: true, affectsCommission: false, requestedByUserId: 'user-1', createdAt: '2026-05-01T00:00:00Z' }];
     priceOverridesApiStub.getOverridesByOrder.mockReturnValue(of(response));
 
     service.getOverridesByOrder('ord-1').subscribe(result => expect(result).toEqual(response));
@@ -114,7 +114,22 @@ describe('OrderService', () => {
       overridePrice: 90,
       reasonCode: 'PRICE_MATCH',
     };
-    const response: PriceOverrideResult = { overrideId: 'ov-1', status: 'PENDING' };
+    const response: PriceOverrideResult = {
+      overrideId: 'ov-1',
+      orderId: 'ord-1',
+      orderLineId: 'line-1',
+      productId: 'SKU-1',
+      originalPrice: 100,
+      overridePrice: 90,
+      discountAmount: 10,
+      discountPercentage: 10,
+      reasonCode: 'PRICE_MATCH',
+      status: 'PENDING',
+      requiresApproval: true,
+      affectsCommission: false,
+      requestedByUserId: 'user-1',
+      createdAt: '2026-05-01T00:00:00Z',
+    };
     priceOverridesApiStub.applyPriceOverride.mockReturnValue(of(response));
 
     service.applyPriceOverride(request).subscribe(result => expect(result).toEqual(response));

--- a/src/app/features/people/pages/work-session/work-session-page.component.spec.ts
+++ b/src/app/features/people/pages/work-session/work-session-page.component.spec.ts
@@ -48,12 +48,14 @@ describe('WorkSessionPageComponent', () => {
   const activeSession: WorkSessionDto = {
     sessionId: 's-1',
     personId: 'person-001',
+    status: 'ACTIVE',
     startedAt: '2026-04-25T08:00:00Z',
   };
 
   const stoppedSession: WorkSessionDto = {
     sessionId: 's-1',
     personId: 'person-001',
+    status: 'STOPPED',
     startedAt: '2026-04-25T08:00:00Z',
     endedAt: '2026-04-25T17:00:00Z',
   };

--- a/src/app/features/people/services/people.service.spec.ts
+++ b/src/app/features/people/services/people.service.spec.ts
@@ -7,6 +7,7 @@ import {
   CreateStaffingAssignmentRequest,
   EmployeeAPIService,
   EmployeeProfileDto,
+  EmployeeProfileDtoStatusEnum,
   UpdateEmployeeRequest,
   PeopleAccessControlService,
   PeopleReportsAPIService,
@@ -76,7 +77,13 @@ describe('PeopleService', () => {
   });
 
   it('getEmployee() delegates to EmployeeAPIService.getEmployee', () => {
-    const response: EmployeeProfileDto = { id: 'emp-1', legalName: 'Jane Doe' };
+    const response: EmployeeProfileDto = {
+      id: 'emp-1',
+      legalName: 'Jane Doe',
+      employeeNumber: 'EMP-1',
+      status: EmployeeProfileDtoStatusEnum.Active,
+      hireDate: '2026-05-01',
+    };
     employeeApiStub.getEmployee.mockReturnValue(of(response));
 
     service.getEmployee('emp-1').subscribe(result => expect(result).toEqual(response));
@@ -91,7 +98,13 @@ describe('PeopleService', () => {
       status: CreateEmployeeRequestStatusEnum.Active,
       hireDate: '2026-05-01',
     };
-    const response: EmployeeProfileDto = { id: 'emp-1', legalName: 'Jane Doe' };
+    const response: EmployeeProfileDto = {
+      id: 'emp-1',
+      legalName: 'Jane Doe',
+      employeeNumber: 'EMP-1',
+      status: EmployeeProfileDtoStatusEnum.Active,
+      hireDate: '2026-05-01',
+    };
     employeeApiStub.createEmployee.mockReturnValue(of(response));
 
     service.createEmployee(request).subscribe(result => expect(result).toEqual(response));
@@ -106,7 +119,13 @@ describe('PeopleService', () => {
       status: UpdateEmployeeRequestStatusEnum.Active,
       hireDate: '2026-05-01',
     };
-    const response: EmployeeProfileDto = { id: 'emp-1', legalName: 'Updated Name' };
+    const response: EmployeeProfileDto = {
+      id: 'emp-1',
+      legalName: 'Updated Name',
+      employeeNumber: 'EMP-1',
+      status: EmployeeProfileDtoStatusEnum.Active,
+      hireDate: '2026-05-01',
+    };
     employeeApiStub.updateEmployee.mockReturnValue(of(response));
 
     service.updateEmployee('emp-1', request).subscribe(result => expect(result).toEqual(response));
@@ -297,7 +316,7 @@ describe('PeopleService', () => {
   });
 
   it('startSession() delegates to WorkSessionsAPIService.startWorkSession', () => {
-    const response: WorkSessionDto = { sessionId: 's-1', personId: 'p-1' };
+    const response: WorkSessionDto = { sessionId: 's-1', personId: 'p-1', status: 'ACTIVE' };
     workSessionsApiStub.startWorkSession.mockReturnValue(of(response));
 
     service.startSession('p-1').subscribe(result => expect(result).toEqual(response));
@@ -306,7 +325,7 @@ describe('PeopleService', () => {
   });
 
   it('stopSession() delegates to WorkSessionsAPIService.stopWorkSession', () => {
-    const response: WorkSessionDto = { sessionId: 's-1', personId: 'p-1', endedAt: '2026-05-05T12:00:00Z' };
+    const response: WorkSessionDto = { sessionId: 's-1', personId: 'p-1', status: 'STOPPED', endedAt: '2026-05-05T12:00:00Z' };
     workSessionsApiStub.stopWorkSession.mockReturnValue(of(response));
 
     service.stopSession('p-1').subscribe(result => expect(result).toEqual(response));

--- a/src/app/features/people/services/work-session.service.spec.ts
+++ b/src/app/features/people/services/work-session.service.spec.ts
@@ -16,6 +16,7 @@ describe('WorkSessionService', () => {
   const session: WorkSessionDto = {
     sessionId: 'session-001',
     personId: 'person-001',
+    status: 'ACTIVE',
     startedAt: '2026-04-25T08:00:00Z',
   };
 


### PR DESCRIPTION
## Summary

The #699 SDK regeneration promoted several response fields to **required**, but spec fixtures predating the regen omitted them. This broke the unit-test **build** (`TS2741`/`TS2740`) so the entire suite could not compile.

Updated 9 spec files to satisfy the current SDK contracts (test fixtures only — no production code):

- **people** — `WorkSessionDto.status`, `EmployeeProfileDto` (`employeeNumber`/`status`/`hireDate`)
- **order** — `SalesOrderResponse.status`, full `PriceOverrideDetail` / `PriceOverrideResult` shapes
- **billing** — `ReceiptResponse.status`
- **inventory** — `LocationResponseDTO.active`

## Validation

- [x] `ng test` now **compiles** (was: build aborted on TS2741/TS2740)
- [ ] `npm run build`

## Notes / Follow-ups

⚠️ Compiling the suite reveals **~88 pre-existing test failures** unrelated to these fixtures — tests that never ran while the build was broken. Two clusters: `TestBed already instantiated` isolation errors (workexec `estimate-create`/`approval-in-person`, inventory `po-detail`) and error-state assertion drift (inventory `location-overview`, shopmgmt `dispatch-board`). These need a separate remediation effort and are **out of scope** for this fixture reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
