### PR TITLE
feat(workexec): approve workorder + status-gated detail actions

### DIFF
--- a/src/app/features/workexec/models/workexec.models.ts
+++ b/src/app/features/workexec/models/workexec.models.ts
@@ -294,18 +294,17 @@ export interface ApproveEstimateRequest {
 
 // ── CAP-004: Workorder types (Stories 231, 230, 229, 228, 227, 226) ──────────
 
+// Mirrors the backend WorkorderStatus enum / SDK WorkorderDetailResponseStatusEnum.
 export type WorkorderStatus =
   | 'DRAFT'
-  | 'PLANNED'
-  | 'PENDING_ASSIGNMENT'
+  | 'APPROVED'
   | 'ASSIGNED'
-  | 'IN_PROGRESS'
-  | 'ON_HOLD'
-  | 'PENDING_REVIEW'
+  | 'WORK_IN_PROGRESS'
+  | 'AWAITING_PARTS'
+  | 'AWAITING_APPROVAL'
+  | 'READY_FOR_PICKUP'
   | 'COMPLETED'
-  | 'INVOICED'
-  | 'CANCELLED'
-  | 'ARCHIVED';
+  | 'CANCELLED';
 
 export type ChangeRequestStatus =
   | 'AWAITING_ADVISOR_REVIEW'

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
@@ -45,6 +45,9 @@
 
       <!-- Primary CTAs — Electric Teal only for positive primary action -->
       <div class="wo-header__actions">
+        @if (canApprove()) {
+        <button class="btn btn--accent" (click)="openApproveModal()">Approve Work Order</button>
+        }
         @if (canStartWork()) {
         <button class="btn btn--accent" (click)="openStartWorkModal()">Start Work</button>
         }
@@ -67,7 +70,9 @@
         @if (invoiceError()) {
         <span class="inline-error" role="alert">{{ invoiceError() }}</span>
         }
-        <button class="btn btn--ghost" (click)="navigateToAssign()">
+        <button class="btn btn--ghost" (click)="navigateToAssign()"
+          [disabled]="!canAssignTechnician()"
+          [attr.title]="canAssignTechnician() ? null : 'Approve the work order before assigning a technician'">
           {{ technicianName() ? 'Reassign' : 'Assign Technician' }}
         </button>
       </div>
@@ -259,6 +264,42 @@
 }
 
 <!-- Start Work confirmation modal — glassmorphism per design authority -->
+@if (showApproveModal()) {
+<div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="approve-modal-title">
+  <div class="modal-glass">
+    <h2 id="approve-modal-title" class="modal-glass__title">Approve {{ workorder()!.workorderNumber ?? workorderId() }}?</h2>
+    <p class="modal-glass__body">
+      This moves the work order to <strong>APPROVED</strong>, after which a technician can be assigned.
+    </p>
+
+    <label class="field">
+      <span class="field__label">Approved by (name)</span>
+      <input class="field__input" type="text" [value]="approveSignerName()"
+        (input)="approveSignerName.set($any($event.target).value)"
+        placeholder="Name of approver" />
+    </label>
+    <label class="field">
+      <span class="field__label">Notes (optional)</span>
+      <textarea class="field__input" rows="2" [value]="approveNotes()"
+        (input)="approveNotes.set($any($event.target).value)"></textarea>
+    </label>
+
+    @if (approveError()) {
+    <div class="alert alert--error" role="alert">{{ approveError() }}</div>
+    }
+
+    <div class="modal-glass__actions">
+      <button class="btn btn--ghost" (click)="cancelApprove()"
+        [disabled]="approveModalState() === 'loading'">Cancel</button>
+      <button class="btn btn--accent" (click)="confirmApprove()"
+        [disabled]="approveModalState() === 'loading'" [attr.aria-busy]="approveModalState() === 'loading'">
+        {{ approveModalState() === 'loading' ? 'Approving…' : 'Confirm — Approve' }}
+      </button>
+    </div>
+  </div>
+</div>
+}
+
 @if (showStartWorkModal()) {
 <div class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="start-work-modal-title">
   <div class="modal-glass">

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
@@ -116,7 +116,7 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
 
     it('does not call loadWorkorder after component is destroyed before 1200 ms elapses (F5/r2998536732)', () => {
       fixture.detectChanges();
-      drainInit(http, { ...STUB_WORKORDER, status: 'IN_PROGRESS' });
+      drainInit(http, { ...STUB_WORKORDER, status: 'WORK_IN_PROGRESS' });
 
       component.completionNotes.set('all done');
       component.confirmComplete();
@@ -167,11 +167,37 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
   describe('checklist DOM structure (PRCR-003)', () => {
     it('renders ul.checklist-list when pageState is ready and canComplete() is true', () => {
       fixture.detectChanges();
-      drainInit(http, { ...STUB_WORKORDER, status: 'IN_PROGRESS' });
+      drainInit(http, { ...STUB_WORKORDER, status: 'WORK_IN_PROGRESS' });
       fixture.detectChanges();
 
       const list = fixture.nativeElement.querySelector('ul.checklist-list');
       expect(list).not.toBeNull();
+    });
+  });
+
+  describe('status-gated workflow actions', () => {
+    it('shows Approve and disables Assign Technician when DRAFT', () => {
+      fixture.detectChanges();
+      drainInit(http, { ...STUB_WORKORDER, status: 'DRAFT' });
+      fixture.detectChanges();
+
+      const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+      const approve = buttons.find(b => (b.textContent ?? '').includes('Approve Work Order'));
+      const assign = buttons.find(b => (b.textContent ?? '').includes('Assign Technician'));
+      expect(approve).toBeTruthy();
+      expect(assign?.disabled).toBe(true);
+    });
+
+    it('hides Approve and enables Assign Technician when APPROVED', () => {
+      fixture.detectChanges();
+      drainInit(http, { ...STUB_WORKORDER, status: 'APPROVED' });
+      fixture.detectChanges();
+
+      const buttons = Array.from(fixture.nativeElement.querySelectorAll('button')) as HTMLButtonElement[];
+      const approve = buttons.find(b => (b.textContent ?? '').includes('Approve Work Order'));
+      const assign = buttons.find(b => (b.textContent ?? '').includes('Assign Technician'));
+      expect(approve).toBeUndefined();
+      expect(assign?.disabled).toBe(false);
     });
   });
 

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
@@ -55,6 +55,14 @@ export class WorkorderDetailPageComponent implements OnInit {
   readonly activeTab = signal<WorkorderTab>('items');
   readonly errorMessage = signal<string | null>(null);
 
+  // ── Approve Workorder modal (DRAFT → APPROVED) ────────────────────────────
+
+  readonly showApproveModal = signal(false);
+  readonly approveModalState = signal<ModalState>('idle');
+  readonly approveSignerName = signal('');
+  readonly approveNotes = signal('');
+  readonly approveError = signal<string | null>(null);
+
   // ── Start Work modal ──────────────────────────────────────────────────────
 
   readonly showStartWorkModal = signal(false);
@@ -98,25 +106,37 @@ export class WorkorderDetailPageComponent implements OnInit {
 
   // ── Computed guards ───────────────────────────────────────────────────────
 
-  readonly canStartWork = computed(() => {
-    const wo = this.workorder();
-    return wo?.status === 'ASSIGNED' || wo?.status === 'PENDING_ASSIGNMENT';
+  /** DRAFT is the only status that can be approved (DRAFT → APPROVED). */
+  readonly canApprove = computed(() => this.workorder()?.status === 'DRAFT');
+
+  /** Technician (re)assignment is allowed once approved and before completion. */
+  readonly canAssignTechnician = computed(() => {
+    const s = this.workorder()?.status;
+    return s === 'APPROVED' || s === 'ASSIGNED' || s === 'WORK_IN_PROGRESS';
   });
 
-  readonly isInProgress = computed(() => this.workorder()?.status === 'IN_PROGRESS');
+  readonly canStartWork = computed(() => {
+    const s = this.workorder()?.status;
+    return s === 'APPROVED' || s === 'ASSIGNED';
+  });
+
+  readonly isInProgress = computed(() => this.workorder()?.status === 'WORK_IN_PROGRESS');
 
   readonly isCompleted = computed(() => this.workorder()?.status === 'COMPLETED');
 
   readonly canComplete = computed(() => {
-    const wo = this.workorder();
-    return wo?.status === 'IN_PROGRESS' || wo?.status === 'PENDING_REVIEW';
+    const s = this.workorder()?.status;
+    return (
+      s === 'WORK_IN_PROGRESS' ||
+      s === 'AWAITING_PARTS' ||
+      s === 'AWAITING_APPROVAL' ||
+      s === 'READY_FOR_PICKUP'
+    );
   });
 
   readonly canReopen = computed(() => this.workorder()?.status === 'COMPLETED');
 
-  readonly canCreateInvoice = computed(() =>
-    this.workorder()?.status === 'COMPLETED' || this.workorder()?.status === 'INVOICED',
-  );
+  readonly canCreateInvoice = computed(() => this.workorder()?.status === 'COMPLETED');
 
   readonly pendingCrCount = computed(
     () => this.changeRequests().filter(cr => cr.status === 'AWAITING_ADVISOR_REVIEW').length,
@@ -124,10 +144,10 @@ export class WorkorderDetailPageComponent implements OnInit {
 
   readonly items = computed((): WorkorderItemResponse[] => this.workorder()?.items ?? []);
 
-  /** Line items can be completed while the workorder is not terminal. */
+  /** Line items can only be completed once work has started (not in DRAFT/APPROVED/ASSIGNED). */
   readonly canCompleteItems = computed(() => {
     const s = this.workorder()?.status;
-    return s !== undefined && s !== 'COMPLETED' && s !== 'CANCELLED';
+    return s === 'WORK_IN_PROGRESS' || s === 'AWAITING_PARTS' || s === 'AWAITING_APPROVAL';
   });
 
   readonly technicianName = computed(() =>
@@ -203,6 +223,47 @@ export class WorkorderDetailPageComponent implements OnInit {
   }
 
   // ── Start Work ────────────────────────────────────────────────────────────
+
+  // ── Approve Workorder (DRAFT → APPROVED) ─────────────────────────────────
+
+  openApproveModal(): void {
+    this.approveError.set(null);
+    this.approveModalState.set('confirming');
+    this.approveSignerName.set('');
+    this.approveNotes.set('');
+    this.showApproveModal.set(true);
+  }
+
+  confirmApprove(): void {
+    const id = this.workorderId();
+    const customerId = this.workorder()?.customerId;
+    if (!customerId) {
+      this.approveError.set('Work order has no customer; cannot approve.');
+      return;
+    }
+    this.approveModalState.set('loading');
+    this.approveError.set(null);
+    this.service
+      .approveWorkorder(id, customerId, this.approveSignerName().trim() || undefined, this.approveNotes().trim() || undefined)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.approveModalState.set('success');
+          this.showApproveModal.set(false);
+          this.loadWorkorder(id);
+        },
+        error: (err) => {
+          this.approveModalState.set('error');
+          this.approveError.set(err?.error?.message ?? 'Failed to approve work order. Please try again.');
+        },
+      });
+  }
+
+  cancelApprove(): void {
+    this.showApproveModal.set(false);
+    this.approveError.set(null);
+    this.approveModalState.set('idle');
+  }
 
   openStartWorkModal(): void {
     this.startWorkError.set(null);
@@ -425,6 +486,9 @@ export class WorkorderDetailPageComponent implements OnInit {
   // ── Navigation helpers ────────────────────────────────────────────────────
 
   navigateToAssign(): void {
+    if (!this.canAssignTechnician()) {
+      return;
+    }
     this.router.navigate(['/app/workexec/workorders', this.workorderId(), 'assign']);
   }
 

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -492,7 +492,7 @@ export class WorkexecService {
   private toReopenWorkorderResponse(dto: import('@durion-sdk/workorder').ReopenWorkorderResponse): ReopenWorkorderResponse {
     return {
       workorderId: dto.workorderId ?? '',
-      status: (dto.currentStatus as WorkorderStatus) ?? 'IN_PROGRESS',
+      status: (dto.currentStatus as WorkorderStatus) ?? 'WORK_IN_PROGRESS',
       reopenedAt: dto.reopenedAt,
     };
   }
@@ -783,6 +783,26 @@ export class WorkexecService {
 
   getWorkorder(workorderId: string): Observable<WorkorderResponse> {
     return this.getWorkorderById(workorderId);
+  }
+
+  /**
+   * operationId: approveWorkorder
+   * POST /v1/workorders/{workorderId}/approval
+   * Advances a DRAFT workorder to APPROVED. Click-confirm approval: customer +
+   * signer name, no signature image (CLICK_CONFIRM approval method).
+   */
+  approveWorkorder(
+    workorderId: string,
+    customerId: string,
+    signerName?: string,
+    notes?: string,
+  ): Observable<WorkorderResponse> {
+    const request: import('@durion-sdk/workorder').ApproveWorkorderRequest = {
+      customerId,
+      signerName: signerName || undefined,
+      notes: notes || undefined,
+    };
+    return this.workOrderApi.approveWorkorder(workorderId, request) as Observable<WorkorderResponse>;
   }
 
   /**


### PR DESCRIPTION
## What
On the workorder detail page:
- **Add an Approve Work Order action** (DRAFT → APPROVED) — click-confirm modal (customer + signer name + notes, no signature), wiring the existing `approveWorkorder` endpoint.
- **Disable Assign/Reassign Technician** until the workorder is APPROVED / ASSIGNED / WORK_IN_PROGRESS (the backend assignment precondition) — stops users hitting a 400 on a DRAFT workorder.
- **Gate per-item completion checkboxes** to work-started statuses.

## Root cause it also fixes
The page's `WorkorderStatus` union was **stale and fictional** (`IN_PROGRESS`, `PENDING_ASSIGNMENT`, `PENDING_REVIEW`, `INVOICED`, …) — values the backend/SDK never emit (real enum: `WORK_IN_PROGRESS`, `APPROVED`, `AWAITING_*`, …). So guards silently never matched: **Complete and Record Labor never appeared**, and Assign was always enabled. Aligned the union to the SDK and corrected every guard (`canStartWork`, `isInProgress`, `canComplete`, `canCreateInvoice`).

## Scope
Frontend-only — the approve endpoint (`POST /v1/workorders/{id}/approval`) and SDK `approveWorkorder` already exist; no backend/contract change.

## Verification
- `tsc` (app + spec): clean
- `ng test` (detail spec): **11 passed** (incl. 2 new — DRAFT shows Approve + disables Assign; APPROVED hides Approve + enables Assign)

🤖 Generated with [Claude Code](https://claude.com/claude-code)