### PR TITLE
fix(workexec): distinguish "no shop assigned" from roster load failure

### DIFF
--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.html
@@ -48,6 +48,9 @@
         @if (rosterState() === 'error') {
           <p class="hint-text">Could not load technicians for this location.</p>
         }
+        @if (rosterState() === 'no-shop') {
+          <p class="hint-text">This work order has no shop assigned, so technicians cannot be listed.</p>
+        }
         @if (rosterState() === 'ready' && technicians().length === 0) {
           <p class="hint-text">No technicians assigned to this location.</p>
         }

--- a/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-assign/workorder-assign-page.component.ts
@@ -14,7 +14,7 @@ import { WorkexecService } from '../../services/workexec.service';
 
 type PageState = 'loading' | 'ready' | 'error';
 type FormMode = 'assign' | 'reassign';
-type RosterState = 'idle' | 'loading' | 'ready' | 'error';
+type RosterState = 'idle' | 'loading' | 'ready' | 'error' | 'no-shop';
 
 /**
  * WorkorderAssignPageComponent — Story 225 (CAP-005)
@@ -97,7 +97,9 @@ export class WorkorderAssignPageComponent implements OnInit {
 
   private loadTechnicians(locationId: string | undefined): void {
     if (!locationId) {
-      this.rosterState.set('error');
+      // The work order has no shop, so there is no location to source a roster from.
+      // Distinct from 'error' (a failed availability call) so the UI can explain why.
+      this.rosterState.set('no-shop');
       return;
     }
     this.rosterState.set('loading');


### PR DESCRIPTION
## Problem
On the assign page, when a work order has no `shopId`, `loadTechnicians` set `rosterState = 'error'` — the same state as a failed availability call. The no-shop case never fires a request, so the generic "Could not load technicians for this location." message was misleading. (This is the UX half of the root cause fixed backend-side in durion-positivity-backend#748.)

## Fix
- New `'no-shop'` roster state, set when `shopId` is absent.
- Distinct message: *"This work order has no shop assigned, so technicians cannot be listed."*
- A genuine availability-call failure still shows the load-failure message.

## Verification
- `tsc --noEmit` clean (template change is a literal `@if` block mirroring existing roster-state blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)