### PR TITLE
fix(crm): correct customer type filter values to PartyType enum

### DIFF
--- a/src/app/features/crm/pages/customer-list/customer-list.component.html
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.html
@@ -41,8 +41,8 @@
       <label for="filter-party-type" class="sr-only">Party type</label>
       <select id="filter-party-type" formControlName="partyType" class="filter-select" data-testid="filter-party-type">
         <option value="">All types</option>
-        <option value="ORGANIZATION">Commercial</option>
-        <option value="INDIVIDUAL">Individual</option>
+        <option value="COMMERCIAL">Commercial</option>
+        <option value="PERSON">Individual</option>
       </select>
     </div>
     <button class="btn btn--ghost" type="button" (click)="clearFilters()" data-testid="clear-filters">Clear</button>

--- a/src/app/features/crm/pages/customer-list/customer-list.component.spec.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.spec.ts
@@ -87,12 +87,12 @@ describe('CustomerListComponent', () => {
     fixture.detectChanges();
     crmServiceStub.browseParties.mockClear();
 
-    component.filterForm.patchValue({ name: 'acme', status: 'ACTIVE', partyType: 'ORGANIZATION', customerNumber: 'CUST-1' });
+    component.filterForm.patchValue({ name: 'acme', status: 'ACTIVE', partyType: 'COMMERCIAL', customerNumber: 'CUST-1' });
     await new Promise(r => setTimeout(r, 400));
 
     expect(crmServiceStub.browseParties).toHaveBeenCalledWith(
       expect.objectContaining({
-        page: 0, name: 'acme', status: 'ACTIVE', partyType: 'ORGANIZATION', customerNumber: 'CUST-1',
+        page: 0, name: 'acme', status: 'ACTIVE', partyType: 'COMMERCIAL', customerNumber: 'CUST-1',
       }),
     );
   });


### PR DESCRIPTION
## Problem
On the CRM customers page, selecting a Type filter (Individual / Commercial) returned **empty** results.

The filter sent `INDIVIDUAL` / `ORGANIZATION`, but the backend `PartyType` enum is `PERSON` / `COMMERCIAL`, and the browse search matches the value case-insensitively against `partyType.toString()` (`PartyServiceImpl:228`). No row's type ever equalled the sent value → everything filtered out.

## Fix (frontend-only)
Map the `<option>` **values** to the real enum names (labels unchanged):
- Commercial: `ORGANIZATION` → `COMMERCIAL`
- Individual: `INDIVIDUAL` → `PERSON`

Spec updated to assert the corrected value.

Backend is correct — no backend/contract change.

## Verification
- `tsc --noEmit`: clean
- Values now equal the enum names the search compares against

> Out of scope: `merge-parties` renders `INDIVIDUAL` as a display-only label from `taxId` (cosmetic, not a filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)