### PR TITLE
fix(workexec): skip totals recalc for non-DRAFT estimates (409 on /calculate)

### DIFF
--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.spec.ts
@@ -99,6 +99,24 @@ describe('EstimateDetailPageComponent [Story 236]', () => {
     expect(component.canSubmitForApproval()).toBe(false);
   });
 
+  it('does not call /calculate for a non-DRAFT estimate and renders stored totals', () => {
+    fixture.detectChanges();
+    // Estimate already promoted past DRAFT: backend freezes totals and returns
+    // 409 on /calculate. The page must render the persisted totals instead.
+    http.expectOne(`${BASE}/v1/workorders/estimates/est-123`).flush({
+      ...STUB_ESTIMATE,
+      status: 'APPROVED',
+      subtotal: 100,
+      taxAmount: 8,
+      total: 108,
+    });
+    vi.advanceTimersByTime(350);
+    // No POST /calculate is issued; http.verify() in afterEach asserts no
+    // outstanding requests. totalsState stays out of the 'error' state.
+    expect(component.totalsState()).toBe('updated');
+    expect(component.totalsState()).not.toBe('error');
+  });
+
   describe('CRM References [Story 157]', () => {
     it('displays crm-ref-block with populated CRM IDs when estimate has crmPartyId and crmVehicleId', async () => {
       fixture.detectChanges();

--- a/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-detail/estimate-detail-page.component.ts
@@ -117,7 +117,14 @@ export class EstimateDetailPageComponent implements OnInit {
           this.estimate.set(est);
           this.items.set(est.items ?? []);
           this.pageState.set('ready');
-          this.recalcTrigger$.next();
+          // Totals are only mutable while the estimate is in DRAFT. Once it is
+          // submitted/approved/declined the backend freezes totals and rejects
+          // /calculate with 409. Render the stored totals instead of recalculating.
+          if (est.status === 'DRAFT') {
+            this.recalcTrigger$.next();
+          } else {
+            this.totalsState.set('updated');
+          }
           this.buildApprovalScope(est);
           this.loadContacts(est);
           this.resolveCrmRefs(est);


### PR DESCRIPTION
## Problem

Viewing a non-DRAFT estimate (e.g. `019ef066-9bc5-7b02-8440-ee293bdd7808`) showed **"Totals calculation failed. Retry"**, and `POST /api/workorder/v1/workorders/estimates/{id}/calculate` returned **409**.

### Root cause

`EstimateDetailPageComponent.loadEstimate()` unconditionally fired the debounced recalc pipeline (`recalcTrigger$.next()`) after load. The backend (`EstimateServiceImpl.calculateEstimateTaxesAndTotals`) only permits recalc while `status == DRAFT` and otherwise throws `IllegalStateException`, which `GlobalExceptionHandler` maps to **409 CONFLICT**. So every submitted/approved/declined estimate hit a 409 → `totalsState='error'` → a Retry button that could never succeed.

Backend behavior is correct by design: totals are frozen once the estimate leaves DRAFT. This was an over-eager frontend recalc.

## Fix

- Gate auto-recalc to `status === 'DRAFT'`.
- Non-DRAFT estimates render the persisted totals already present on the payload; set `totalsState='updated'` and skip the `/calculate` call.

## Tests

- New spec: non-DRAFT estimate issues **no** `POST /calculate` (asserted via `HttpTestingController.verify()`) and `totalsState` never enters `error`.
- Full estimate-detail spec: **8/8 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)