### PR TITLE
fix(crm): typeahead finds individual persons (#59)

### DIFF
--- a/src/app/features/crm/services/crm.service.spec.ts
+++ b/src/app/features/crm/services/crm.service.spec.ts
@@ -296,12 +296,35 @@ describe('CrmService', () => {
   });
 
   describe('searchParties()', () => {
-    it('sends trimmed name criteria for non-empty query', () => {
-      crmAccountsStub.searchParties.mockReturnValueOnce(of({ results: [] }));
+    it('browses the unified directory by trimmed name so individuals are found too (issue #59)', () => {
+      crmAccountsStub.browseParties.mockReturnValueOnce(
+        of({ results: [browseParty], totalCount: 1, pageNumber: 0, pageSize: 25 }),
+      );
 
-      service.searchParties('  acme  ').subscribe();
+      let result: { parties: unknown[] } | undefined;
+      service.searchParties('  Albert  ').subscribe(value => {
+        result = value;
+      });
 
-      expect(crmAccountsStub.searchParties).toHaveBeenCalledWith({ name: 'acme' });
+      const expectedPageable: Pageable = { page: 0, size: 25 };
+      expect(crmAccountsStub.browseParties).toHaveBeenCalledWith(
+        expectedPageable, 'Albert', undefined, undefined, undefined, undefined, undefined,
+      );
+      expect(crmAccountsStub.searchParties).not.toHaveBeenCalled();
+      expect(result).toEqual({ parties: [browseParty] });
+    });
+
+    it('omits the name filter for an empty query', () => {
+      crmAccountsStub.browseParties.mockReturnValueOnce(
+        of({ results: [], totalCount: 0, pageNumber: 0, pageSize: 25 }),
+      );
+
+      service.searchParties('   ').subscribe();
+
+      const expectedPageable: Pageable = { page: 0, size: 25 };
+      expect(crmAccountsStub.browseParties).toHaveBeenCalledWith(
+        expectedPageable, undefined, undefined, undefined, undefined, undefined, undefined,
+      );
     });
   });
 });

--- a/src/app/features/crm/services/crm.service.ts
+++ b/src/app/features/crm/services/crm.service.ts
@@ -13,7 +13,6 @@ import type {
   CreateCommercialAccountRequest as SdkCreateCommercialAccountRequest,
   MergePartiesRequest as SdkMergePartiesRequest,
   Pageable as SdkPageable,
-  SearchPartiesRequest as SdkSearchPartiesRequest,
   CreatePersonRequest as SdkCreatePersonRequest,
   CreatePartyRelationshipRequest as SdkCreatePartyRelationshipRequest,
   UpsertCommunicationPreferencesRequest as SdkUpsertCommunicationPreferencesRequest,
@@ -148,11 +147,16 @@ export class CrmService {
       );
   }
 
+  /**
+   * Customer typeahead search across the full directory. Delegates to browseParties
+   * (unified commercial accounts + individual person customers) rather than
+   * accountsApi.searchParties, which matches commercial legalName only and never
+   * returns individuals (CUST-PP-*). See issue #59.
+   */
   searchParties(query: string): Observable<{ parties: PartyDetail[] }> {
     const normalizedQuery = query.trim();
-    const sdkRequest: SdkSearchPartiesRequest = { name: normalizedQuery };
-    return this.accountsApi.searchParties(sdkRequest).pipe(
-      map(response => ({ parties: (response.results ?? []) as PartyDetail[] })),
+    return this.browseParties({ name: normalizedQuery || undefined }).pipe(
+      map(page => ({ parties: page.parties })),
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes #59. CRM customer typeahead returned commercial accounts only; individual person customers (`CUST-PP-*`, e.g. `Albert Rogers`) were never findable.

## Root cause
`CrmService.searchParties` called `accountsApi.searchParties`, whose backend impl searches `CommercialParty` legalName only. The customer directory uses `browseParties`, which merges commercial accounts **and** individual persons and filters on `legalName` OR `displayName`.

## Fix
Delegate `searchParties` to `browseParties` (frontend-only). One call now covers both party kinds:
- No backend or SDK change.
- Consumers still receive `{ parties: PartyDetail[] }` unchanged.
- Empty query omits the name filter.

Affects all CRM Customer typeaheads: Party Detail, Add Vehicle, Party Contacts, Billing Rules, CRM Snapshot by Party (landing), standalone CRM Snapshot.

## Tests
- `crm.service.spec.ts` — searchParties now asserts `browseParties` delegation + empty-query behaviour (12 passed).
- landing + crm-snapshot specs (35 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)