### PR TITLE
feat(workexec): catalog part search with MSRP auto-fill on estimate parts

### DIFF
--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.css
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.css
@@ -205,20 +205,16 @@
   box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.12);
 }
 
-.part-search__option-btn {
+.part-search__option {
   display: flex;
   align-items: baseline;
   gap: 0.75rem;
-  width: 100%;
   padding: 0.5rem 0.75rem;
-  background: transparent;
-  border: none;
-  text-align: left;
   cursor: pointer;
 }
 
-.part-search__option-btn:hover,
-.part-search__option-btn:focus-visible {
+.part-search__option:hover,
+.part-search__option--active {
   background: var(--surface-hover, rgba(0, 52, 111, 0.06));
 }
 

--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.css
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.css
@@ -191,6 +191,58 @@
   align-items: center;
 }
 
+/* Catalog part search */
+.part-search { position: relative; }
+
+.part-search__results {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  background: var(--surface-2, #fff);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.12);
+}
+
+.part-search__option-btn {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.part-search__option-btn:hover,
+.part-search__option-btn:focus-visible {
+  background: var(--surface-hover, rgba(0, 52, 111, 0.06));
+}
+
+.part-search__name { font-weight: 600; }
+.part-search__sku  { font-size: 0.8125rem; color: var(--text-muted, #5a6b7b); font-family: monospace; }
+.part-search__cat  { font-size: 0.8125rem; color: var(--text-muted, #5a6b7b); margin-left: auto; }
+
+.part-search__selected {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+}
+
+.part-search__clear {
+  background: transparent;
+  border: none;
+  color: var(--brand-primary, #00346f);
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+}
+
 .btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .btn--accent {

--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.html
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.html
@@ -60,6 +60,48 @@
 
       <form [formGroup]="addForm" (ngSubmit)="addItem()" novalidate aria-label="Add part form" class="add-form">
 
+        <!-- Catalog Part Search (name / SKU) -->
+        <div class="field-row">
+          <div class="field-group field-group--grow part-search">
+            <label for="partSearch" class="field-label">Search Catalog <span class="field-optional">(name or SKU)</span></label>
+            <input id="partSearch" type="text" class="field-input"
+              role="combobox" [attr.aria-expanded]="searchState() === 'ready'" aria-controls="partSearchResults" autocomplete="off"
+              placeholder="Search parts by name or SKU…"
+              [value]="searchQuery()" (input)="onSearchChange($any($event.target).value)" />
+
+            @if (searchState() === 'loading') {
+              <p class="hint-text" aria-busy="true">Searching…</p>
+            }
+            @if (searchState() === 'empty') {
+              <p class="hint-text">No matching parts found.</p>
+            }
+            @if (searchState() === 'error') {
+              <p class="field-error" role="alert">Part search failed. Try again.</p>
+            }
+            @if (searchState() === 'ready') {
+              <ul id="partSearchResults" class="part-search__results" role="listbox" aria-label="Matching parts">
+                @for (part of searchResults(); track part.id) {
+                  <li role="option" class="part-search__option">
+                    <button type="button" class="part-search__option-btn" (click)="selectPart(part)">
+                      <span class="part-search__name">{{ part.name }}</span>
+                      @if (part.sku) { <span class="part-search__sku">{{ part.sku }}</span> }
+                      @if (part.category) { <span class="part-search__cat">{{ part.category }}</span> }
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
+
+            @if (selectedPart()) {
+              <p class="part-search__selected">
+                Linked: <strong>{{ selectedPart()!.name }}</strong>
+                @if (selectedPart()!.sku) { <span class="part-search__sku">{{ selectedPart()!.sku }}</span> }
+                <button type="button" class="part-search__clear" (click)="clearSelectedPart()">Clear</button>
+              </p>
+            }
+          </div>
+        </div>
+
         <div class="field-row">
           <div class="field-group field-group--grow">
             <label for="partDescription" class="field-label">Description <span class="required" aria-hidden="true">*</span></label>
@@ -89,6 +131,13 @@
             @if (addForm.controls.unitPrice.invalid && addForm.controls.unitPrice.touched) {
               <p class="field-error" role="alert">Valid price required.</p>
             }
+            @if (priceState() === 'loading') {
+              <p class="hint-text" aria-busy="true">Fetching MSRP…</p>
+            } @else if (priceState() === 'filled') {
+              <p class="hint-text">Auto-filled from MSRP.</p>
+            } @else if (priceState() === 'none') {
+              <p class="hint-text">No MSRP on file — enter price.</p>
+            }
           </div>
         </div>
 
@@ -98,8 +147,9 @@
             <input id="partTaxCode" type="text" formControlName="taxCode" class="field-input" placeholder="e.g. TX-GENERAL" />
           </div>
           <div class="field-group field-group--grow">
-            <label for="partProductId" class="field-label">Catalog Product ID <span class="field-optional">(optional)</span></label>
-            <input id="partProductId" type="text" formControlName="productId" class="field-input" placeholder="Product catalog reference" />
+            <label for="partProductId" class="field-label">Catalog Product ID <span class="field-optional">(set by search)</span></label>
+            <input id="partProductId" type="text" formControlName="productId" class="field-input" readonly
+              placeholder="Linked via catalog search" />
           </div>
         </div>
 

--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.html
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.html
@@ -65,9 +65,11 @@
           <div class="field-group field-group--grow part-search">
             <label for="partSearch" class="field-label">Search Catalog <span class="field-optional">(name or SKU)</span></label>
             <input id="partSearch" type="text" class="field-input"
-              role="combobox" [attr.aria-expanded]="searchState() === 'ready'" aria-controls="partSearchResults" autocomplete="off"
+              role="combobox" aria-autocomplete="list" autocomplete="off"
+              [attr.aria-expanded]="searchState() === 'ready'" aria-controls="partSearchResults"
+              [attr.aria-activedescendant]="searchState() === 'ready' && activeIndex() >= 0 ? ('partSearch-opt-' + activeIndex()) : null"
               placeholder="Search parts by name or SKU…"
-              [value]="searchQuery()" (input)="onSearchChange($any($event.target).value)" />
+              [value]="searchQuery()" (input)="onSearchChange($any($event.target).value)" (keydown)="onSearchKeydown($event)" />
 
             @if (searchState() === 'loading') {
               <p class="hint-text" aria-busy="true">Searching…</p>
@@ -80,13 +82,15 @@
             }
             @if (searchState() === 'ready') {
               <ul id="partSearchResults" class="part-search__results" role="listbox" aria-label="Matching parts">
-                @for (part of searchResults(); track part.id) {
-                  <li role="option" class="part-search__option">
-                    <button type="button" class="part-search__option-btn" (click)="selectPart(part)">
-                      <span class="part-search__name">{{ part.name }}</span>
-                      @if (part.sku) { <span class="part-search__sku">{{ part.sku }}</span> }
-                      @if (part.category) { <span class="part-search__cat">{{ part.category }}</span> }
-                    </button>
+                @for (part of searchResults(); track part.id; let i = $index) {
+                  <li role="option" class="part-search__option"
+                    [id]="'partSearch-opt-' + i"
+                    [class.part-search__option--active]="i === activeIndex()"
+                    [attr.aria-selected]="i === activeIndex()"
+                    (mousedown)="selectPart(part)">
+                    <span class="part-search__name">{{ part.name }}</span>
+                    @if (part.sku) { <span class="part-search__sku">{{ part.sku }}</span> }
+                    @if (part.category) { <span class="part-search__cat">{{ part.category }}</span> }
                   </li>
                 }
               </ul>

--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.ts
@@ -43,6 +43,7 @@ export class EstimatePartsPageComponent implements OnInit {
   readonly searchResults = signal<ProductSummary[]>([]);
   readonly selectedPart  = signal<ProductSummary | null>(null);
   readonly priceState    = signal<'idle' | 'loading' | 'filled' | 'none'>('idle');
+  readonly activeIndex   = signal(-1);
   private readonly searchChanges$ = new Subject<string>();
 
   estimateId = '';
@@ -68,13 +69,36 @@ export class EstimatePartsPageComponent implements OnInit {
 
   onSearchChange(query: string): void {
     this.searchQuery.set(query);
+    this.activeIndex.set(-1);
     this.searchChanges$.next(query);
+  }
+
+  onSearchKeydown(event: KeyboardEvent): void {
+    const results = this.searchResults();
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.activeIndex.set(Math.min(this.activeIndex() + 1, results.length - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex.set(Math.max(this.activeIndex() - 1, 0));
+    } else if (event.key === 'Enter') {
+      const idx = this.activeIndex();
+      if (idx >= 0 && idx < results.length) {
+        event.preventDefault();
+        this.selectPart(results[idx]);
+      }
+    } else if (event.key === 'Escape') {
+      this.searchResults.set([]);
+      this.searchState.set('idle');
+      this.activeIndex.set(-1);
+    }
   }
 
   private runPartSearch(query: string): void {
     if (!query.trim()) {
       this.searchResults.set([]);
       this.searchState.set('idle');
+      this.activeIndex.set(-1);
       return;
     }
     this.searchState.set('loading');
@@ -83,6 +107,7 @@ export class EstimatePartsPageComponent implements OnInit {
       .subscribe({
         next: products => {
           this.searchResults.set(products);
+          this.activeIndex.set(-1);
           this.searchState.set(products.length > 0 ? 'ready' : 'empty');
         },
         error: () => {
@@ -97,6 +122,7 @@ export class EstimatePartsPageComponent implements OnInit {
     this.addForm.patchValue({ description: part.name, productId: part.id });
     this.searchResults.set([]);
     this.searchState.set('idle');
+    this.activeIndex.set(-1);
     this.searchQuery.set(part.sku ? `${part.name} (${part.sku})` : part.name);
 
     // Auto-fill unit price from the product's active MSRP (no price on the summary/product).
@@ -123,6 +149,7 @@ export class EstimatePartsPageComponent implements OnInit {
     this.searchResults.set([]);
     this.searchState.set('idle');
     this.priceState.set('idle');
+    this.activeIndex.set(-1);
     this.addForm.patchValue({ productId: '' });
   }
 

--- a/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-parts/estimate-parts-page.component.ts
@@ -3,9 +3,12 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { switchMap } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import { WorkexecService } from '../../services/workexec.service';
 import { EstimateItemResponse, EstimateResponse, PageState } from '../../models/workexec.models';
+import { ProductCatalogService } from '../../../product/services/product-catalog.service';
+import { ProductSummary } from '../../../product/models/product.models';
 
 /**
  * EstimatePartsPageComponent — Story 238 (CAP-002)
@@ -21,6 +24,7 @@ import { EstimateItemResponse, EstimateResponse, PageState } from '../../models/
 })
 export class EstimatePartsPageComponent implements OnInit {
   private readonly workexec    = inject(WorkexecService);
+  private readonly catalog      = inject(ProductCatalogService);
   private readonly route       = inject(ActivatedRoute);
   private readonly router      = inject(Router);
   private readonly fb          = inject(FormBuilder);
@@ -33,6 +37,14 @@ export class EstimatePartsPageComponent implements OnInit {
   readonly errorMessage  = signal<string | null>(null);
   readonly fieldErrors   = signal<Record<string, string>>({});
 
+  // Catalog part search (name / SKU) — mirrors the product catalog list search.
+  readonly searchQuery   = signal('');
+  readonly searchState   = signal<'idle' | 'loading' | 'empty' | 'ready' | 'error'>('idle');
+  readonly searchResults = signal<ProductSummary[]>([]);
+  readonly selectedPart  = signal<ProductSummary | null>(null);
+  readonly priceState    = signal<'idle' | 'loading' | 'filled' | 'none'>('idle');
+  private readonly searchChanges$ = new Subject<string>();
+
   estimateId = '';
 
   readonly addForm = this.fb.nonNullable.group({
@@ -43,9 +55,75 @@ export class EstimatePartsPageComponent implements OnInit {
     productId:   [''],
   });
 
+  constructor() {
+    this.searchChanges$
+      .pipe(debounceTime(300), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
+      .subscribe(query => this.runPartSearch(query));
+  }
+
   ngOnInit(): void {
     this.estimateId = this.route.snapshot.paramMap.get('estimateId') ?? '';
     this.loadEstimate();
+  }
+
+  onSearchChange(query: string): void {
+    this.searchQuery.set(query);
+    this.searchChanges$.next(query);
+  }
+
+  private runPartSearch(query: string): void {
+    if (!query.trim()) {
+      this.searchResults.set([]);
+      this.searchState.set('idle');
+      return;
+    }
+    this.searchState.set('loading');
+    this.catalog.searchProducts(query)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: products => {
+          this.searchResults.set(products);
+          this.searchState.set(products.length > 0 ? 'ready' : 'empty');
+        },
+        error: () => {
+          this.searchResults.set([]);
+          this.searchState.set('error');
+        },
+      });
+  }
+
+  selectPart(part: ProductSummary): void {
+    this.selectedPart.set(part);
+    this.addForm.patchValue({ description: part.name, productId: part.id });
+    this.searchResults.set([]);
+    this.searchState.set('idle');
+    this.searchQuery.set(part.sku ? `${part.name} (${part.sku})` : part.name);
+
+    // Auto-fill unit price from the product's active MSRP (no price on the summary/product).
+    this.priceState.set('loading');
+    this.catalog.getActiveMsrp(part.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: msrp => {
+          if (msrp?.amount != null) {
+            this.addForm.patchValue({ unitPrice: msrp.amount });
+            this.priceState.set('filled');
+          } else {
+            this.priceState.set('none');
+          }
+        },
+        // No active MSRP (e.g. 404) — leave the user-entered price untouched.
+        error: () => this.priceState.set('none'),
+      });
+  }
+
+  clearSelectedPart(): void {
+    this.selectedPart.set(null);
+    this.searchQuery.set('');
+    this.searchResults.set([]);
+    this.searchState.set('idle');
+    this.priceState.set('idle');
+    this.addForm.patchValue({ productId: '' });
   }
 
   loadEstimate(): void {
@@ -93,6 +171,11 @@ export class EstimatePartsPageComponent implements OnInit {
         this.items.set(est.items ?? []);
         this.saveState.set('success');
         this.addForm.reset({ quantity: 1, unitPrice: 0 });
+        this.selectedPart.set(null);
+        this.searchQuery.set('');
+        this.searchResults.set([]);
+        this.searchState.set('idle');
+        this.priceState.set('idle');
       },
       error: err => {
         this.saveState.set('error');


### PR DESCRIPTION
## Summary
Estimate parts page (`/app/workexec/estimates/:id/parts`) had no catalog search — only manual line-item fields and a raw "Catalog Product ID" UUID box, so users could not find parts. This wires the product catalog search (name / SKU) into the Add Part form, mirroring the product catalog list page.

## Changes
- Debounced (300ms) `ProductCatalogService.searchProducts(query)` — same backend op as `/app/product/catalog`, searches name + SKU
- Results listbox (name · SKU · category); selecting a result fills description + productId and locks the productId field to the selection
- On select, fetch active MSRP (`getActiveMsrp`) to auto-fill unit price, with loading / filled / no-MSRP hint states; price remains editable
- Resets search + price state on clear and on successful add

## Notes
- Reuses existing `@durion-sdk/catalog` operations — no backend or contract change
- `ProductCatalogService` is `providedIn: 'root'`; cross-feature inject only

## Test
- `ng test` for the component — 5 passed, build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)