### PR TITLE
feat(workexec): show customer and vehicle names on estimate detail

### DIFF
--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.html
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.html
@@ -23,16 +23,16 @@
       <div class="crm-ref-block" aria-label="CRM references">
         <p class="section-overline">CRM References</p>
         <div class="crm-ref-grid">
-          <span class="crm-ref-label">Party</span>
+          <span class="crm-ref-label">Customer</span>
           @if (estimate()!.crmPartyId) {
-          <span class="crm-ref-value" [title]="estimate()!.crmPartyId!">{{ estimate()!.crmPartyId }}</span>
+          <span class="crm-ref-value" [title]="estimate()!.crmPartyId!">{{ customerLabel() ?? estimate()!.crmPartyId }}</span>
           } @else {
           <span class="crm-ref-value crm-ref-value--empty">Not set</span>
           }
 
           <span class="crm-ref-label">Vehicle</span>
           @if (estimate()!.crmVehicleId) {
-          <span class="crm-ref-value" [title]="estimate()!.crmVehicleId!">{{ estimate()!.crmVehicleId }}</span>
+          <span class="crm-ref-value" [title]="estimate()!.crmVehicleId!">{{ vehicleLabel() ?? estimate()!.crmVehicleId }}</span>
           } @else {
           <span class="crm-ref-value crm-ref-value--empty">Not set</span>
           }

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.spec.ts
@@ -53,9 +53,18 @@ describe('EstimateDetailPageComponent [Story 236]', () => {
   function drainPipeline(estimateOverride?: object): void {
     const estimate = estimateOverride ?? STUB_ESTIMATE;
     http.expectOne(`${BASE}/v1/workorders/estimates/est-123`).flush(estimate);
-    // loadContacts() fires a CRM GET only when the estimate carries a crmPartyId
-    if ((estimate as { crmPartyId?: string }).crmPartyId) {
+    // loadContacts() + resolveCrmRefs() fire CRM GETs only when the estimate
+    // carries a crmPartyId.
+    const partyId = (estimate as { crmPartyId?: string }).crmPartyId;
+    if (partyId) {
       http.expectOne(r => r.url.endsWith('/contacts')).flush(contactsResponse);
+      http.expectOne(r => r.url.endsWith(`/accounts/parties/${partyId}`))
+        .flush({ partyId, legalName: 'Globex Corp', customerNumber: 'CUST-9' });
+      const vehId = (estimate as { crmVehicleId?: string }).crmVehicleId;
+      if (vehId) {
+        http.expectOne(r => r.url.endsWith(`/vehicles/${vehId}`))
+          .flush({ vehicleId: vehId, year: 2020, make: 'Ford', model: 'F-150', vin: '1FTEST' });
+      }
     }
     vi.advanceTimersByTime(350);
     http.expectOne(`${BASE}/v1/workorders/estimates/est-123/calculate`).flush({ subtotal: 0, taxAmount: 0, total: 0 });
@@ -103,8 +112,11 @@ describe('EstimateDetailPageComponent [Story 236]', () => {
 
       const crmRefBlock = fixture.nativeElement.querySelector('.crm-ref-block');
       expect(crmRefBlock).toBeTruthy();
-      expect(crmRefBlock?.textContent ?? '').toContain('crm-party-123');
-      expect(crmRefBlock?.textContent ?? '').toContain('crm-vehicle-456');
+      // Resolved labels are shown; the raw ids remain available via the title attribute.
+      expect(crmRefBlock?.textContent ?? '').toContain('Globex Corp');
+      expect(crmRefBlock?.textContent ?? '').toContain('2020 Ford F-150');
+      expect(crmRefBlock?.innerHTML ?? '').toContain('crm-party-123');
+      expect(crmRefBlock?.innerHTML ?? '').toContain('crm-vehicle-456');
     });
 
     it('resolves customer contacts from CRM and renders name + role', async () => {
@@ -146,6 +158,9 @@ describe('EstimateDetailPageComponent [Story 236]', () => {
         { message: 'boom' },
         { status: 500, statusText: 'Server Error' },
       );
+      // resolveCrmRefs() also fires party/vehicle GETs when crmPartyId is present.
+      http.expectOne(r => r.url.endsWith('/accounts/parties/crm-party-123'))
+        .flush({ partyId: 'crm-party-123', legalName: 'Globex Corp' });
       vi.advanceTimersByTime(350);
       http.expectOne(`${BASE}/v1/workorders/estimates/est-123/calculate`).flush({ subtotal: 0, taxAmount: 0, total: 0 });
       http.expectOne(`${BASE}/v1/workorders/estimates/est-123`).flush({ ...STUB_ESTIMATE, crmPartyId: 'crm-party-123' });

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -5,9 +5,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
+import { catchError, of } from 'rxjs';
+import { CRMVehiclesService, VehicleResponse } from '@durion-sdk/customer';
 import { WorkexecService } from '../../services/workexec.service';
 import { CrmService } from '../../../crm/services/crm.service';
-import { Relationship } from '../../../crm/models/crm.models';
+import { PartyDetail, Relationship } from '../../../crm/models/crm.models';
 import {
   EstimateItemResponse,
   EstimateResponse,
@@ -39,9 +41,14 @@ import {
 export class EstimateDetailPageComponent implements OnInit {
   private readonly workexec   = inject(WorkexecService);
   private readonly crm        = inject(CrmService);
+  private readonly vehiclesApi = inject(CRMVehiclesService);
   private readonly route      = inject(ActivatedRoute);
   private readonly router     = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+
+  /** Human-readable CRM labels resolved from the estimate's crmPartyId / crmVehicleId. */
+  readonly customerLabel = signal<string | null>(null);
+  readonly vehicleLabel  = signal<string | null>(null);
 
   readonly pageState    = signal<PageState>('loading');
   readonly totalsState  = signal<TotalsState>('idle');
@@ -112,6 +119,7 @@ export class EstimateDetailPageComponent implements OnInit {
           this.recalcTrigger$.next();
           this.buildApprovalScope(est);
           this.loadContacts(est);
+          this.resolveCrmRefs(est);
         },
         error: err => {
           this.pageState.set('error');
@@ -141,6 +149,40 @@ export class EstimateDetailPageComponent implements OnInit {
           this.contactsError.set(true);
         },
       });
+  }
+
+  /**
+   * Resolve human-readable customer and vehicle labels from the estimate's CRM
+   * refs (the estimate only carries the ids). Falls back to the raw id on failure.
+   */
+  private resolveCrmRefs(est: EstimateResponse): void {
+    const partyId = est.crmPartyId;
+    const vehicleId = est.crmVehicleId;
+    this.customerLabel.set(null);
+    this.vehicleLabel.set(null);
+
+    if (partyId) {
+      this.crm.getParty(partyId)
+        .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
+        .subscribe(party => this.customerLabel.set(party ? this.partyLabel(party) : null));
+
+      if (vehicleId) {
+        this.vehiclesApi.getVehiclesForCustomer(partyId, vehicleId, 'body', false, { transferCache: false })
+          .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
+          .subscribe(vehicle => this.vehicleLabel.set(vehicle ? this.vehicleLabelOf(vehicle) : null));
+      }
+    }
+  }
+
+  private partyLabel(party: PartyDetail): string {
+    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
+    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
+  }
+
+  private vehicleLabelOf(v: VehicleResponse): string {
+    const desc = `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.trim();
+    if (desc && v.vin) return `${desc} — ${v.vin}`;
+    return v.description || desc || v.vin || '';
   }
 
   /** Humanize a role enum (e.g. PRIMARY_CONTACT -> "Primary Contact") for display. */


### PR DESCRIPTION
## Summary
The estimate detail **CRM References** block showed the raw `crmPartyId` / `crmVehicleId` UUIDs. The estimate only carries the ids, so readable labels are resolved from CRM:
- **Customer**: `crm.getParty(crmPartyId)` → legal name (+ DBA / customer number)
- **Vehicle**: `getVehiclesForCustomer(crmPartyId, crmVehicleId)` → `year make model — VIN`, falling back to description / VIN

## Notes
- Raw ids remain on the `title` attribute; the label falls back to the id while unresolved or on lookup failure.
- Relabeled "Party" → "Customer".
- Frontend-only; reuses `crm.getParty` + the CRM vehicles SDK. No backend/SDK change.

## Test
- `estimate-detail` spec — 7 (updated CRM-ref tests to flush the new party/vehicle GETs and assert the resolved labels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)