### PR TITLE
refactor(crm): extract shared partyLabel / vehicleLabel helpers

### DIFF
--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
@@ -8,6 +8,7 @@ import { Subject, of } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
 import { CrmService } from '../../services/crm.service';
 import { PartyDetail } from '../../models/crm.models';
+import { partyLabel } from '../../util/crm-labels';
 
 const MAX_SUGGESTIONS = 12;
 
@@ -83,7 +84,7 @@ export class CustomerLookupComponent implements ControlValueAccessor {
     // Resolve a readable label for a pre-populated id.
     this.crm.getParty(next)
       .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
-      .subscribe(party => { if (party) this.query.set(this.labelFor(party)); });
+      .subscribe(party => { if (party) this.query.set(partyLabel(party)); });
   }
 
   registerOnChange(fn: (value: string) => void): void { this.onChange = fn; }
@@ -136,14 +137,9 @@ export class CustomerLookupComponent implements ControlValueAccessor {
   select(party: PartyDetail): void {
     const id = party.partyId ?? '';
     this.value.set(id);
-    this.query.set(this.labelFor(party));
+    this.query.set(partyLabel(party));
     this.onChange(id);
     this.showList.set(false);
     this.activeIndex.set(-1);
-  }
-
-  labelFor(party: PartyDetail): string {
-    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
-    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
   }
 }

--- a/src/app/features/crm/util/crm-labels.ts
+++ b/src/app/features/crm/util/crm-labels.ts
@@ -1,0 +1,29 @@
+import { PartyDetail } from '../models/crm.models';
+
+/** Minimal shape needed to render a vehicle label (covers SDK VehicleSummary and VehicleResponse). */
+export interface VehicleLike {
+  year?: number;
+  make?: string;
+  model?: string;
+  vin?: string;
+  description?: string;
+}
+
+/**
+ * Canonical customer display label: "Legal Name (DBA) · CUST-NUMBER",
+ * omitting the DBA and/or number segments when absent.
+ */
+export function partyLabel(party: PartyDetail): string {
+  const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
+  return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
+}
+
+/**
+ * Canonical vehicle display label: "YEAR MAKE MODEL — VIN",
+ * falling back to the human description or VIN when the parts are missing.
+ */
+export function vehicleLabel(v: VehicleLike): string {
+  const desc = `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.trim();
+  if (desc && v.vin) return `${desc} — ${v.vin}`;
+  return v.description || desc || v.vin || '';
+}

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.spec.ts
@@ -102,7 +102,7 @@ describe('EstimateCreatePageComponent [Story 239]', () => {
 
     component.selectCustomer({ partyId: 'p-1', legalName: 'Acme Towing', customerNumber: 'C-100' });
     expect(component.form.controls.customerId.value).toBe('p-1');
-    expect(component.customerDisplayName()).toBe('Acme Towing');
+    expect(component.customerDisplayName()).toBe('Acme Towing · C-100');
 
     // selecting a customer loads that customer's complete vehicle list
     http.expectOne(r => r.method === 'GET' && r.url.endsWith('/v1/crm/p-1/vehicles'))

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@durion-sdk/customer';
 import { CrmService } from '../../../crm/services/crm.service';
 import { PartyDetail } from '../../../crm/models/crm.models';
+import { partyLabel as crmPartyLabel, vehicleLabel as crmVehicleLabel } from '../../../crm/util/crm-labels';
 import { WorkexecService } from '../../services/workexec.service';
 import { PageState } from '../../models/workexec.models';
 
@@ -123,16 +124,14 @@ export class EstimateCreatePageComponent implements OnInit {
       .subscribe(vehicles => this.customerVehicles.set(vehicles ?? []));
   }
 
-  /** Display label for a party row: legal name plus DBA / customer number when present. */
+  /** Display label for a party row (shared CRM label: name + DBA + customer number). */
   customerLabel(party: PartyDetail): string {
-    return party.dba ? `${party.legalName} (${party.dba})` : party.legalName;
+    return crmPartyLabel(party);
   }
 
   /** Human-readable label for a vehicle dropdown option. */
   vehicleLabel(v: VehicleSummary): string {
-    const desc = `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.trim();
-    if (v.vin && desc) return `${v.vin} — ${desc}`;
-    return v.vin ?? v.vehicleId ?? 'Vehicle';
+    return crmVehicleLabel(v) || v.vehicleId || 'Vehicle';
   }
 
   onVehicleSelect(value: string): void {

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -6,10 +6,11 @@ import { Subject } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { v4 as uuidv4 } from 'uuid';
 import { catchError, of } from 'rxjs';
-import { CRMVehiclesService, VehicleResponse } from '@durion-sdk/customer';
+import { CRMVehiclesService } from '@durion-sdk/customer';
 import { WorkexecService } from '../../services/workexec.service';
 import { CrmService } from '../../../crm/services/crm.service';
-import { PartyDetail, Relationship } from '../../../crm/models/crm.models';
+import { Relationship } from '../../../crm/models/crm.models';
+import { partyLabel, vehicleLabel } from '../../../crm/util/crm-labels';
 import {
   EstimateItemResponse,
   EstimateResponse,
@@ -164,25 +165,14 @@ export class EstimateDetailPageComponent implements OnInit {
     if (partyId) {
       this.crm.getParty(partyId)
         .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
-        .subscribe(party => this.customerLabel.set(party ? this.partyLabel(party) : null));
+        .subscribe(party => this.customerLabel.set(party ? partyLabel(party) : null));
 
       if (vehicleId) {
         this.vehiclesApi.getVehiclesForCustomer(partyId, vehicleId, 'body', false, { transferCache: false })
           .pipe(catchError(() => of(null)), takeUntilDestroyed(this.destroyRef))
-          .subscribe(vehicle => this.vehicleLabel.set(vehicle ? this.vehicleLabelOf(vehicle) : null));
+          .subscribe(vehicle => this.vehicleLabel.set(vehicle ? vehicleLabel(vehicle) : null));
       }
     }
-  }
-
-  private partyLabel(party: PartyDetail): string {
-    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
-    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
-  }
-
-  private vehicleLabelOf(v: VehicleResponse): string {
-    const desc = `${v.year ?? ''} ${v.make ?? ''} ${v.model ?? ''}`.trim();
-    if (desc && v.vin) return `${desc} — ${v.vin}`;
-    return v.description || desc || v.vin || '';
   }
 
   /** Humanize a role enum (e.g. PRIMARY_CONTACT -> "Primary Contact") for display. */

--- a/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-list/estimate-list-page.component.ts
@@ -9,7 +9,7 @@ import { catchError, distinctUntilChanged, map } from 'rxjs/operators';
 import { EstimateListItem } from '../../models/workexec.models';
 import { WorkexecService } from '../../services/workexec.service';
 import { CrmService } from '../../../crm/services/crm.service';
-import { PartyDetail } from '../../../crm/models/crm.models';
+import { partyLabel } from '../../../crm/util/crm-labels';
 import { CustomerLookupComponent } from '../../../crm/components/customer-lookup/customer-lookup.component';
 
 @Component({
@@ -115,7 +115,7 @@ export class EstimateListPageComponent {
     forkJoin(
       missing.map(id =>
         this.crm.getParty(id).pipe(
-          map(party => [id, this.partyLabel(party)] as const),
+          map(party => [id, partyLabel(party)] as const),
           catchError(() => of([id, id] as const)),
         ),
       ),
@@ -128,11 +128,6 @@ export class EstimateListPageComponent {
           return next;
         });
       });
-  }
-
-  private partyLabel(party: PartyDetail): string {
-    const num = party.customerNumber ? ` · ${party.customerNumber}` : '';
-    return party.dba ? `${party.legalName} (${party.dba})${num}` : `${party.legalName}${num}`;
   }
 
   openEstimateDetail(id: string): void {


### PR DESCRIPTION
## Summary
The customer display label (legal name + DBA + customer number) was duplicated across `customer-lookup`, `estimate-list`, and `estimate-detail`; the vehicle label across `estimate-create` and `estimate-detail`. Extracted both into `crm/util/crm-labels.ts` and used everywhere.

## Side effect (intentional consistency)
- `estimate-create`'s customer field now shows the canonical label (adds the customer number), and the vehicle option uses the shared `"year make model — VIN"` format — matching the other pickers. Spec assertion updated.

## Test
All four affected component specs green (29). No backend/SDK change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)