### PR TITLE
feat(workexec): show customer name on estimate list cards

### DIFF
--- a/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.html
+++ b/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.html
@@ -28,8 +28,8 @@
     @for (item of estimates(); track item.estimateId) {
     <li class="estimate-list__card" data-testid="estimate-row">
       <button type="button" (click)="openEstimateDetail(item.estimateId)"
-        [attr.aria-label]="('WORKEXEC.ESTIMATE_LIST.CARD.ARIA_LABEL' | translate) + ' ' + (item.customerId || item.estimateId) + ', ' + ('WORKEXEC.ESTIMATE_STATUS.' + item.status | translate)">
-        <span class="estimate-list__primary">{{ item.customerId }}</span>
+        [attr.aria-label]="('WORKEXEC.ESTIMATE_LIST.CARD.ARIA_LABEL' | translate) + ' ' + (customerName(item.customerId) || item.estimateId) + ', ' + ('WORKEXEC.ESTIMATE_STATUS.' + item.status | translate)">
+        <span class="estimate-list__primary">{{ customerName(item.customerId) }}</span>
 
         <span class="estimate-list__meta">
           <span class="estimate-list__status-badge">{{ ('WORKEXEC.ESTIMATE_STATUS.' + item.status) | translate }}</span>

--- a/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.spec.ts
@@ -1,9 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
-import { BehaviorSubject, Subject, throwError } from 'rxjs';
+import { BehaviorSubject, Subject, of, throwError } from 'rxjs';
 import { EstimateListItem } from '../../models/workexec.models';
 import { WorkexecService } from '../../services/workexec.service';
+import { CrmService } from '../../../crm/services/crm.service';
 import { EstimateListPageComponent } from './estimate-list-page.component';
 
 describe('EstimateListPageComponent', () => {
@@ -16,17 +17,24 @@ describe('EstimateListPageComponent', () => {
     listEstimatesForVehicle: vi.fn(),
   };
 
+  const crmMock = {
+    getParty: vi.fn(),
+  };
+
   beforeEach(async () => {
     customerParamMap$ = new BehaviorSubject(convertToParamMap({ customerId: 'cust-1' }));
 
     serviceMock.listEstimatesForCustomer.mockReset();
     serviceMock.listEstimatesForVehicle.mockReset();
+    crmMock.getParty.mockReset();
+    crmMock.getParty.mockReturnValue(of({ partyId: 'cust-1', legalName: 'Acme Tire Co', customerNumber: 'CUST-CP-001' }));
 
     await TestBed.configureTestingModule({
       imports: [EstimateListPageComponent, TranslateModule.forRoot()],
       providers: [
         provideRouter([]),
         { provide: WorkexecService, useValue: serviceMock },
+        { provide: CrmService, useValue: crmMock },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -68,6 +76,19 @@ describe('EstimateListPageComponent', () => {
     expect(component.state()).toBe('ready');
     expect(component.estimates()).toEqual(estimatesFixture);
     expect(fixture.nativeElement.querySelectorAll('[data-testid="estimate-row"]').length).toBe(1);
+  });
+
+  it('resolves the customer display name for the cards', () => {
+    serviceMock.listEstimatesForCustomer.mockReturnValue(of([
+      { estimateId: 'est-1', customerId: 'cust-1', status: 'OPEN', totalAmount: 100, currency: 'USD' },
+    ] as EstimateListItem[]));
+
+    fixture.detectChanges();
+
+    expect(crmMock.getParty).toHaveBeenCalledWith('cust-1');
+    expect(component.customerName('cust-1')).toBe('Acme Tire Co · CUST-CP-001');
+    // Falls back to the raw id when unresolved.
+    expect(component.customerName('unknown')).toBe('unknown');
   });
 
   it('sets error state before errorKey when load fails', () => {

--- a/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.ts
@@ -4,10 +4,12 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
-import { combineLatest, EMPTY, Subscription, switchMap } from 'rxjs';
-import { distinctUntilChanged } from 'rxjs/operators';
+import { combineLatest, EMPTY, forkJoin, of, Subscription, switchMap } from 'rxjs';
+import { catchError, distinctUntilChanged, map } from 'rxjs/operators';
 import { EstimateListItem } from '../../models/workexec.models';
 import { WorkexecService } from '../../services/workexec.service';
+import { CrmService } from '../../../crm/services/crm.service';
+import { PartyDetail } from '../../../crm/models/crm.models';
 import { CustomerLookupComponent } from '../../../crm/components/customer-lookup/customer-lookup.component';
 
 @Component({
@@ -19,6 +21,7 @@ import { CustomerLookupComponent } from '../../../crm/components/customer-lookup
 })
 export class EstimateListPageComponent {
   private readonly workexec = inject(WorkexecService);
+  private readonly crm = inject(CrmService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -29,6 +32,14 @@ export class EstimateListPageComponent {
   readonly errorKey = signal<string | null>(null);
   readonly estimates = signal<EstimateListItem[]>([]);
   readonly selectedEstimateId = signal<string | null>(null);
+
+  /** Resolved CRM display labels keyed by customerId (estimates only carry the id). */
+  readonly customerNames = signal<Record<string, string>>({});
+
+  /** Display label for an estimate's customer: resolved CRM name, else the raw id. */
+  customerName(id: string): string {
+    return this.customerNames()[id] ?? id;
+  }
 
   constructor() {
     effect(onCleanup => {
@@ -65,6 +76,7 @@ export class EstimateListPageComponent {
           next: estimates => {
             this.estimates.set(estimates);
             this.state.set(estimates.length > 0 ? 'ready' : 'empty');
+            this.resolveCustomerNames(estimates);
           },
           error: () => {
             this.state.set('error');
@@ -92,6 +104,35 @@ export class EstimateListPageComponent {
           queryParamsHandling: 'merge',
         });
       });
+  }
+
+  /** Look up CRM display labels for the distinct, not-yet-cached customer ids. */
+  private resolveCustomerNames(estimates: EstimateListItem[]): void {
+    const cached = this.customerNames();
+    const missing = [...new Set(estimates.map(e => e.customerId).filter(id => id && !cached[id]))];
+    if (missing.length === 0) return;
+
+    forkJoin(
+      missing.map(id =>
+        this.crm.getParty(id).pipe(
+          map(party => [id, this.partyLabel(party)] as const),
+          catchError(() => of([id, id] as const)),
+        ),
+      ),
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(pairs => {
+        this.customerNames.update(current => {
+          const next = { ...current };
+          for (const [id, label] of pairs) next[id] = label;
+          return next;
+        });
+      });
+  }
+
+  private partyLabel(party: PartyDetail): string {
+    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
+    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
   }
 
   openEstimateDetail(id: string): void {


### PR DESCRIPTION
## Summary
Estimate list cards showed the raw customer **UUID** as the primary label. Estimate summaries only carry the customer id (the workorder service has no CRM names), so the name is resolved on the frontend.

## Changes
- Resolve the distinct customer ids on each load to CRM display labels (legal name + DBA + customer number) via `crm.getParty`, cached in a `customerNames` map.
- Card primary text and aria-label now show the label, falling back to the id while unresolved or on lookup failure.

## Notes
- Frontend-only; reuses `crm.getParty`. One lookup per distinct customer (a single call for the customer-filtered list).

## Test
- `estimate-list` spec — 4 (added name-resolution + fallback assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)