### PR TITLE
[CAP:005] Technician typeahead on workorder assign page

### DIFF
--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -398,6 +398,18 @@ export interface AssignTechnicianRequest {
   notes?: string;
 }
 
+/**
+ * A technician staffed at a location, derived from the people-availability
+ * roster. Used to populate the assign-page typeahead so an operator selects a
+ * known technician instead of pasting a raw UUID.
+ */
+export interface LocationTechnician {
+  /** Canonical personId — the value submitted as technicianId. */
+  id: string;
+  name: string;
+  role?: string;
+}
+
 // ── CAP-005: Workorder start/status (Story 224) ───────────────────────────────
 
 export interface WorkorderStartResponse {

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.css
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.css
@@ -11,6 +11,12 @@
 .field__input {background:var(--cardBackground,#f6f8fa);border:none;border-bottom:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm) var(--radius-sm) 0 0;padding:var(--space-3);font-size:0.9rem;transition:border-color 0.15s;outline:none;}
 .field__input:focus {border-bottom:2px solid var(--brand-accent,#006a62);}
 .field__input--textarea {resize:vertical;min-height:80px;}
+.tech-lookup {position:relative;}
+.tech-list {list-style:none;margin:var(--space-1) 0 0;padding:0;position:absolute;top:100%;left:0;right:0;z-index:20;max-height:16rem;overflow-y:auto;background:var(--cardBackground,#fff);border:1px solid rgba(130,130,130,0.25);border-radius:var(--radius-sm);box-shadow:0 0.25rem 1rem rgba(0,0,0,0.12);}
+.tech-option {display:flex;align-items:baseline;justify-content:space-between;gap:var(--space-3);padding:var(--space-2) var(--space-3);cursor:pointer;}
+.tech-option:hover,.tech-option--active {background:color-mix(in srgb,var(--brand-accent,#006a62) 10%,var(--cardBackground,#fff));}
+.tech-option__name {font-weight:600;font-size:0.9rem;}
+.tech-option__role {font-size:0.75rem;text-transform:uppercase;letter-spacing:0.04em;opacity:0.55;}
 .form-actions {display:flex;gap:var(--space-3);justify-content:flex-end;margin-top:var(--space-2);}
 .hint-text {font-size:0.875rem;opacity:0.55;font-style:italic;}
 .alert {padding:var(--space-3) var(--space-4);border-radius:var(--radius-md);font-size:0.875rem;}

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
@@ -20,17 +20,58 @@
     }
 
     <div class="assign-form">
-      <div class="field">
-        <label for="technicianId" class="field__label">Technician ID <span aria-hidden="true">*</span></label>
+      <div class="field tech-lookup">
+        <label for="technicianId" class="field__label">Technician <span aria-hidden="true">*</span></label>
         <input
           id="technicianId"
           class="field__input"
           type="text"
-          [value]="technicianId()"
-          (input)="technicianId.set($any($event.target).value)"
-          placeholder="Enter technician UUID"
+          role="combobox"
+          autocomplete="off"
+          spellcheck="false"
+          aria-autocomplete="list"
           aria-required="true"
+          aria-controls="technician-listbox"
+          [attr.aria-expanded]="showTechList() && filteredTechnicians().length > 0"
+          [attr.aria-activedescendant]="showTechList() && activeIndex() >= 0 ? ('technician-opt-' + activeIndex()) : null"
+          [value]="techQuery()"
+          (input)="onTechInput($any($event.target).value)"
+          (focus)="onTechFocus()"
+          (blur)="onTechBlur()"
+          (keydown)="onTechKeydown($event)"
+          placeholder="Search technicians at this location"
         />
+
+        @if (rosterState() === 'loading') {
+          <p class="hint-text" aria-busy="true">Loading technicians…</p>
+        }
+        @if (rosterState() === 'error') {
+          <p class="hint-text">Could not load technicians for this location.</p>
+        }
+        @if (rosterState() === 'ready' && technicians().length === 0) {
+          <p class="hint-text">No technicians assigned to this location.</p>
+        }
+
+        @if (showTechList() && filteredTechnicians().length > 0) {
+          <ul id="technician-listbox" class="tech-list" role="listbox" aria-label="Technicians at this location">
+            @for (tech of filteredTechnicians(); track tech.id; let i = $index) {
+              <li
+                role="option"
+                class="tech-option"
+                [id]="'technician-opt-' + i"
+                [class.tech-option--active]="i === activeIndex()"
+                [attr.aria-selected]="i === activeIndex()"
+                (mousedown)="selectTechnician(tech)"
+              >
+                <span class="tech-option__name">{{ tech.name }}</span>
+                @if (tech.role) { <span class="tech-option__role">{{ tech.role }}</span> }
+              </li>
+            }
+          </ul>
+        }
+        @if (showTechList() && rosterState() === 'ready' && technicians().length > 0 && filteredTechnicians().length === 0) {
+          <p class="hint-text">No technicians match “{{ techQuery() }}”.</p>
+        }
       </div>
       <div class="field">
         <label for="assignNotes" class="field__label">Notes</label>

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
@@ -31,7 +31,7 @@
           spellcheck="false"
           aria-autocomplete="list"
           aria-required="true"
-          aria-controls="technician-listbox"
+          [attr.aria-controls]="showTechList() && filteredTechnicians().length > 0 ? 'technician-listbox' : null"
           [attr.aria-expanded]="showTechList() && filteredTechnicians().length > 0"
           [attr.aria-activedescendant]="showTechList() && activeIndex() >= 0 ? ('technician-opt-' + activeIndex()) : null"
           [value]="techQuery()"

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { v4 as uuidv4 } from 'uuid';
 import {
   AssignTechnicianRequest,
+  LocationTechnician,
   TechnicianAssignmentResponse,
   WorkorderResponse,
 } from '../../models/workexec.models';
@@ -13,6 +14,7 @@ import { WorkexecService } from '../../services/workexec.service';
 
 type PageState = 'loading' | 'ready' | 'error';
 type FormMode = 'assign' | 'reassign';
+type RosterState = 'idle' | 'loading' | 'ready' | 'error';
 
 /**
  * WorkorderAssignPageComponent — Story 225 (CAP-005)
@@ -45,6 +47,25 @@ export class WorkorderAssignPageComponent implements OnInit {
 
   readonly formMode = signal<FormMode>('assign');
 
+  // ── Technician typeahead ──────────────────────────────────────────────────
+  /** Full technician roster for the workorder's location. */
+  readonly technicians = signal<LocationTechnician[]>([]);
+  readonly rosterState = signal<RosterState>('idle');
+  /** Free text typed into the typeahead; filters the roster client-side. */
+  readonly techQuery = signal<string>('');
+  readonly showTechList = signal<boolean>(false);
+  readonly activeIndex = signal<number>(-1);
+
+  /** Roster filtered by the typeahead term; shows all when the term is empty. */
+  readonly filteredTechnicians = computed(() => {
+    const q = this.techQuery().trim().toLowerCase();
+    const all = this.technicians();
+    if (!q) {
+      return all;
+    }
+    return all.filter(t => t.name.toLowerCase().includes(q) || t.id.toLowerCase().includes(q));
+  });
+
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
     this.workorderId.set(id);
@@ -59,6 +80,7 @@ export class WorkorderAssignPageComponent implements OnInit {
       .subscribe({
         next: (wo) => {
           this.workorder.set(wo);
+          this.loadTechnicians(wo.shopId);
           if (wo.primaryTechnicianId) {
             this.formMode.set('reassign');
             this.loadCurrentAssignment(id);
@@ -69,6 +91,27 @@ export class WorkorderAssignPageComponent implements OnInit {
         error: () => {
           this.errorMessage.set('Failed to load work order.');
           this.pageState.set('error');
+        },
+      });
+  }
+
+  private loadTechnicians(locationId: string | undefined): void {
+    if (!locationId) {
+      this.rosterState.set('error');
+      return;
+    }
+    this.rosterState.set('loading');
+    this.service
+      .listTechniciansForLocation(locationId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (techs) => {
+          this.technicians.set(techs);
+          this.rosterState.set('ready');
+        },
+        error: () => {
+          this.technicians.set([]);
+          this.rosterState.set('error');
         },
       });
   }
@@ -86,11 +129,58 @@ export class WorkorderAssignPageComponent implements OnInit {
       });
   }
 
+  // ── Technician typeahead interaction ──────────────────────────────────────
+  onTechInput(text: string): void {
+    this.techQuery.set(text);
+    // Typing invalidates a prior selection until a row is chosen again.
+    this.technicianId.set('');
+    this.showTechList.set(true);
+    this.activeIndex.set(-1);
+  }
+
+  onTechFocus(): void {
+    this.showTechList.set(true);
+  }
+
+  onTechBlur(): void {
+    // Delay so a row mousedown registers before the list closes.
+    setTimeout(() => this.showTechList.set(false), 150);
+  }
+
+  onTechKeydown(event: KeyboardEvent): void {
+    const items = this.filteredTechnicians();
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.showTechList.set(true);
+      this.activeIndex.set(Math.min(this.activeIndex() + 1, items.length - 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.activeIndex.set(Math.max(this.activeIndex() - 1, 0));
+    } else if (event.key === 'Enter') {
+      const idx = this.activeIndex();
+      if (idx >= 0 && idx < items.length) {
+        event.preventDefault();
+        this.selectTechnician(items[idx]);
+      }
+    } else if (event.key === 'Escape') {
+      this.showTechList.set(false);
+      this.activeIndex.set(-1);
+    }
+  }
+
+  selectTechnician(tech: LocationTechnician): void {
+    this.technicianId.set(tech.id);
+    this.techQuery.set(tech.name);
+    this.showTechList.set(false);
+    this.activeIndex.set(-1);
+    this.saveError.set(null);
+  }
+
   save(): void {
     const id = this.workorderId();
     const techId = this.technicianId().trim();
     if (!techId) {
-      this.saveError.set('Technician ID is required.');
+      this.saveError.set('Select a technician from the list.');
       return;
     }
     const request: AssignTechnicianRequest = { technicianId: techId, notes: this.notes().trim() || undefined };

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { PeopleAvailabilityAPIService, PeopleAvailabilityResponse } from '@durion-sdk/people';
 import { ApiBaseService } from '../../../core/services/api-base.service';
 import {
   ChangeRequestAPIService,
@@ -28,6 +29,7 @@ import {
   AssignTechnicianRequest,
   CalculateEstimateTotalsResponse,
   ChangeRequestResponse,
+  LocationTechnician,
   CompleteWorkorderRequest,
   CompleteWorkorderResponse,
   ConsumePickedItemsRequest,
@@ -160,6 +162,7 @@ export class WorkexecService {
   private readonly substituteLink = inject(SubstituteLinkAPIService);
   private readonly workorderPartAdjustments = inject(WorkorderPartAdjustmentsService);
   private readonly timeTracking = inject(WorkexecTimeTrackingAPIService);
+  private readonly peopleAvailability = inject(PeopleAvailabilityAPIService);
 
   /** Builds an options object carrying the Idempotency-Key header when a key is provided. */
   private idempotencyOptions(key?: string) {
@@ -820,6 +823,38 @@ export class WorkexecService {
    */
   getTechnicianAssignment(workorderId: string): Observable<TechnicianAssignmentResponse> {
     return this.technicianAssignment.getTechnicianAssignment(workorderId) as Observable<TechnicianAssignmentResponse>;
+  }
+
+  /**
+   * operationId: getPeopleAvailability
+   * GET /v1/people/availability?locationId={locationId}
+   *
+   * Returns the technicians staffed at a location, used to populate the assign
+   * page typeahead. Filters the location roster to ACTIVE assignments whose role
+   * denotes a technician/mechanic — role labels are not strictly normalised
+   * (TECHNICIAN, TECH, MECHANIC all occur), so the match is case-insensitive on
+   * those stems.
+   */
+  listTechniciansForLocation(locationId: string): Observable<LocationTechnician[]> {
+    return this.peopleAvailability.getPeopleAvailability(locationId.trim()).pipe(
+      map(roster => (roster ?? [])
+        .filter(p => String(p.assignmentStatus) !== 'ENDED' && this.isTechnicianRole(p.role))
+        .map(p => this.toLocationTechnician(p))),
+    );
+  }
+
+  private isTechnicianRole(role?: string): boolean {
+    const r = (role ?? '').toLowerCase();
+    return r.includes('tech') || r.includes('mechanic');
+  }
+
+  private toLocationTechnician(p: PeopleAvailabilityResponse): LocationTechnician {
+    const name = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+    return {
+      id: p.personId,
+      name: name || p.personId,
+      role: p.role,
+    };
   }
 
   // ── CAP-005: Start Work (Story 224) ──────────────────────────────────────

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -836,7 +836,8 @@ export class WorkexecService {
    * those stems.
    */
   listTechniciansForLocation(locationId: string): Observable<LocationTechnician[]> {
-    return this.peopleAvailability.getPeopleAvailability(locationId.trim()).pipe(
+    const today = new Date().toISOString().slice(0, 10);
+    return this.peopleAvailability.getPeopleAvailability(locationId.trim(), today).pipe(
       map(roster => (roster ?? [])
         .filter(p => String(p.assignmentStatus) !== 'ENDED' && this.isTechnicianRole(p.role))
         .map(p => this.toLocationTechnician(p))),


### PR DESCRIPTION
## Summary

- Replace the raw technician UUID text input on the workorder assign page with a location-scoped typeahead dropdown.
- Roster loads from the workorder's location (`shopId`) via the people-availability endpoint, filtered to ACTIVE technician/mechanic assignments.
- All technicians show on focus; typing filters client-side by name or id; selecting a row submits the canonical `personId`.
- New `WorkexecService.listTechniciansForLocation(locationId)` wrapping `PeopleAvailabilityAPIService.getPeopleAvailability`, new `LocationTechnician` model, combobox markup with listbox roles and arrow/Enter/Escape keyboard nav.
- Frontend only — no backend or contract changes (`getPeopleAvailability` already in the people SDK).

## Validation

- [x] `npm run build` (ng build bundle generation complete)
- [x] `npm run test` (ng test: 1688 passed, 0 failed)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [x] All interactive controls reachable using `Tab`/`Shift+Tab`
- [x] Visible focus indicator present on focused controls
- [x] No keyboard traps encountered
- [x] Primary user flow completes without pointer input (combobox supports arrow/Enter/Escape selection)
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

## Notes / Follow-ups

- Role labels are not strictly normalised (`TECHNICIAN`/`TECH`/`MECHANIC`); filter matches case-insensitively on `tech`/`mechanic` stems.
- Screen-reader smoke (NVDA/VoiceOver) not yet run — needs manual pass before merge.
- Decisions confirmed with requester: technicians-only roster, location sourced from workorder `shopId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
