### PR TITLE
feat(workexec): estimate vehicle dropdown with add-new-vehicle

### DIFF
--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.css
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.css
@@ -160,6 +160,43 @@
   opacity: 0.7;
 }
 
+.btn--sm {
+  padding: var(--space-2, 0.5rem) var(--space-4, 1rem);
+  font-size: 0.875rem;
+}
+
+/* ── Add vehicle (inline) ───────────────────────────────────────────────── */
+.add-vehicle {
+  margin-top: var(--space-3, 0.75rem);
+  padding: var(--space-4, 1rem);
+  border: 1px solid var(--input-border, var(--border-color));
+  border-radius: var(--radius-md, 0.375rem);
+  background: color-mix(in srgb, var(--brand-primary) 3%, var(--cardBackground));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+}
+
+.add-vehicle__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.add-vehicle__row {
+  display: flex;
+  gap: var(--space-3, 0.75rem);
+}
+
+.add-vehicle__row .field-group {
+  flex: 1;
+}
+
+.add-vehicle__actions {
+  display: flex;
+  gap: var(--space-3, 0.75rem);
+}
+
 /* ── Typeahead ──────────────────────────────────────────────────────────── */
 .typeahead-wrap {
   position: relative;

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
@@ -65,6 +65,7 @@
         [disabled]="!form.controls.customerId.value"
         [value]="showAddVehicle() ? addVehicleOption : form.controls.vehicleId.value"
         (change)="onVehicleSelect($any($event.target).value)"
+        [attr.aria-describedby]="form.controls.vehicleId.invalid && form.controls.vehicleId.touched && !showAddVehicle() ? 'vehicleId-err' : null"
         aria-required="true"
       >
         <option value="" disabled>Select vehicle…</option>
@@ -94,11 +95,12 @@
               class="field-input"
               formControlName="vinNumber"
               [class.field-input--error]="newVehicleForm.controls.vinNumber.invalid && newVehicleForm.controls.vinNumber.touched"
+              [attr.aria-describedby]="newVehicleForm.controls.vinNumber.invalid && newVehicleForm.controls.vinNumber.touched ? 'newVin-err' : null"
               placeholder="Vehicle Identification Number"
               aria-required="true"
             />
             @if (newVehicleForm.controls.vinNumber.invalid && newVehicleForm.controls.vinNumber.touched) {
-              <p class="field-error" role="alert">VIN is required.</p>
+              <p id="newVin-err" class="field-error" role="alert">VIN is required.</p>
             }
           </div>
 

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
@@ -55,44 +55,93 @@
       }
     </div>
 
-    <!-- Vehicle VIN search -->
+    <!-- Vehicle selection -->
     <div class="field-group">
-      <label for="vehicleVinSearch" class="field-label">Vehicle VIN <span class="required" aria-hidden="true">*</span></label>
-      <div class="typeahead-wrap">
-        <input
-          id="vehicleVinSearch"
-          type="text"
-          autocomplete="off"
-          class="field-input"
-          [class.field-input--error]="form.controls.vehicleId.invalid && form.controls.vehicleId.touched"
-          [value]="vehicleVinInput()"
-          (input)="onVehicleInput($any($event.target).value)"
-          (focus)="onVehicleFocus()"
-          (blur)="onVehicleBlur()"
-          [attr.aria-expanded]="showVehicleSuggestions() && vehicleSuggestions().length > 0"
-          aria-autocomplete="list"
-          aria-haspopup="listbox"
-          placeholder="Enter or search VIN…"
-          aria-required="true"
-        />
-        @if (showVehicleSuggestions() && vehicleSuggestions().length > 0) {
-          <ul class="typeahead-suggestions" role="listbox">
-            @for (v of vehicleSuggestions(); track v.vehicleId ?? v.vin) {
-              <li class="typeahead-item" role="option" (mousedown)="selectVehicle(v)">
-                <span class="suggestion-primary">{{ v.vin }}</span>
-                @if (v.year || v.make || v.model) {
-                  <span class="suggestion-secondary">{{ v.year }} {{ v.make }} {{ v.model }}</span>
-                }
-              </li>
-            }
-          </ul>
+      <label for="vehicleSelect" class="field-label">Vehicle <span class="required" aria-hidden="true">*</span></label>
+      <select
+        id="vehicleSelect"
+        class="field-input"
+        [class.field-input--error]="form.controls.vehicleId.invalid && form.controls.vehicleId.touched"
+        [disabled]="!form.controls.customerId.value"
+        [value]="showAddVehicle() ? addVehicleOption : form.controls.vehicleId.value"
+        (change)="onVehicleSelect($any($event.target).value)"
+        aria-required="true"
+      >
+        <option value="" disabled>Select vehicle…</option>
+        @for (v of customerVehicles(); track v.vehicleId ?? v.vin) {
+          <option [value]="v.vehicleId">{{ vehicleLabel(v) }}</option>
         }
-      </div>
-      @if (form.controls.vehicleId.invalid && form.controls.vehicleId.touched) {
-        <p id="vehicleId-err" class="field-error" role="alert">Vehicle VIN is required.</p>
+        <option [value]="addVehicleOption">+ Add new vehicle…</option>
+      </select>
+      @if (form.controls.vehicleId.invalid && form.controls.vehicleId.touched && !showAddVehicle()) {
+        <p id="vehicleId-err" class="field-error" role="alert">Vehicle is required.</p>
       }
       @if (fieldError('vehicleId')) {
         <p class="field-error" role="alert">{{ fieldError('vehicleId') }}</p>
+      }
+
+      <!-- Inline add-vehicle form -->
+      @if (showAddVehicle()) {
+        <div class="add-vehicle" [formGroup]="newVehicleForm">
+          <p class="add-vehicle__title">New vehicle</p>
+
+          <div class="field-group">
+            <label for="newVin" class="field-label">VIN <span class="required" aria-hidden="true">*</span></label>
+            <input
+              id="newVin"
+              type="text"
+              autocomplete="off"
+              class="field-input"
+              formControlName="vinNumber"
+              [class.field-input--error]="newVehicleForm.controls.vinNumber.invalid && newVehicleForm.controls.vinNumber.touched"
+              placeholder="Vehicle Identification Number"
+              aria-required="true"
+            />
+            @if (newVehicleForm.controls.vinNumber.invalid && newVehicleForm.controls.vinNumber.touched) {
+              <p class="field-error" role="alert">VIN is required.</p>
+            }
+          </div>
+
+          <div class="field-group">
+            <label for="newDescription" class="field-label">Description</label>
+            <input id="newDescription" type="text" autocomplete="off" class="field-input"
+                   formControlName="description" placeholder="e.g. 2019 Ford F-150" />
+          </div>
+
+          <div class="field-group">
+            <label for="newUnitNumber" class="field-label">Unit number</label>
+            <input id="newUnitNumber" type="text" autocomplete="off" class="field-input"
+                   formControlName="unitNumber" placeholder="Unit or internal reference" />
+          </div>
+
+          <div class="add-vehicle__row">
+            <div class="field-group">
+              <label for="newPlate" class="field-label">License plate</label>
+              <input id="newPlate" type="text" autocomplete="off" class="field-input"
+                     formControlName="licensePlate" placeholder="Plate" />
+            </div>
+            <div class="field-group">
+              <label for="newPlateRegion" class="field-label">Region</label>
+              <input id="newPlateRegion" type="text" autocomplete="off" class="field-input"
+                     formControlName="licensePlateRegion" placeholder="State / province" />
+            </div>
+          </div>
+
+          @if (vehicleSaveError()) {
+            <p class="field-error" role="alert">{{ vehicleSaveError() }}</p>
+          }
+
+          <div class="add-vehicle__actions">
+            <button type="button" class="btn btn--primary btn--sm" (click)="saveNewVehicle()"
+                    [disabled]="vehicleSaving()" [attr.aria-busy]="vehicleSaving()">
+              @if (vehicleSaving()) { Saving… } @else { Save vehicle }
+            </button>
+            <button type="button" class="btn btn--ghost btn--sm" (click)="cancelAddVehicle()"
+                    [disabled]="vehicleSaving()">
+              Cancel
+            </button>
+          </div>
+        </div>
       }
     </div>
 

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
@@ -90,4 +90,50 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     expect(component.state()).toBe('error');
     expect(component.errorMessage()).toBe('Server error');
   });
+
+  it('should reveal inline add-vehicle form when add option chosen', () => {
+    expect(component.showAddVehicle()).toBe(false);
+    component.onVehicleSelect(component.addVehicleOption);
+    expect(component.showAddVehicle()).toBe(true);
+    expect(component.form.controls.vehicleId.value).toBe('');
+  });
+
+  it('should not POST a new vehicle when VIN is empty', () => {
+    component.form.patchValue({ customerId: 'cust-1' });
+    component.onVehicleSelect(component.addVehicleOption);
+    component.saveNewVehicle();
+    expect(component.newVehicleForm.controls.vinNumber.touched).toBe(true);
+    http.expectNone(r => r.method === 'POST' && /\/v1\/crm\/.+\/vehicles$/.test(r.url));
+  });
+
+  it('should POST new vehicle then select it on success', () => {
+    component.form.patchValue({ customerId: 'cust-1' });
+    component.onVehicleSelect(component.addVehicleOption);
+    component.newVehicleForm.patchValue({ vinNumber: '1FTABC123', description: 'F-150' });
+
+    component.saveNewVehicle();
+
+    const req = http.expectOne(r => r.method === 'POST' && r.url.endsWith('/v1/crm/cust-1/vehicles'));
+    expect(req.request.body).toEqual({ vinNumber: '1FTABC123', description: 'F-150' });
+    req.flush({ vehicleId: 'veh-new', vin: '1FTABC123', make: 'Ford', model: 'F-150', year: 2019 });
+
+    expect(component.customerVehicles().some(v => v.vehicleId === 'veh-new')).toBe(true);
+    expect(component.form.controls.vehicleId.value).toBe('veh-new');
+    expect(component.showAddVehicle()).toBe(false);
+  });
+
+  it('should surface an error when vehicle creation fails', () => {
+    component.form.patchValue({ customerId: 'cust-1' });
+    component.onVehicleSelect(component.addVehicleOption);
+    component.newVehicleForm.patchValue({ vinNumber: '1FTABC123' });
+
+    component.saveNewVehicle();
+
+    const req = http.expectOne(r => r.method === 'POST' && r.url.endsWith('/v1/crm/cust-1/vehicles'));
+    req.flush({ message: 'Duplicate VIN' }, { status: 409, statusText: 'Conflict' });
+
+    expect(component.vehicleSaving()).toBe(false);
+    expect(component.vehicleSaveError()).toBe('Duplicate VIN');
+    expect(component.showAddVehicle()).toBe(true);
+  });
 });

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -4,11 +4,20 @@ import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { catchError, of } from 'rxjs';
-import { CustomerAPIService, CustomerDTO, CRMSnapshotsService, VehicleSummary } from '@durion-sdk/customer';
+import {
+  CustomerAPIService,
+  CustomerDTO,
+  CRMSnapshotsService,
+  CRMVehiclesService,
+  CreateVehicleForPartyRequest,
+  VehicleResponse,
+  VehicleSummary,
+} from '@durion-sdk/customer';
 import { WorkexecService } from '../../services/workexec.service';
 import { PageState } from '../../models/workexec.models';
 
 const MAX_SUGGESTIONS = 8;
+const ADD_VEHICLE_OPTION = '__add__';
 
 @Component({
   selector: 'app-estimate-create-page',
@@ -24,6 +33,7 @@ export class EstimateCreatePageComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly customerApi = inject(CustomerAPIService);
   private readonly snapshotsApi = inject(CRMSnapshotsService);
+  private readonly vehiclesApi = inject(CRMVehiclesService);
 
   readonly state        = signal<PageState>('idle');
   readonly errorMessage = signal<string | null>(null);
@@ -34,8 +44,12 @@ export class EstimateCreatePageComponent implements OnInit {
   readonly showCustomerSuggestions = signal(false);
 
   readonly customerVehicles = signal<VehicleSummary[]>([]);
-  readonly vehicleVinInput = signal('');
-  readonly showVehicleSuggestions = signal(false);
+
+  readonly showAddVehicle = signal(false);
+  readonly vehicleSaving = signal(false);
+  readonly vehicleSaveError = signal<string | null>(null);
+
+  readonly addVehicleOption = ADD_VEHICLE_OPTION;
 
   readonly customerSuggestions = computed<CustomerDTO[]>(() => {
     const q = this.customerDisplayName().trim().toLowerCase();
@@ -48,19 +62,17 @@ export class EstimateCreatePageComponent implements OnInit {
     }).slice(0, MAX_SUGGESTIONS);
   });
 
-  readonly vehicleSuggestions = computed<VehicleSummary[]>(() => {
-    const q = this.vehicleVinInput().trim().toLowerCase();
-    const vehicles = this.customerVehicles();
-    if (!q) return vehicles.slice(0, MAX_SUGGESTIONS);
-    return vehicles.filter(v =>
-      v.vin?.toLowerCase().includes(q) ||
-      `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.toLowerCase().includes(q),
-    ).slice(0, MAX_SUGGESTIONS);
-  });
-
   readonly form = this.fb.nonNullable.group({
     customerId: ['', Validators.required],
     vehicleId:  ['', Validators.required],
+  });
+
+  readonly newVehicleForm = this.fb.nonNullable.group({
+    vinNumber:          ['', Validators.required],
+    description:        [''],
+    unitNumber:         [''],
+    licensePlate:       [''],
+    licensePlateRegion: [''],
   });
 
   ngOnInit(): void {
@@ -82,9 +94,7 @@ export class EstimateCreatePageComponent implements OnInit {
   onCustomerInput(value: string): void {
     this.customerDisplayName.set(value);
     this.form.patchValue({ customerId: '' });
-    this.customerVehicles.set([]);
-    this.vehicleVinInput.set('');
-    this.form.patchValue({ vehicleId: '' });
+    this.resetVehicleSelection();
     this.showCustomerSuggestions.set(true);
   }
 
@@ -101,8 +111,7 @@ export class EstimateCreatePageComponent implements OnInit {
     this.form.patchValue({ customerId: id });
     this.customerDisplayName.set(`${customer.firstName} ${customer.lastName}`);
     this.showCustomerSuggestions.set(false);
-    this.vehicleVinInput.set('');
-    this.form.patchValue({ vehicleId: '' });
+    this.resetVehicleSelection();
 
     if (!id) { return; }
 
@@ -123,26 +132,81 @@ export class EstimateCreatePageComponent implements OnInit {
       });
   }
 
-  onVehicleInput(value: string): void {
-    this.vehicleVinInput.set(value);
+  /** Human-readable label for a vehicle dropdown option. */
+  vehicleLabel(v: VehicleSummary): string {
+    const desc = `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.trim();
+    if (v.vin && desc) return `${v.vin} — ${desc}`;
+    return v.vin ?? v.vehicleId ?? 'Vehicle';
+  }
+
+  onVehicleSelect(value: string): void {
+    if (value === ADD_VEHICLE_OPTION) {
+      this.form.patchValue({ vehicleId: '' });
+      this.showAddVehicle.set(true);
+      this.vehicleSaveError.set(null);
+      return;
+    }
+    this.showAddVehicle.set(false);
+    this.form.patchValue({ vehicleId: value });
+  }
+
+  cancelAddVehicle(): void {
+    this.showAddVehicle.set(false);
+    this.vehicleSaveError.set(null);
+    this.newVehicleForm.reset();
+  }
+
+  saveNewVehicle(): void {
+    if (this.newVehicleForm.invalid) {
+      this.newVehicleForm.markAllAsTouched();
+      return;
+    }
+    const customerId = this.form.controls.customerId.value;
+    if (!customerId) { return; }
+
+    this.vehicleSaving.set(true);
+    this.vehicleSaveError.set(null);
+
+    const raw = this.newVehicleForm.getRawValue();
+    const request: CreateVehicleForPartyRequest = {
+      vinNumber: raw.vinNumber.trim(),
+      ...(raw.description.trim()        ? { description: raw.description.trim() } : {}),
+      ...(raw.unitNumber.trim()         ? { unitNumber: raw.unitNumber.trim() } : {}),
+      ...(raw.licensePlate.trim()       ? { licensePlate: raw.licensePlate.trim() } : {}),
+      ...(raw.licensePlateRegion.trim() ? { licensePlateRegion: raw.licensePlateRegion.trim() } : {}),
+    };
+
+    this.vehiclesApi.createVehicles(customerId, request, 'body', false, { transferCache: false })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (created: VehicleResponse) => {
+          this.vehicleSaving.set(false);
+          const summary: VehicleSummary = {
+            vehicleId: created.vehicleId ?? '',
+            vin: created.vin,
+            make: created.make,
+            model: created.model,
+            year: created.year,
+          };
+          this.customerVehicles.update(list => [...list, summary]);
+          this.form.patchValue({ vehicleId: summary.vehicleId });
+          this.showAddVehicle.set(false);
+          this.newVehicleForm.reset();
+        },
+        error: err => {
+          this.vehicleSaving.set(false);
+          const body = err.error;
+          this.vehicleSaveError.set(body?.message ?? 'Could not add vehicle. Please try again.');
+        },
+      });
+  }
+
+  private resetVehicleSelection(): void {
+    this.customerVehicles.set([]);
     this.form.patchValue({ vehicleId: '' });
-    this.showVehicleSuggestions.set(true);
-  }
-
-  onVehicleFocus(): void {
-    if (this.customerVehicles().length > 0) this.showVehicleSuggestions.set(true);
-  }
-
-  onVehicleBlur(): void {
-    setTimeout(() => this.showVehicleSuggestions.set(false), 150);
-  }
-
-  selectVehicle(vehicle: VehicleSummary): void {
-    // vehicleId must be a UUID; VIN stubs (no UUID) leave the field empty so form stays invalid
-    const id = vehicle.vehicleId ?? '';
-    this.form.patchValue({ vehicleId: id });
-    this.vehicleVinInput.set(vehicle.vin ?? id);
-    this.showVehicleSuggestions.set(false);
+    this.showAddVehicle.set(false);
+    this.vehicleSaveError.set(null);
+    this.newVehicleForm.reset();
   }
 
   submit(): void {


### PR DESCRIPTION
## Summary

- Replaces the VIN typeahead on the New Estimate page (`/app/workexec/estimates/new`) with a **dropdown** of the selected customer's associated vehicles.
- Adds an inline **"Add new vehicle"** option that reveals a form (VIN required; description, unit number, license plate + region optional) and creates the vehicle via `CRMVehiclesService.createVehicles` (`POST /v1/crm/{customerId}/vehicles`).
- On success the new vehicle is appended to the list and auto-selected; create failures surface an inline error.
- No backend/controller change — consumes an existing SDK endpoint. Customer typeahead and CRM-snapshot vehicle sourcing unchanged.

## Validation

- [x] `npx tsc --noEmit` — no errors
- [x] Targeted tests: `estimate-create-page.component.spec.ts` — 11/11 pass (4 new: open form, VIN-required guard, POST+select success, 409 error surface)
- [ ] `npm run build`
- [ ] `npm run test` (full suite)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on the New Estimate page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver):
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

Note: native `<select>` + `<input>` controls used; inline add-vehicle form uses labelled fields and `role="alert"` error messaging. Manual keyboard/SR smoke still pending.

## Notes / Follow-ups

- VIN-stub vehicles (CustomerDTO fallback without a UUID) render in the dropdown but have an empty value, so they cannot be selected — same constraint as the prior typeahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
