### PR TITLE
feat(crm): reusable customer typeahead; replace raw Customer ID inputs

### DIFF
--- a/src/app/features/accounting/pages/credit-memo/credit-memo-create/credit-memo-create-page.component.html
+++ b/src/app/features/accounting/pages/credit-memo/credit-memo-create/credit-memo-create-page.component.html
@@ -14,8 +14,8 @@
     <label for="original-invoice">{{ 'ACCOUNTING.CREDIT_MEMO_CREATE.FIELD_ORIGINAL_INVOICE_ID' | translate }}</label>
     <input id="original-invoice" formControlName="originalInvoiceId" />
 
-    <label for="customer-id">{{ 'ACCOUNTING.CREDIT_MEMO_CREATE.FIELD_CUSTOMER_ID' | translate }}</label>
-    <input id="customer-id" formControlName="customerId" />
+    <app-customer-lookup formControlName="customerId" inputId="customer-id"
+      [label]="'ACCOUNTING.CREDIT_MEMO_CREATE.FIELD_CUSTOMER_ID' | translate" [required]="true" />
 
     <label for="credit-amount">{{ 'ACCOUNTING.CREDIT_MEMO_CREATE.FIELD_CREDIT_AMOUNT' | translate }}</label>
     <input id="credit-amount" type="number" class="amount-input" formControlName="creditAmount" />

--- a/src/app/features/accounting/pages/credit-memo/credit-memo-create/credit-memo-create-page.component.ts
+++ b/src/app/features/accounting/pages/credit-memo/credit-memo-create/credit-memo-create-page.component.ts
@@ -12,6 +12,7 @@ import {
 import { TranslatePipe } from '@ngx-translate/core';
 import { CreditMemo } from '../../../models/accounting.models';
 import { AccountingService } from '../../../services/accounting.service';
+import { CustomerLookupComponent } from '../../../../crm/components/customer-lookup/customer-lookup.component';
 
 function creditAmountWithinBalanceValidator(): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
@@ -30,7 +31,7 @@ type CreditMemoCreateState = 'idle' | 'submitting' | 'success' | 'error' | 'forb
 @Component({
   selector: 'app-credit-memo-create-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [CommonModule, ReactiveFormsModule, TranslatePipe, CustomerLookupComponent],
   templateUrl: './credit-memo-create-page.component.html',
   styleUrl: './credit-memo-create-page.component.css',
 })

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.css
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.css
@@ -1,0 +1,53 @@
+.customer-lookup { position: relative; display: flex; flex-direction: column; gap: var(--space-1, 0.25rem); }
+
+/* Self-contained field styles (component styles are scoped, so the host page's
+   .field-* rules do not reach this template). */
+.field-label { font-size: 0.8125rem; font-weight: 600; color: var(--currentTextColor); }
+.required { color: var(--functional-error-red, #c84c47); margin-left: 2px; }
+.field-input {
+  background: var(--input-background, #fff);
+  border: none;
+  border-bottom: 2px solid var(--input-border, var(--border-color));
+  border-radius: 0;
+  padding: var(--space-2, 0.5rem) 0;
+  font-size: 0.9375rem;
+  color: var(--currentTextColor);
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+}
+.field-input:focus { border-bottom-color: var(--input-focus-border, var(--accentA400)); }
+.field-input:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.customer-lookup__list {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  max-height: 16rem;
+  overflow-y: auto;
+  background: var(--surface-2, #fff);
+  border-radius: 0.25rem;
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.12);
+}
+
+.customer-lookup__option {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+}
+
+.customer-lookup__option:hover,
+.customer-lookup__option--active {
+  background: var(--surface-hover, rgba(0, 52, 111, 0.06));
+}
+
+.customer-lookup__name { font-weight: 600; }
+.customer-lookup__num { font-size: 0.8125rem; color: var(--text-muted, #5a6b7b); font-family: monospace; }

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.html
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.html
@@ -1,0 +1,35 @@
+<div class="customer-lookup">
+  <label [attr.for]="inputId" class="field-label">
+    {{ label }}
+    @if (required) { <span class="required" aria-hidden="true">*</span> }
+  </label>
+
+  <input [id]="inputId" type="text" class="field-input"
+    role="combobox" aria-autocomplete="list" autocomplete="off"
+    [attr.aria-expanded]="showList() && suggestions().length > 0"
+    [attr.aria-controls]="inputId + '-listbox'"
+    [attr.aria-activedescendant]="showList() && activeIndex() >= 0 ? (inputId + '-opt-' + activeIndex()) : null"
+    [attr.aria-required]="required ? 'true' : null"
+    [value]="query()"
+    [disabled]="disabled()"
+    [placeholder]="placeholder"
+    (input)="onInput($any($event.target).value)"
+    (focus)="onFocus()"
+    (blur)="onBlur()"
+    (keydown)="onKeydown($event)" />
+
+  @if (showList() && suggestions().length > 0) {
+    <ul [id]="inputId + '-listbox'" class="customer-lookup__list" role="listbox" [attr.aria-label]="label">
+      @for (party of suggestions(); track party.partyId; let i = $index) {
+        <li role="option" class="customer-lookup__option"
+          [id]="inputId + '-opt-' + i"
+          [class.customer-lookup__option--active]="i === activeIndex()"
+          [attr.aria-selected]="i === activeIndex()"
+          (mousedown)="select(party)">
+          <span class="customer-lookup__name">{{ party.legalName }}{{ party.dba ? ' (' + party.dba + ')' : '' }}</span>
+          @if (party.customerNumber) { <span class="customer-lookup__num">{{ party.customerNumber }}</span> }
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.spec.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { CustomerLookupComponent } from './customer-lookup.component';
+import { CrmService } from '../../services/crm.service';
+import { PartyDetail } from '../../models/crm.models';
+
+const PARTIES: PartyDetail[] = [
+  { partyId: 'p1', legalName: 'Acme Tire Co', dba: 'Acme', customerNumber: 'CUST-CP-001' },
+  { partyId: 'p2', legalName: 'Blue Ridge Landscaping', customerNumber: 'CUST-CP-004' },
+  { partyId: 'p3', legalName: 'Angela Freeman', customerNumber: 'CUST-PP-004' },
+];
+
+describe('CustomerLookupComponent', () => {
+  let fixture: ComponentFixture<CustomerLookupComponent>;
+  let component: CustomerLookupComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CustomerLookupComponent],
+      providers: [
+        { provide: CrmService, useValue: { browseParties: () => of({ parties: PARTIES }) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CustomerLookupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // ngOnInit → load parties
+  });
+
+  it('loads the party directory on init', () => {
+    expect(component.allCustomers().length).toBe(3);
+  });
+
+  it('filters suggestions by legal name, DBA, and customer number', () => {
+    component.onInput('acme');
+    expect(component.suggestions().map(p => p.partyId)).toEqual(['p1']);
+
+    component.onInput('CUST-CP-004');
+    expect(component.suggestions().map(p => p.partyId)).toEqual(['p2']);
+  });
+
+  it('emits the selected party id and shows a readable label', () => {
+    const seen: string[] = [];
+    component.registerOnChange(v => seen.push(v));
+
+    component.select(PARTIES[0]);
+
+    expect(seen).toEqual(['p1']);
+    expect(component.value()).toBe('p1');
+    expect(component.query()).toContain('Acme Tire Co');
+    expect(component.query()).toContain('CUST-CP-001');
+  });
+
+  it('clears the value when the user edits the text', () => {
+    component.select(PARTIES[0]);
+    const seen: string[] = [];
+    component.registerOnChange(v => seen.push(v));
+
+    component.onInput('blu');
+
+    expect(component.value()).toBe('');
+    expect(seen).toEqual(['']);
+  });
+
+  it('writeValue resolves the display label for a known id', () => {
+    component.writeValue('p3');
+    expect(component.value()).toBe('p3');
+    expect(component.query()).toContain('Angela Freeman');
+  });
+
+  it('Enter selects the active suggestion', () => {
+    component.onInput('cust');
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+    const expected = component.suggestions()[0].partyId;
+    component.onKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
+    expect(component.value()).toBe(expected);
+  });
+});

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
@@ -1,0 +1,153 @@
+import {
+  Component, inject, signal, computed, forwardRef, Input, OnInit, DestroyRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CrmService } from '../../services/crm.service';
+import { PartyDetail } from '../../models/crm.models';
+
+const MAX_SUGGESTIONS = 8;
+
+/**
+ * Reusable customer typeahead bound as a reactive-form control. The control
+ * value is the selected party id (the canonical customerId). Loads the CRM
+ * party directory once and filters client-side by legal name, DBA, and
+ * customer number — replacing raw "Customer ID" text entry across the app.
+ */
+@Component({
+  selector: 'app-customer-lookup',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './customer-lookup.component.html',
+  styleUrl: './customer-lookup.component.css',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CustomerLookupComponent),
+      multi: true,
+    },
+  ],
+})
+export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
+  private readonly crm = inject(CrmService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  @Input() inputId = 'customer-lookup';
+  @Input() label = 'Customer';
+  @Input() required = false;
+  @Input() placeholder = 'Search by name or customer number…';
+
+  readonly allCustomers = signal<PartyDetail[]>([]);
+  readonly query        = signal('');
+  readonly showList     = signal(false);
+  readonly activeIndex  = signal(-1);
+  readonly disabled     = signal(false);
+  readonly value        = signal('');
+
+  private pendingId: string | null = null;
+  private onChange: (value: string) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  readonly suggestions = computed<PartyDetail[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const all = this.allCustomers();
+    if (!q) return all.slice(0, MAX_SUGGESTIONS);
+    return all.filter(p => {
+      const name = (p.legalName ?? '').toLowerCase();
+      const dba = (p.dba ?? '').toLowerCase();
+      const num = (p.customerNumber ?? '').toLowerCase();
+      return name.includes(q) || dba.includes(q) || num.includes(q);
+    }).slice(0, MAX_SUGGESTIONS);
+  });
+
+  ngOnInit(): void {
+    this.crm.browseParties({ page: 0, size: 200 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: page => {
+          this.allCustomers.set(page.parties ?? []);
+          if (this.pendingId) {
+            this.applyDisplayForId(this.pendingId);
+            this.pendingId = null;
+          }
+        },
+        error: () => {},
+      });
+  }
+
+  // ControlValueAccessor ----------------------------------------------------
+  writeValue(id: string | null): void {
+    const next = id ?? '';
+    this.value.set(next);
+    if (!next) {
+      this.query.set('');
+    } else if (this.allCustomers().length > 0) {
+      this.applyDisplayForId(next);
+    } else {
+      this.pendingId = next;
+    }
+  }
+
+  registerOnChange(fn: (value: string) => void): void { this.onChange = fn; }
+  registerOnTouched(fn: () => void): void { this.onTouched = fn; }
+  setDisabledState(isDisabled: boolean): void { this.disabled.set(isDisabled); }
+
+  // Interaction -------------------------------------------------------------
+  onInput(text: string): void {
+    this.query.set(text);
+    this.value.set('');
+    this.onChange('');
+    this.activeIndex.set(-1);
+    this.showList.set(true);
+  }
+
+  onFocus(): void {
+    if (this.allCustomers().length > 0) this.showList.set(true);
+  }
+
+  onBlur(): void {
+    this.onTouched();
+    setTimeout(() => this.showList.set(false), 150);
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    const items = this.suggestions();
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.showList.set(true);
+      this.activeIndex.set(Math.min(this.activeIndex() + 1, items.length - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex.set(Math.max(this.activeIndex() - 1, 0));
+    } else if (event.key === 'Enter') {
+      const idx = this.activeIndex();
+      if (idx >= 0 && idx < items.length) {
+        event.preventDefault();
+        this.select(items[idx]);
+      }
+    } else if (event.key === 'Escape') {
+      this.showList.set(false);
+      this.activeIndex.set(-1);
+    }
+  }
+
+  select(party: PartyDetail): void {
+    const id = party.partyId ?? '';
+    this.value.set(id);
+    this.query.set(this.labelFor(party));
+    this.onChange(id);
+    this.showList.set(false);
+    this.activeIndex.set(-1);
+  }
+
+  labelFor(party: PartyDetail): string {
+    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
+    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
+  }
+
+  private applyDisplayForId(id: string): void {
+    const party = this.allCustomers().find(p => p.partyId === id);
+    if (party) this.query.set(this.labelFor(party));
+  }
+}

--- a/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.html
+++ b/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.html
@@ -27,12 +27,10 @@
       <form [formGroup]="signerForm" novalidate aria-label="Signer information" class="signer-form">
         <div class="field-row">
           <div class="field-group field-group--grow">
-            <label for="customerId" class="field-label">Customer ID <span class="required" aria-hidden="true">*</span></label>
-            <input id="customerId" type="text" formControlName="customerId" class="field-input"
-              [class.field-input--error]="signerForm.controls.customerId.invalid && signerForm.controls.customerId.touched"
-              placeholder="Customer identifier" aria-required="true" />
+            <app-customer-lookup formControlName="customerId" inputId="customerId"
+              label="Customer" [required]="true" />
             @if (signerForm.controls.customerId.invalid && signerForm.controls.customerId.touched) {
-              <p class="field-error" role="alert">Customer ID is required.</p>
+              <p class="field-error" role="alert">Customer is required.</p>
             }
           </div>
           <div class="field-group field-group--grow">

--- a/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.ts
+++ b/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.ts
@@ -8,6 +8,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { WorkexecService } from '../../services/workexec.service';
 import { EstimateResponse, PageState } from '../../models/workexec.models';
+import { CustomerLookupComponent } from '../../../crm/components/customer-lookup/customer-lookup.component';
 
 /**
  * ApprovalDigitalPageComponent — Story 271 (CAP-003)
@@ -24,7 +25,7 @@ import { EstimateResponse, PageState } from '../../models/workexec.models';
 @Component({
   selector: 'app-approval-digital-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, CustomerLookupComponent],
   templateUrl: './approval-digital-page.component.html',
   styleUrl: './approval-digital-page.component.css',
 })

--- a/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.html
+++ b/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.html
@@ -18,12 +18,10 @@
       <p class="approval-description">Customer is present in-person. Confirm their approval below.</p>
       <form [formGroup]="approvalForm" novalidate aria-label="In-person approval" class="approval-form">
         <div class="field-group">
-          <label for="inPersonCustomerId" class="field-label">Customer ID <span class="required" aria-hidden="true">*</span></label>
-          <input id="inPersonCustomerId" type="text" formControlName="customerId" class="field-input"
-            [class.field-input--error]="approvalForm.controls.customerId.invalid && approvalForm.controls.customerId.touched"
-            placeholder="Customer identifier" aria-required="true" />
+          <app-customer-lookup formControlName="customerId" inputId="inPersonCustomerId"
+            label="Customer" [required]="true" />
           @if (approvalForm.controls.customerId.invalid && approvalForm.controls.customerId.touched) {
-            <p class="field-error" role="alert">Customer ID is required.</p>
+            <p class="field-error" role="alert">Customer is required.</p>
           }
         </div>
         <div class="field-group">

--- a/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.ts
+++ b/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { WorkexecService } from '../../services/workexec.service';
 import { EstimateResponse, PageState } from '../../models/workexec.models';
+import { CustomerLookupComponent } from '../../../crm/components/customer-lookup/customer-lookup.component';
 
 /**
  * ApprovalInPersonPageComponent — Story 270 (CAP-003)
@@ -19,7 +20,7 @@ import { EstimateResponse, PageState } from '../../models/workexec.models';
 @Component({
   selector: 'app-approval-in-person-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, CustomerLookupComponent],
   templateUrl: './approval-in-person-page.component.html',
   styleUrl: './approval-in-person-page.component.css',
 })

--- a/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.html
+++ b/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.html
@@ -15,12 +15,10 @@
       <form [formGroup]="headerForm" novalidate aria-label="Approval header" class="header-form">
         <div class="field-row">
           <div class="field-group field-group--grow">
-            <label for="partialCustomerId" class="field-label">Customer ID <span class="required" aria-hidden="true">*</span></label>
-            <input id="partialCustomerId" type="text" formControlName="customerId" class="field-input"
-              [class.field-input--error]="headerForm.controls.customerId.invalid && headerForm.controls.customerId.touched"
-              placeholder="Customer identifier" aria-required="true" />
+            <app-customer-lookup formControlName="customerId" inputId="partialCustomerId"
+              label="Customer" [required]="true" />
             @if (headerForm.controls.customerId.invalid && headerForm.controls.customerId.touched) {
-              <p class="field-error" role="alert">Customer ID is required.</p>
+              <p class="field-error" role="alert">Customer is required.</p>
             }
           </div>
           <div class="field-group field-group--grow">

--- a/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.ts
+++ b/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { WorkexecService } from '../../services/workexec.service';
 import { EstimateItemResponse, EstimateResponse, LineItemApprovalDto, PageState } from '../../models/workexec.models';
+import { CustomerLookupComponent } from '../../../crm/components/customer-lookup/customer-lookup.component';
 
 /**
  * ApprovalPartialPageComponent — Story 269 (CAP-003)
@@ -20,7 +21,7 @@ import { EstimateItemResponse, EstimateResponse, LineItemApprovalDto, PageState 
 @Component({
   selector: 'app-approval-partial-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, CustomerLookupComponent],
   templateUrl: './approval-partial-page.component.html',
   styleUrl: './approval-partial-page.component.css',
 })


### PR DESCRIPTION
## Summary
Several screens required a raw **Customer ID** (the user had to know/paste the party UUID). This adds a reusable typeahead and swaps it in everywhere a customer is required.

## New component — `CustomerLookupComponent` (`features/crm/components/customer-lookup`)
- `ControlValueAccessor` → drops into any reactive form via `formControlName="customerId"`; the control value is the selected party id (canonical customerId).
- Loads the CRM party directory once (`crm.browseParties`, size 200) and filters client-side by **legal name, DBA, and customer number**.
- Full ARIA combobox: `aria-autocomplete`, `aria-activedescendant`, listbox/options, ArrowUp/Down/Enter/Escape.
- Self-styled (component styles are scoped) so it renders correctly in any host.

## Converted pages (customer required)
- workexec: `approval/in-person` (the reported page), `approval/partial`, `approval/digital`
- accounting: `credit-memo/create` (translated label preserved via `[label]`)

`order-cart` left unchanged — customer there is optional, not required.

## Notes
- Frontend-only; reuses the existing `crm.browseParties` SDK call (same source the New Estimate customer picker already uses). No backend/SDK change.
- `estimate-create` keeps its existing inline picker (already shipped/verified); not refactored to avoid churn on a working screen.

## Test
- New `CustomerLookupComponent` spec — 6 passed.
- Host page specs (in-person, partial, digital, credit-memo-create) — 19 passed, builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)