### PR TITLE
fix(workexec): source estimate customers from CRM party directory

### DIFF
--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.html
@@ -36,11 +36,11 @@
         />
         @if (showCustomerSuggestions() && customerSuggestions().length > 0) {
           <ul class="typeahead-suggestions" role="listbox">
-            @for (c of customerSuggestions(); track c.id) {
-              <li class="typeahead-item" role="option" (mousedown)="selectCustomer(c)">
-                <span class="suggestion-primary">{{ c.firstName }} {{ c.lastName }}</span>
-                @if (c.customerNumber) {
-                  <span class="suggestion-secondary">{{ c.customerNumber }}</span>
+            @for (p of customerSuggestions(); track p.partyId) {
+              <li class="typeahead-item" role="option" (mousedown)="selectCustomer(p)">
+                <span class="suggestion-primary">{{ customerLabel(p) }}</span>
+                @if (p.customerNumber) {
+                  <span class="suggestion-secondary">{{ p.customerNumber }}</span>
                 }
               </li>
             }

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
@@ -30,10 +30,11 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     http = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
 
-    // ngOnInit eagerly loads the customer list for the typeahead exactly once.
+    // ngOnInit eagerly browses the CRM party directory for the typeahead exactly once.
     // expectOne asserts the single init request (catches accidental double-loads)
     // and flushing it leaves each test a clean HTTP backend.
-    http.expectOne(r => r.method === 'GET' && r.url.endsWith('/v1/crm')).flush({ content: [] });
+    http.expectOne(r => r.method === 'GET' && /\/v1\/crm\/accounts\/parties(\?|$)/.test(r.url))
+      .flush({ results: [], totalCount: 0, pageNumber: 0, pageSize: 200 });
   });
 
   afterEach(() => {
@@ -89,6 +90,23 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     fixture.detectChanges();
     expect(component.state()).toBe('error');
     expect(component.errorMessage()).toBe('Server error');
+  });
+
+  it('should suggest CRM parties by legal name / customer number and select by partyId', () => {
+    component.allCustomers.set([
+      { partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' },
+      { partyId: 'p-2', legalName: 'Bravo Logistics', customerNumber: 'C-200' },
+    ]);
+    component.onCustomerInput('acme');
+    expect(component.customerSuggestions().map(p => p.partyId)).toEqual(['p-1']);
+
+    component.selectCustomer({ partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' });
+    expect(component.form.controls.customerId.value).toBe('p-1');
+    expect(component.customerDisplayName()).toBe('Acme Towing');
+
+    // selecting a customer triggers a CRM snapshot fetch for that party's vehicles
+    http.expectOne(r => r.method === 'GET' && r.url.includes('/snapshot') && r.url.includes('p-1'))
+      .flush({ vehicles: [] });
   });
 
   it('should reveal inline add-vehicle form when add option chosen', () => {

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -5,14 +5,14 @@ import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { catchError, of } from 'rxjs';
 import {
-  CustomerAPIService,
-  CustomerDTO,
   CRMSnapshotsService,
   CRMVehiclesService,
   CreateVehicleForPartyRequest,
   VehicleResponse,
   VehicleSummary,
 } from '@durion-sdk/customer';
+import { CrmService } from '../../../crm/services/crm.service';
+import { PartyDetail } from '../../../crm/models/crm.models';
 import { WorkexecService } from '../../services/workexec.service';
 import { PageState } from '../../models/workexec.models';
 
@@ -31,7 +31,7 @@ export class EstimateCreatePageComponent implements OnInit {
   private readonly router   = inject(Router);
   private readonly fb       = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly customerApi = inject(CustomerAPIService);
+  private readonly crm = inject(CrmService);
   private readonly snapshotsApi = inject(CRMSnapshotsService);
   private readonly vehiclesApi = inject(CRMVehiclesService);
 
@@ -39,7 +39,7 @@ export class EstimateCreatePageComponent implements OnInit {
   readonly errorMessage = signal<string | null>(null);
   readonly fieldErrors  = signal<Record<string, string>>({});
 
-  readonly allCustomers = signal<CustomerDTO[]>([]);
+  readonly allCustomers = signal<PartyDetail[]>([]);
   readonly customerDisplayName = signal('');
   readonly showCustomerSuggestions = signal(false);
 
@@ -51,14 +51,15 @@ export class EstimateCreatePageComponent implements OnInit {
 
   readonly addVehicleOption = ADD_VEHICLE_OPTION;
 
-  readonly customerSuggestions = computed<CustomerDTO[]>(() => {
+  readonly customerSuggestions = computed<PartyDetail[]>(() => {
     const q = this.customerDisplayName().trim().toLowerCase();
     const all = this.allCustomers();
     if (!q) return all.slice(0, MAX_SUGGESTIONS);
-    return all.filter(c => {
-      const name = `${c.firstName ?? ''} ${c.lastName ?? ''}`.toLowerCase();
-      const customerNumber = (c.customerNumber ?? '').toLowerCase();
-      return name.includes(q) || customerNumber.includes(q);
+    return all.filter(p => {
+      const name = (p.legalName ?? '').toLowerCase();
+      const dba = (p.dba ?? '').toLowerCase();
+      const customerNumber = (p.customerNumber ?? '').toLowerCase();
+      return name.includes(q) || dba.includes(q) || customerNumber.includes(q);
     }).slice(0, MAX_SUGGESTIONS);
   });
 
@@ -76,13 +77,12 @@ export class EstimateCreatePageComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    // name/email left undefined: unfiltered listing (server-side search params added in #663).
-    this.customerApi.getAllCustomers({ page: 0, size: 200 }, undefined, undefined, undefined, 'body', false, {
-      transferCache: false,
-    })
+    // Load CRM parties (the canonical customer directory). Client-side filtered
+    // below; server-side name search can replace this when typeahead paging lands.
+    this.crm.browseParties({ page: 0, size: 200 })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: page => this.allCustomers.set(page.content ?? []),
+        next: page => this.allCustomers.set(page.parties ?? []),
         error: () => {},
       });
 
@@ -106,10 +106,10 @@ export class EstimateCreatePageComponent implements OnInit {
     setTimeout(() => this.showCustomerSuggestions.set(false), 150);
   }
 
-  selectCustomer(customer: CustomerDTO): void {
-    const id = customer.id ?? '';
+  selectCustomer(party: PartyDetail): void {
+    const id = party.partyId ?? '';
     this.form.patchValue({ customerId: id });
-    this.customerDisplayName.set(`${customer.firstName} ${customer.lastName}`);
+    this.customerDisplayName.set(this.customerLabel(party));
     this.showCustomerSuggestions.set(false);
     this.resetVehicleSelection();
 
@@ -123,13 +123,18 @@ export class EstimateCreatePageComponent implements OnInit {
       )
       .subscribe(snapshot => {
         const vehicles: VehicleSummary[] = (snapshot as { vehicles?: VehicleSummary[] } | null)?.vehicles ?? [];
-        if (vehicles.length === 0 && customer.vehicleVins?.length) {
-          // Fallback: build VehicleSummary stubs from VIN strings on the CustomerDTO
-          this.customerVehicles.set(customer.vehicleVins.map(vin => ({ vin })) as VehicleSummary[]);
+        if (vehicles.length === 0 && party.vehicles?.length) {
+          // Fallback: vehicle refs carried on the directory row (vehicleId + vin + make/model/year)
+          this.customerVehicles.set(party.vehicles as VehicleSummary[]);
         } else {
           this.customerVehicles.set(vehicles);
         }
       });
+  }
+
+  /** Display label for a party row: legal name plus DBA / customer number when present. */
+  customerLabel(party: PartyDetail): string {
+    return party.dba ? `${party.legalName} (${party.dba})` : party.legalName;
   }
 
   /** Human-readable label for a vehicle dropdown option. */


### PR DESCRIPTION
## Summary

The New Estimate page (`/app/workexec/estimates/new`) customer typeahead pulled from the **legacy `CustomerAPIService.getAllCustomers` (`CustomerDTO`)** endpoint. That set does not match the **CRM party directory** shown on the Customers page (and used across CRM), so the suggested customers did not correspond to existing customers.

**Fix:** source the customer list from `CrmService.browseParties` (`GET /v1/crm/accounts/parties`) — the same source the CRM customer-list page uses.

- Renders `legalName` (+ `DBA`) and `customerNumber`.
- Selects by `partyId`, so the estimate's `crmPartyId`/`customerId` links to the real CRM party.
- Vehicle fallback (when the CRM snapshot has none) now uses the party's vehicle refs (`vehicleId` + VIN + make/model/year) instead of bare VIN stubs.
- Vehicle dropdown + add-vehicle flow (PR #65) unchanged.

## Validation

- [x] `npx tsc --noEmit` — no errors
- [x] `estimate-create-page.component.spec.ts` — 12/12 pass (new test: parties suggested by legal name / customer number, selected by `partyId`, snapshot fetch fired)
- [ ] `npm run build` (full)
- [ ] Manual: confirm dropdown now lists the same customers as `/app/crm` directory

## Accessibility Verification

- No structural a11y change; existing labels, `role="listbox"`/`option`, and `aria-describedby` error bindings retained. Manual keyboard/SR smoke pending.

## Notes / Follow-ups

- Still preloads up to 200 parties and filters client-side; server-side typeahead search via `browseParties({ name })` is the natural follow-up (prior #663 TODO) and would drop the 200-row cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
