### PR TITLE
fix(dev): proxy /api to gateway so local dev mirrors alpha/prod

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -109,6 +109,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "durion-positivity-frontend:build:production"

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,17 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/api": ""
+    },
+    "logLevel": "debug"
+  },
+  "/mcp-server": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}

--- a/src/app/features/bulk-import/services/bulk-import.service.spec.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.spec.ts
@@ -115,7 +115,7 @@ describe('BulkImportService', () => {
       });
       expect(response).toEqual({
         jobId: 'job-001',
-        uploadUrl: 'http://localhost:8080/api/bulk-loader/v1/bulk-jobs/job-001/tus',
+        uploadUrl: '/api/bulk-loader/v1/bulk-jobs/job-001/tus',
       });
     });
   });
@@ -429,7 +429,7 @@ describe('BulkImportService', () => {
 
   describe('getTusUploadUrl()', () => {
     it('returns a resumable upload endpoint for an existing job', () => {
-      expect(service.getTusUploadUrl('job-123')).toBe('http://localhost:8080/api/bulk-loader/v1/bulk-jobs/job-123/tus');
+      expect(service.getTusUploadUrl('job-123')).toBe('/api/bulk-loader/v1/bulk-jobs/job-123/tus');
     });
   });
 });

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080/api',
+  apiBaseUrl: '/api', // dev-server proxies /api -> http://localhost:8080 (see proxy.conf.json), mirroring alpha/prod
   /** Set to true to skip the real login API and use a local mock session. */
   mockAuth: true,
 };


### PR DESCRIPTION
## Problem
Local `ng serve` calls the gateway directly at `http://localhost:8080`, but gateway routes carry **no** `/api` prefix (`/customer/**`, `/people/**`, …). The frontend's `apiBaseUrl` baked in `/api`, so every SDK/CRM call **404'd in dev only**. Alpha/prod work because a reverse-proxy strips `/api` before the gateway — dev never replicated that proxy. This is the recurring "api-prefixing" pain (surfaced verifying #59/#60).

## Fix
- `proxy.conf.json`: rewrite `^/api` → `''` and forward to `http://localhost:8080`; `/mcp-server` passthrough for the chat transport (it targets the gateway root, not `/api`).
- `angular.json`: wire `serve.options.proxyConfig`.
- `environment.ts`: dev `apiBaseUrl` → `/api`, matching alpha/prod. The dev-server proxy now plays the deployed reverse-proxy's role; `/api` is consistent across **all** envs.
- Prefix ownership stays with the frontend/proxy (per decision) — **no backend/gateway change**.

## Verification
`/api/customer/v1/crm/accounts/parties` via `:4200` now returns **401** (auth), byte-identical to a direct gateway `/customer/...` call — the **404 prefix mismatch is gone**. (Remaining local-dev auth gap: the mockAuth JWT isn't accepted by a really-secured backend → re-verify behavior on alpha.)

## Tests
Updated `bulk-import.service.spec.ts` to relative `/api/...` URLs. Affected specs green (27/27: bulk-import + chat-api).

🤖 Generated with [Claude Code](https://claude.com/claude-code)