### PR TITLE
feat(crm): server-side customer search (lookup + estimate-create)

### DIFF
--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.css
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.css
@@ -49,5 +49,6 @@
   background: var(--surface-hover, rgba(0, 52, 111, 0.06));
 }
 
+.customer-lookup__hint { font-size: 0.8125rem; color: var(--text-muted, #5a6b7b); margin: 0.25rem 0 0; }
 .customer-lookup__name { font-weight: 600; }
 .customer-lookup__num { font-size: 0.8125rem; color: var(--text-muted, #5a6b7b); font-family: monospace; }

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.html
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.html
@@ -18,6 +18,10 @@
     (blur)="onBlur()"
     (keydown)="onKeydown($event)" />
 
+  @if (showList() && loading() && suggestions().length === 0) {
+    <p class="customer-lookup__hint" aria-busy="true">Searching…</p>
+  }
+
   @if (showList() && suggestions().length > 0) {
     <ul [id]="inputId + '-listbox'" class="customer-lookup__list" role="listbox" [attr.aria-label]="label">
       @for (party of suggestions(); track party.partyId; let i = $index) {

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.spec.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { TestBed, ComponentFixture, fakeAsync, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { CustomerLookupComponent } from './customer-lookup.component';
 import { CrmService } from '../../services/crm.service';
@@ -7,37 +7,35 @@ import { PartyDetail } from '../../models/crm.models';
 const PARTIES: PartyDetail[] = [
   { partyId: 'p1', legalName: 'Acme Tire Co', dba: 'Acme', customerNumber: 'CUST-CP-001' },
   { partyId: 'p2', legalName: 'Blue Ridge Landscaping', customerNumber: 'CUST-CP-004' },
-  { partyId: 'p3', legalName: 'Angela Freeman', customerNumber: 'CUST-PP-004' },
 ];
 
 describe('CustomerLookupComponent', () => {
   let fixture: ComponentFixture<CustomerLookupComponent>;
   let component: CustomerLookupComponent;
+  let searchParties: ReturnType<typeof vi.fn>;
+  let getParty: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    searchParties = vi.fn().mockReturnValue(of({ parties: PARTIES }));
+    getParty = vi.fn().mockReturnValue(of(PARTIES[1]));
+
     await TestBed.configureTestingModule({
       imports: [CustomerLookupComponent],
-      providers: [
-        { provide: CrmService, useValue: { browseParties: () => of({ parties: PARTIES }) } },
-      ],
+      providers: [{ provide: CrmService, useValue: { searchParties, getParty } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CustomerLookupComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges(); // ngOnInit → load parties
+    fixture.detectChanges();
   });
 
-  it('loads the party directory on init', () => {
-    expect(component.allCustomers().length).toBe(3);
-  });
-
-  it('filters suggestions by legal name, DBA, and customer number', () => {
-    component.onInput('acme');
-    expect(component.suggestions().map(p => p.partyId)).toEqual(['p1']);
-
-    component.onInput('CUST-CP-004');
-    expect(component.suggestions().map(p => p.partyId)).toEqual(['p2']);
-  });
+  it('searches server-side (debounced) on input', fakeAsync(() => {
+    component.onInput('blue');
+    expect(searchParties).not.toHaveBeenCalled(); // debounced
+    tick(250);
+    expect(searchParties).toHaveBeenCalledWith('blue');
+    expect(component.suggestions().map(p => p.partyId)).toEqual(['p1', 'p2']);
+  }));
 
   it('emits the selected party id and shows a readable label', () => {
     const seen: string[] = [];
@@ -51,28 +49,37 @@ describe('CustomerLookupComponent', () => {
     expect(component.query()).toContain('CUST-CP-001');
   });
 
-  it('clears the value when the user edits the text', () => {
+  it('clears the value when the user edits the text', fakeAsync(() => {
     component.select(PARTIES[0]);
     const seen: string[] = [];
     component.registerOnChange(v => seen.push(v));
 
     component.onInput('blu');
-
     expect(component.value()).toBe('');
     expect(seen).toEqual(['']);
+    tick(250);
+  }));
+
+  it('writeValue resolves a readable label via getParty', () => {
+    component.writeValue('p2');
+    expect(component.value()).toBe('p2');
+    expect(getParty).toHaveBeenCalledWith('p2');
+    expect(component.query()).toContain('Blue Ridge Landscaping');
   });
 
-  it('writeValue resolves the display label for a known id', () => {
-    component.writeValue('p3');
-    expect(component.value()).toBe('p3');
-    expect(component.query()).toContain('Angela Freeman');
+  it('writeValue with empty id clears the field and does not fetch', () => {
+    component.writeValue('');
+    expect(component.value()).toBe('');
+    expect(component.query()).toBe('');
+    expect(getParty).not.toHaveBeenCalled();
   });
 
-  it('Enter selects the active suggestion', () => {
+  it('Enter selects the active suggestion', fakeAsync(() => {
     component.onInput('cust');
+    tick(250);
     component.onKeydown(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
     const expected = component.suggestions()[0].partyId;
     component.onKeydown(new KeyboardEvent('keydown', { key: 'Enter' }));
     expect(component.value()).toBe(expected);
-  });
+  }));
 });

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
@@ -1,19 +1,23 @@
 import {
-  Component, inject, signal, computed, forwardRef, Input, OnInit, DestroyRef,
+  Component, inject, signal, forwardRef, Input, DestroyRef,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Subject, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
 import { CrmService } from '../../services/crm.service';
 import { PartyDetail } from '../../models/crm.models';
 
-const MAX_SUGGESTIONS = 8;
+const MAX_SUGGESTIONS = 12;
 
 /**
  * Reusable customer typeahead bound as a reactive-form control. The control
- * value is the selected party id (the canonical customerId). Loads the CRM
- * party directory once and filters client-side by legal name, DBA, and
- * customer number — replacing raw "Customer ID" text entry across the app.
+ * value is the selected party id (the canonical customerId).
+ *
+ * Searches the customer directory server-side per keystroke (debounced) via
+ * the unified browse term, which matches legal/display name and customer
+ * number — so there is no client-side row cap.
  */
 @Component({
   selector: 'app-customer-lookup',
@@ -29,7 +33,7 @@ const MAX_SUGGESTIONS = 8;
     },
   ],
 })
-export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
+export class CustomerLookupComponent implements ControlValueAccessor {
   private readonly crm = inject(CrmService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -38,41 +42,33 @@ export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
   @Input() required = false;
   @Input() placeholder = 'Search by name or customer number…';
 
-  readonly allCustomers = signal<PartyDetail[]>([]);
+  readonly suggestions = signal<PartyDetail[]>([]);
   readonly query        = signal('');
   readonly showList     = signal(false);
+  readonly loading      = signal(false);
   readonly activeIndex  = signal(-1);
   readonly disabled     = signal(false);
   readonly value        = signal('');
 
-  private pendingId: string | null = null;
+  private primed = false;
   private onChange: (value: string) => void = () => {};
   private onTouched: () => void = () => {};
 
-  readonly suggestions = computed<PartyDetail[]>(() => {
-    const q = this.query().trim().toLowerCase();
-    const all = this.allCustomers();
-    if (!q) return all.slice(0, MAX_SUGGESTIONS);
-    return all.filter(p => {
-      const name = (p.legalName ?? '').toLowerCase();
-      const dba = (p.dba ?? '').toLowerCase();
-      const num = (p.customerNumber ?? '').toLowerCase();
-      return name.includes(q) || dba.includes(q) || num.includes(q);
-    }).slice(0, MAX_SUGGESTIONS);
-  });
+  private readonly queryChanges$ = new Subject<string>();
 
-  ngOnInit(): void {
-    this.crm.browseParties({ page: 0, size: 200 })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: page => {
-          this.allCustomers.set(page.parties ?? []);
-          if (this.pendingId) {
-            this.applyDisplayForId(this.pendingId);
-            this.pendingId = null;
-          }
-        },
-        error: () => {},
+  constructor() {
+    this.queryChanges$
+      .pipe(
+        debounceTime(250),
+        distinctUntilChanged(),
+        tap(() => this.loading.set(true)),
+        switchMap(q => this.crm.searchParties(q).pipe(catchError(() => of({ parties: [] as PartyDetail[] })))),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(res => {
+        this.suggestions.set((res.parties ?? []).slice(0, MAX_SUGGESTIONS));
+        this.activeIndex.set(-1);
+        this.loading.set(false);
       });
   }
 
@@ -82,11 +78,12 @@ export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
     this.value.set(next);
     if (!next) {
       this.query.set('');
-    } else if (this.allCustomers().length > 0) {
-      this.applyDisplayForId(next);
-    } else {
-      this.pendingId = next;
+      return;
     }
+    // Resolve a readable label for a pre-populated id.
+    this.crm.getParty(next)
+      .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
+      .subscribe(party => { if (party) this.query.set(this.labelFor(party)); });
   }
 
   registerOnChange(fn: (value: string) => void): void { this.onChange = fn; }
@@ -98,12 +95,16 @@ export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
     this.query.set(text);
     this.value.set('');
     this.onChange('');
-    this.activeIndex.set(-1);
     this.showList.set(true);
+    this.queryChanges$.next(text);
   }
 
   onFocus(): void {
-    if (this.allCustomers().length > 0) this.showList.set(true);
+    this.showList.set(true);
+    if (!this.primed) {
+      this.primed = true;
+      this.queryChanges$.next(this.query());
+    }
   }
 
   onBlur(): void {
@@ -144,10 +145,5 @@ export class CustomerLookupComponent implements OnInit, ControlValueAccessor {
   labelFor(party: PartyDetail): string {
     const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
     return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
-  }
-
-  private applyDisplayForId(id: string): void {
-    const party = this.allCustomers().find(p => p.partyId === id);
-    if (party) this.query.set(this.labelFor(party));
   }
 }

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ComponentFixture } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
@@ -29,12 +29,8 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     component = fixture.componentInstance;
     http = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
-
-    // ngOnInit eagerly browses the CRM party directory for the typeahead exactly once.
-    // expectOne asserts the single init request (catches accidental double-loads)
-    // and flushing it leaves each test a clean HTTP backend.
-    http.expectOne(r => r.method === 'GET' && /\/v1\/crm\/accounts\/parties(\?|$)/.test(r.url))
-      .flush({ results: [], totalCount: 0, pageNumber: 0, pageSize: 200 });
+    // Customer search is now server-side and lazy (fires on focus/input), so there
+    // is no eager request to flush here.
   });
 
   afterEach(() => {
@@ -92,12 +88,16 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
     expect(component.errorMessage()).toBe('Server error');
   });
 
-  it('should suggest CRM parties by legal name / customer number and select by partyId', () => {
-    component.allCustomers.set([
-      { partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' },
-      { partyId: 'p-2', legalName: 'Bravo Logistics', customerNumber: 'C-200' },
-    ]);
+  it('should suggest CRM parties via server-side search and select by partyId', fakeAsync(() => {
     component.onCustomerInput('acme');
+    tick(250); // debounce
+
+    const search = http.expectOne(r =>
+      r.method === 'GET' && r.url.endsWith('/v1/crm/accounts/parties') && r.params.get('name') === 'acme');
+    search.flush({
+      results: [{ partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' }],
+      totalCount: 1, pageNumber: 0, pageSize: 25,
+    });
     expect(component.customerSuggestions().map(p => p.partyId)).toEqual(['p-1']);
 
     component.selectCustomer({ partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' });
@@ -111,7 +111,7 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
         { vehicleId: 'v-2', vin: '2XYZ', make: 'GMC', model: 'Sierra', year: 2021 },
       ]);
     expect(component.customerVehicles().length).toBe(2);
-  });
+  }));
 
   it('should reveal inline add-vehicle form when add option chosen', () => {
     expect(component.showAddVehicle()).toBe(false);

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -1,9 +1,10 @@
-import { Component, inject, signal, computed, OnInit, DestroyRef } from '@angular/core';
+import { Component, inject, signal, OnInit, DestroyRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { catchError, of } from 'rxjs';
+import { Subject, catchError, of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
 import {
   CRMVehiclesService,
   CreateVehicleForPartyRequest,
@@ -37,9 +38,11 @@ export class EstimateCreatePageComponent implements OnInit {
   readonly errorMessage = signal<string | null>(null);
   readonly fieldErrors  = signal<Record<string, string>>({});
 
-  readonly allCustomers = signal<PartyDetail[]>([]);
+  readonly customerSuggestions = signal<PartyDetail[]>([]);
   readonly customerDisplayName = signal('');
   readonly showCustomerSuggestions = signal(false);
+  private readonly customerQuery$ = new Subject<string>();
+  private customerSearchPrimed = false;
 
   readonly customerVehicles = signal<VehicleSummary[]>([]);
 
@@ -49,17 +52,18 @@ export class EstimateCreatePageComponent implements OnInit {
 
   readonly addVehicleOption = ADD_VEHICLE_OPTION;
 
-  readonly customerSuggestions = computed<PartyDetail[]>(() => {
-    const q = this.customerDisplayName().trim().toLowerCase();
-    const all = this.allCustomers();
-    if (!q) return all.slice(0, MAX_SUGGESTIONS);
-    return all.filter(p => {
-      const name = (p.legalName ?? '').toLowerCase();
-      const dba = (p.dba ?? '').toLowerCase();
-      const customerNumber = (p.customerNumber ?? '').toLowerCase();
-      return name.includes(q) || dba.includes(q) || customerNumber.includes(q);
-    }).slice(0, MAX_SUGGESTIONS);
-  });
+  constructor() {
+    // Server-side customer search (debounced); the browse term matches name and
+    // customer number, so there is no client-side row cap.
+    this.customerQuery$
+      .pipe(
+        debounceTime(250),
+        distinctUntilChanged(),
+        switchMap(q => this.crm.searchParties(q).pipe(catchError(() => of({ parties: [] as PartyDetail[] })))),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(res => this.customerSuggestions.set((res.parties ?? []).slice(0, MAX_SUGGESTIONS)));
+  }
 
   readonly form = this.fb.nonNullable.group({
     customerId: ['', Validators.required],
@@ -75,15 +79,6 @@ export class EstimateCreatePageComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    // Load CRM parties (the canonical customer directory). Client-side filtered
-    // below; server-side name search can replace this when typeahead paging lands.
-    this.crm.browseParties({ page: 0, size: 200 })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: page => this.allCustomers.set(page.parties ?? []),
-        error: () => {},
-      });
-
     const nav = this.router.getCurrentNavigation()?.extras?.state as Record<string, string> | undefined;
     if (nav?.['customerId']) this.form.patchValue({ customerId: nav['customerId'] });
     if (nav?.['vehicleId'])  this.form.patchValue({ vehicleId: nav['vehicleId'] });
@@ -94,10 +89,15 @@ export class EstimateCreatePageComponent implements OnInit {
     this.form.patchValue({ customerId: '' });
     this.resetVehicleSelection();
     this.showCustomerSuggestions.set(true);
+    this.customerQuery$.next(value);
   }
 
   onCustomerFocus(): void {
-    if (this.allCustomers().length > 0) this.showCustomerSuggestions.set(true);
+    this.showCustomerSuggestions.set(true);
+    if (!this.customerSearchPrimed) {
+      this.customerSearchPrimed = true;
+      this.customerQuery$.next(this.customerDisplayName());
+    }
   }
 
   onCustomerBlur(): void {


### PR DESCRIPTION
## Summary
Removes the client-side 200-row cap from the customer pickers. Both `CustomerLookupComponent` (approval in-person/partial/digital, credit-memo create) and `estimate-create` now search the directory **server-side, debounced per keystroke** via `crm.searchParties` — no row cap.

## Changes
- `CustomerLookupComponent`: server-driven suggestions, "Searching…" hint, `writeValue` resolves a pre-populated id's label via `crm.getParty`.
- `estimate-create`: same debounced server search; removed the eager 200-row load + client-side computed filter (vehicle flow unchanged).

## Depends on
- Backend [durion-positivity-backend#723](https://github.com/louisburroughs/durion-positivity-backend/pull/723) — makes the browse `name` term also match customer number. **Merge backend first**; otherwise number search returns nothing (name search works regardless). No SDK change (reuses existing `browseParties`).

## Test
- `CustomerLookupComponent` spec — 6 (rewritten for debounced server search, fakeAsync).
- `estimate-create` spec — 12 (server-search request asserted via `params.get('name')`).
- Four host pages — 19, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)