### PR TITLE
fix(workexec): send technicianId when starting a labor session

### DIFF
--- a/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.ts
@@ -104,9 +104,15 @@ export class WorkorderLaborPageComponent implements OnInit {
       this.sessionError.set('Select a labor service line to start a session.');
       return;
     }
+    const technicianId =
+      this.workorder()?.primaryTechnicianId ?? this.workorder()?.technician?.technicianId;
+    if (!technicianId) {
+      this.sessionError.set('This work order has no assigned technician. Assign a technician before starting labor.');
+      return;
+    }
     this.sessionState.set('starting');
     this.sessionError.set(null);
-    const request: StartLaborRequest = { workorderServiceId: serviceId };
+    const request: StartLaborRequest = { workorderServiceId: serviceId, technicianId };
     this.service
       .startLaborSession(id, serviceId, request, uuidv4())
       .pipe(takeUntilDestroyed(this.destroyRef))


### PR DESCRIPTION
## Problem
Starting a labor session returned `VALIDATION_FAILED` — "Technician ID is required". The labor page built the request as `{ workorderServiceId }` with no `technicianId`, so the service adapter sent `technicianId: ''` and the backend rejected it.

## Fix
Source `technicianId` from the workorder's assigned technician (`primaryTechnicianId`, falling back to `technician.technicianId`) and guard with a clear message when none is assigned. The page already loads `getWorkorderDetail`, so the assigned tech is available. Backend stores `technicianId` as the performing technician (no match validation), so the assigned tech is correct.

## Verification
- `tsc` clean. (Component has no spec.)

Frontend-only — no backend/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)