### PR TITLE
fix(styles): legible select dropdowns in dark mode

### DIFF
--- a/src/app/features/shell/components/header/header.component.css
+++ b/src/app/features/shell/components/header/header.component.css
@@ -85,9 +85,8 @@
   outline-offset: 2px;
 }
 
-.locale-select option {
-  color: var(--durion-grey-900);
-}
+/* Option list governed by the global `option` rule in styles.css (theme-token
+   bg + text) so the header locale popup stays legible in light and dark. */
 
 .icon-btn {
   background: transparent;

--- a/src/styles.css
+++ b/src/styles.css
@@ -296,6 +296,18 @@ textarea::placeholder {
   opacity: 1;
 }
 
+/* Native <select> dropdown list. The option popup is rendered by the UA and
+   does not inherit the select's background in all browsers, so an unstyled
+   option list defaults to a light popup — in dark mode the inherited light
+   text then reads white-on-whitish. Pin both to theme tokens: light resolves
+   to white bg / grey-900 text (unchanged); dark resolves to graphite-800 bg /
+   #e8e9eb text (~9.9:1, WCAG AAA). */
+option,
+optgroup {
+  background: var(--input-background);
+  color: var(--currentTextColor);
+}
+
 /* ── Button Base ─────────────────────────────────────────────────────────── */
 button {
   cursor: pointer;


### PR DESCRIPTION
## Summary

- Native `<select>` option popups are rendered by the UA and do not inherit the select's background in all browsers. The unstyled option list defaulted to a light popup; in dark mode the inherited light text read **white-on-whitish**.
- Added a global `option, optgroup` rule in `src/styles.css` pinned to theme tokens (`--input-background` / `--currentTextColor`): light resolves to white bg / `grey-900` text (**unchanged**); dark resolves to `graphite-800` bg / `#e8e9eb` text (~**9.9:1, WCAG AAA**). Fixes every page with a native select.
- Removed the now-redundant `.locale-select option { color: grey-900 }` override in `header.component.css`, which would otherwise render dark-on-dark against the new global dark option bg. Global rule governs it correctly in both modes.
- Landing locale-select option rules left as-is — already self-consistent (blue-700/graphite-800 + white) in both modes.

## Validation

- [ ] `npm run build`
- [ ] `npm run test` (or relevant targeted tests)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

## Notes / Follow-ups

- CSS-only, token-driven change. Light mode resolves to prior values everywhere (no visual change). Dark mode only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)