### PR TITLE
feat(people): surface employee profile resolution warnings

### DIFF
--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.css
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.css
@@ -125,6 +125,21 @@ label {
   color: var(--functional-error-red);
 }
 
+.alert--warning {
+  background: color-mix(in srgb, var(--functional-warning-amber, #b8860b) 12%, var(--cardBackground));
+  color: var(--functional-warning-amber, #8a6d0b);
+}
+
+.alert__title {
+  margin: 0 0 var(--space-2);
+  font-weight: 600;
+}
+
+.alert__list {
+  margin: 0;
+  padding-left: var(--space-4);
+}
+
 .status-badge {
   display: inline-flex;
   justify-self: start;

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.html
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.html
@@ -23,6 +23,17 @@
   </section>
   }
 
+  @if (warnings().length > 0) {
+  <section class="alert alert--warning" role="status" aria-live="polite" data-testid="profile-warnings">
+    <p class="alert__title">Some profile details could not be fully resolved:</p>
+    <ul class="alert__list">
+      @for (warning of warnings(); track warning) {
+      <li>{{ warning }}</li>
+      }
+    </ul>
+  </section>
+  }
+
   <form [formGroup]="form" (ngSubmit)="save()" novalidate class="profile-form">
     <fieldset class="form-section">
       <legend>Personal details</legend>

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.spec.ts
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.spec.ts
@@ -106,6 +106,37 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     expect(legalNameInput.nativeElement.value).toBe(STUB_EMPLOYEE.legalName);
   });
 
+  it('surfaces backend resolution warnings as a banner', async () => {
+    vi.clearAllMocks();
+    stubPeopleService.getEmployee.mockReturnValue(
+      of({ ...STUB_EMPLOYEE, warnings: ['Ambiguous duplicate match detected by legalName similarity'] }),
+    );
+
+    await TestBed.configureTestingModule({
+      imports: [EmployeeProfilePageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: PeopleService, useValue: stubPeopleService },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: (k: string) => (k === 'id' ? 'emp-warn' : null) } }, params: of({ id: 'emp-warn' }) },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(EmployeeProfilePageComponent);
+    fixture.detectChanges();
+
+    const banner = fixture.debugElement.query(By.css('[data-testid="profile-warnings"]'));
+    expect(banner).toBeTruthy();
+    expect(banner.nativeElement.textContent).toContain('Ambiguous duplicate match');
+  });
+
+  it('renders no warnings banner when the profile has none', async () => {
+    const { fixture } = await setupEdit('emp-1');
+    expect(fixture.debugElement.query(By.css('[data-testid="profile-warnings"]'))).toBeNull();
+  });
+
   // ── T3: Loading state ────────────────────────────────────────────────────
 
   it('shows a loading indicator while fetching employee data', async () => {

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.ts
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -29,6 +29,8 @@ export class EmployeeProfilePageComponent implements OnInit {
   readonly error = signal<string | null>(null);
   readonly conflictError = signal<string | null>(null);
   readonly fieldErrors = signal<Record<string, string>>({});
+  /** Non-fatal warnings returned by the backend while resolving the profile. */
+  readonly warnings = computed<string[]>(() => this.employee()?.warnings ?? []);
   readonly saveSuccess = signal(false);
 
   readonly form = new FormGroup({


### PR DESCRIPTION
## Summary

The employee profile page (`/app/people/employees/{id}`) silently dropped `EmployeeProfileDto.warnings[]` returned by the backend (raised while resolving the profile — e.g. "Ambiguous duplicate match detected by legalName similarity"). Operators had no signal that resolution was partial.

Render the warnings as a non-blocking `role="status"` `aria-live="polite"` banner above the form.

## Validation

- [x] `ng test` employee-profile spec — **13 passing** (incl. banner-shown + banner-absent)
- [x] Angular build (template + TS typecheck) clean

## Accessibility Verification (Required for Changed UI)

- [x] Banner announced via `aria-live="polite"` / `role="status"`
- [x] Keyboard: non-interactive banner, no focus trap
- [ ] Manual screen-reader smoke — reviewer to confirm or defer

## Notes / Follow-ups

- Pairs with backend PR durion-positivity-backend#725 (which populates name/contact); related model reconciliation tracked in durion-positivity-backend#726.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
