### PR TITLE
fix(workexec): map estimate list rows so totals render

### DIFF
--- a/src/app/features/workexec/services/workexec.service.spec.ts
+++ b/src/app/features/workexec/services/workexec.service.spec.ts
@@ -285,54 +285,60 @@ describe('WorkexecService', () => {
   // ── CAP-248: Stories 259, 260, 261 ───────────────────────────────────────
 
   describe('CAP-248 service methods', () => {
-    it('listEstimatesForCustomer — gets /v1/workorders/estimates with customerId query', () => {
-      const fixture: EstimateListItem[] = [
+    it('listEstimatesForCustomer — maps API rows (id/total/currencyUomId) to the card model', () => {
+      // API shape: id / total / currencyUomId (not estimateId / totalAmount / currency).
+      const apiRows = [
         {
-          estimateId: 'est-259-1',
+          id: 'est-259-1',
           workorderId: 'wo-259-1',
           customerId: 'cust-259-1',
           vehicleId: 'veh-259-1',
           status: 'OPEN',
-          totalAmount: 250.45,
-          currency: 'USD',
-          lastUpdatedAt: '2026-03-30T12:00:00Z',
+          total: 250.45,
+          currencyUomId: 'USD',
           createdAt: '2026-03-29T12:00:00Z',
           notes: 'cap-248',
         },
       ];
 
       service.listEstimatesForCustomer('cust-259-1').subscribe(result => {
-        expect(result).toEqual(fixture);
+        expect(result).toEqual([
+          {
+            estimateId: 'est-259-1',
+            workorderId: 'wo-259-1',
+            customerId: 'cust-259-1',
+            vehicleId: 'veh-259-1',
+            status: 'OPEN',
+            totalAmount: 250.45,
+            currency: 'USD',
+            lastUpdatedAt: undefined,
+            createdAt: '2026-03-29T12:00:00Z',
+            notes: 'cap-248',
+          },
+        ] as EstimateListItem[]);
       });
 
       const req = http.expectOne(`${BASE}/v1/workorders/estimates/customer/cust-259-1`);
       expect(req.request.method).toBe('GET');
-      expect(req.request.url).toContain('/v1/workorders/estimates/customer/');
-      req.flush(fixture);
+      req.flush(apiRows);
     });
 
-    it('listEstimatesForVehicle — gets /v1/workorders/estimates with vehicleId query', () => {
-      const fixture: EstimateListItem[] = [
-        {
-          estimateId: 'est-259-2',
-          customerId: 'cust-259-2',
-          vehicleId: 'veh-259-2',
-          status: 'APPROVED',
-          totalAmount: 399,
-          currency: 'USD',
-        },
+    it('listEstimatesForVehicle — maps API rows and defaults missing total to 0', () => {
+      const apiRows = [
+        { id: 'est-259-2', customerId: 'cust-259-2', vehicleId: 'veh-259-2', status: 'APPROVED', currencyUomId: 'USD' },
       ];
 
       service.listEstimatesForVehicle('veh-259-2').subscribe(result => {
-        expect(result).toEqual(fixture);
+        expect(result[0].estimateId).toBe('est-259-2');
+        expect(result[0].totalAmount).toBe(0);
+        expect(result[0].currency).toBe('USD');
       });
 
       const req = http.expectOne(r =>
         r.url === `${BASE}/v1/workorders/estimates` && r.params.get('vehicleId') === 'veh-259-2',
       );
       expect(req.request.method).toBe('GET');
-      expect(req.request.url).toContain('/v1/workorders/estimates');
-      req.flush(fixture);
+      req.flush(apiRows);
     });
 
     it('listActiveWorkorders — gets /v1/workorders/wip with wipStatus query', () => {

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -125,6 +125,21 @@ import {
  *   declineChangeRequest       → POST   /v1/workorders/changeRequests/{changeId}/decline
  *   getChangeRequestById       → GET    /v1/workorders/changeRequests/{changeId}
  */
+/** Raw estimate row as returned by the workorder list endpoints (API field names). */
+interface RawEstimateSummary {
+  id?: string;
+  workorderId?: string;
+  customerId?: string;
+  vehicleId?: string;
+  status?: string;
+  total?: number;
+  currencyUomId?: string;
+  updatedAt?: string;
+  lastUpdatedAt?: string;
+  createdAt?: string;
+  notes?: string;
+}
+
 @Injectable({ providedIn: 'root' })
 export class WorkexecService {
   private readonly api = inject(ApiBaseService);
@@ -573,7 +588,8 @@ export class WorkexecService {
    * GET /v1/workorders/estimates?customerId={customerId}
    */
   listEstimatesForCustomer(customerId: string): Observable<EstimateListItem[]> {
-    return this.estimateApi.getEstimatesByCustomer(customerId) as unknown as Observable<EstimateListItem[]>;
+    return (this.estimateApi.getEstimatesByCustomer(customerId) as unknown as Observable<RawEstimateSummary[]>)
+      .pipe(map(list => (list ?? []).map(r => this.toEstimateListItem(r))));
   }
 
   /**
@@ -582,7 +598,29 @@ export class WorkexecService {
    */
   listEstimatesForVehicle(vehicleId: string): Observable<EstimateListItem[]> {
     const params = new HttpParams().set('vehicleId', vehicleId);
-    return this.api.get<EstimateListItem[]>('/v1/workorders/estimates', params);
+    return this.api.get<RawEstimateSummary[]>('/v1/workorders/estimates', params)
+      .pipe(map(list => (list ?? []).map(r => this.toEstimateListItem(r))));
+  }
+
+  /**
+   * Adapts an estimate response/summary row to the list-card model. The API uses
+   * `id` / `total` / `currencyUomId`; the card model uses `estimateId` /
+   * `totalAmount` / `currency`, so a direct cast silently dropped the totals
+   * (and the estimate id used for navigation).
+   */
+  private toEstimateListItem(r: RawEstimateSummary): EstimateListItem {
+    return {
+      estimateId: r.id ?? '',
+      workorderId: r.workorderId,
+      customerId: r.customerId ?? '',
+      vehicleId: r.vehicleId,
+      status: (r.status ?? 'DRAFT') as EstimateListItem['status'],
+      totalAmount: r.total ?? 0,
+      currency: r.currencyUomId ?? 'USD',
+      lastUpdatedAt: r.updatedAt ?? r.lastUpdatedAt,
+      createdAt: r.createdAt,
+      notes: r.notes,
+    };
   }
 
   // ── CAP-003: Approval Workflow ────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Estimate list cards showed an empty **"Total:"**. `listEstimatesForCustomer`/`ForVehicle` cast the raw API response straight to the card model, but the field names differ:

| API | Card model |
|-----|-----------|
| `id` | `estimateId` |
| `total` | `totalAmount` |
| `currencyUomId` | `currency` |

So `totalAmount`/`currency` read `undefined` (blank total) and `estimateId` was blank (card-click navigation targeted `estimates/undefined`).

## Fix
Add a `toEstimateListItem` mapper applied by both list methods: `id→estimateId`, `total→totalAmount` (default 0), `currencyUomId→currency` (default USD), plus createdAt/notes/status passthrough.

## Test
Service spec updated to API-shaped rows asserting the mapped output — `workexec.service` spec green (33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)