### PR TITLE
fix(workexec): show workorder number and parts on detail screen

### DIFF
--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -335,6 +335,7 @@ export interface WorkorderResponse {
 /** operationId: getWorkorderDetail — rich composite response */
 export interface WorkorderDetailResponse {
   id: string;
+  workorderNumber?: string;
   estimateId?: string;
   status?: WorkorderStatus;
   customerId?: string;

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
@@ -18,7 +18,7 @@
     <div class="wo-header__inner">
       <div class="wo-header__identity">
         <p class="wo-header__overline">Work Order</p>
-        <h1 id="wo-heading" class="wo-header__id">{{ workorderId() }}</h1>
+        <h1 id="wo-heading" class="wo-header__id">{{ workorder()!.workorderNumber ?? workorderId() }}</h1>
         <span class="status-chip status-chip--{{ workorder()!.status?.toLowerCase() }}"
           aria-label="Status: {{ workorder()!.status }}">{{ workorder()!.status }}</span>
       </div>
@@ -262,7 +262,7 @@
 @if (showStartWorkModal()) {
 <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-work-modal-title">
   <div class="modal-glass">
-    <h2 id="start-work-modal-title" class="modal-glass__title">Start Work on {{ workorderId() }}?</h2>
+    <h2 id="start-work-modal-title" class="modal-glass__title">Start Work on {{ workorder()!.workorderNumber ?? workorderId() }}?</h2>
     <p class="modal-glass__body">
       This will move the work order to <strong>IN PROGRESS</strong> and allow labor and parts recording.
       This action cannot be undone from this screen.

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -443,6 +443,7 @@ export class WorkexecService {
     }));
     return {
       id: dto.workorderId,
+      workorderNumber: dto.workorderNumber,
       status: (dto.status as string as WorkorderStatus) ?? undefined,
       customerId: dto.customerId,
       vehicleId: dto.vehicleId,


### PR DESCRIPTION
## Problem
Workorder detail screen showed the raw UUID in the heading instead of the human number (WO-YYYY-NNNN), and parts were missing.

The SDK already exposes `workorderNumber` and `parts`, but the local adapter `toWorkorderDetailResponse` dropped `workorderNumber`, and the template rendered the route param UUID.

## Fix
- `WorkorderDetailResponse` model gains `workorderNumber`.
- Adapter carries `dto.workorderNumber` through.
- Template renders `workorder().workorderNumber ?? workorderId()` in the heading and the Start Work modal title.
- Parts: the adapter already flattens `dto.parts` into scope items — they appear once the backend populates standalone parts (durion-positivity-backend#749).

## Verification
- `tsc --noEmit`: clean
- Detail spec: no assertions on changed lines (heading/number not asserted)

> Note: full `ng test` not run locally (vendored `sdk:install` build); change is a model field + adapter passthrough + null-coalescing template binding.

## Related
- Backend: durion-positivity-backend#749 (emit real number; include standalone parts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)