### PR TITLE
fix(workexec): load estimate customer vehicles from list endpoint

### DIFF
--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
@@ -104,9 +104,13 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     expect(component.form.controls.customerId.value).toBe('p-1');
     expect(component.customerDisplayName()).toBe('Acme Towing');
 
-    // selecting a customer triggers a CRM snapshot fetch for that party's vehicles
-    http.expectOne(r => r.method === 'GET' && r.url.includes('/snapshot') && r.url.includes('p-1'))
-      .flush({ vehicles: [] });
+    // selecting a customer loads that customer's complete vehicle list
+    http.expectOne(r => r.method === 'GET' && r.url.endsWith('/v1/crm/p-1/vehicles'))
+      .flush([
+        { vehicleId: 'v-1', vin: '1ABC', make: 'Ford', model: 'F-150', year: 2019 },
+        { vehicleId: 'v-2', vin: '2XYZ', make: 'GMC', model: 'Sierra', year: 2021 },
+      ]);
+    expect(component.customerVehicles().length).toBe(2);
   });
 
   it('should reveal inline add-vehicle form when add option chosen', () => {

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -5,7 +5,6 @@ import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { catchError, of } from 'rxjs';
 import {
-  CRMSnapshotsService,
   CRMVehiclesService,
   CreateVehicleForPartyRequest,
   VehicleResponse,
@@ -32,7 +31,6 @@ export class EstimateCreatePageComponent implements OnInit {
   private readonly fb       = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
   private readonly crm = inject(CrmService);
-  private readonly snapshotsApi = inject(CRMSnapshotsService);
   private readonly vehiclesApi = inject(CRMVehiclesService);
 
   readonly state        = signal<PageState>('idle');
@@ -115,21 +113,14 @@ export class EstimateCreatePageComponent implements OnInit {
 
     if (!id) { return; }
 
-    // Try CRM snapshot to get full VehicleSummary objects (vehicleId + vin + make/model/year)
-    this.snapshotsApi.fetchByParty(id, 'body', false, { transferCache: false })
+    // Authoritative, complete vehicle list for the customer (the CRM snapshot does
+    // not reliably carry vehicles for commercial accounts).
+    this.vehiclesApi.listVehiclesForCustomer(id, 'body', false, { transferCache: false })
       .pipe(
         takeUntilDestroyed(this.destroyRef),
-        catchError(() => of(null)),
+        catchError(() => of([] as VehicleSummary[])),
       )
-      .subscribe(snapshot => {
-        const vehicles: VehicleSummary[] = (snapshot as { vehicles?: VehicleSummary[] } | null)?.vehicles ?? [];
-        if (vehicles.length === 0 && party.vehicles?.length) {
-          // Fallback: vehicle refs carried on the directory row (vehicleId + vin + make/model/year)
-          this.customerVehicles.set(party.vehicles as VehicleSummary[]);
-        } else {
-          this.customerVehicles.set(vehicles);
-        }
-      });
+      .subscribe(vehicles => this.customerVehicles.set(vehicles ?? []));
   }
 
   /** Display label for a party row: legal name plus DBA / customer number when present. */


### PR DESCRIPTION
## Summary

Selecting a customer with vehicles on the New Estimate page showed an **empty vehicle dropdown** (e.g. Blue Ridge Landscaping with 12 vehicles).

**Root cause:** vehicles were read from the CRM snapshot (`CRMSnapshotsService.fetchByParty`), whose `vehicles` array does not reliably populate for commercial accounts.

**Fix:** load vehicles from the authoritative `CRMVehiclesService.listVehiclesForCustomer` endpoint (`GET /v1/crm/{customerId}/vehicles`) which returns the complete `VehicleSummary[]`. Removes the snapshot dependency and the directory-row vehicle fallback (browse rows only carry `vehicleCount`, never the list).

## Validation

- [x] `npx tsc --noEmit` — no errors
- [x] `estimate-create-page.component.spec.ts` — 12/12 pass (party-select test now asserts the vehicle-list GET and a populated dropdown)
- [ ] `npm run build` (full)
- [ ] Manual: select Blue Ridge Landscaping → 12 vehicles listed

## Notes / Follow-ups

- Add-new-vehicle flow already posts to the same customer-scoped endpoint family (`POST /v1/crm/{customerId}/vehicles`), so created vehicles remain consistent with this list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
