### PR TITLE
[design] Brand & Asset Guide v2 rollout (gold, mic→dur, token cleanup, stylelint guard)

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,32 @@
+{
+  "//": "Durion drift guardrail. Run: npx stylelint \"src/**/*.css\". See design/source/durion-style-guide.md.",
+  "rules": {
+    "selector-disallowed-list": [
+      ["/\\.mic-(elevation|status)/"],
+      {
+        "message": "Use the .dur-* utility prefix, not .mic-* (mic- is upstream-template drift). See design/source/durion-style-guide.md §05.",
+        "severity": "error"
+      }
+    ],
+    "declaration-property-value-disallowed-list": [
+      {
+        "/.+/": [
+          "/--surface-container[a-z0-9-]*/",
+          "/--secondary-container/",
+          "/--on-surface[a-z-]*/",
+          "/--on-(secondary|error)-container/",
+          "/--error-container/",
+          "/--color-(primary|secondary|error|warning|success|on-[a-z-]+)/",
+          "/--typescale-[a-z0-9-]+/",
+          "/--spacing-[0-9]/",
+          "/Michelin Unit Titling/",
+          "/#cc9030/i"
+        ]
+      },
+      {
+        "message": "Unsanctioned or undefined token. Use a documented Durion token (design/source/theme-tokens.md): --space-* not --spacing-*; --brand-primary / --cardBackground / --currentTextColor not Material-3 names like --color-primary or --surface-container-*; --goldA400 not raw #cc9030; Barlow Semi Condensed not 'Michelin Unit Titling'.",
+        "severity": "error"
+      }
+    ]
+  }
+}

--- a/design/source/durion-style-guide.md
+++ b/design/source/durion-style-guide.md
@@ -1,168 +1,141 @@
 # Durion Style Guide
 
-This guide is derived from `durion/theme/durion-theme.css` and the `durion/theme/fonts` + `durion/theme/images` asset folders.
+> **v2 · June 2026 — reconciled to `src/styles.css`.** Changes in this revision: functional
+> error/success hex corrected (`#ba1a1a` / `#2e7d32`); **Heritage Gold** added as a documented
+> token; display font moved from the retired `'Michelin Unit Titling'` to **Barlow Semi
+> Condensed**; both fonts now self-hosted; utility prefix confirmed as **`.dur-*`** (the shipped
+> `.mic-*` is drift and is being renamed back). See `theme-tokens.md` for the full token inventory.
 
-Excluded by request:
-
-- `durion/theme/tiotf-theme.css`
+This guide is derived from `src/styles.css` and the asset folders under `src/assets/` and
+`design/source/`.
 
 ## 1. Brand Foundation
 
 Durion uses a cool industrial palette:
 
-- Blueprint Blues for primary brand actions and navigation
-- Graphite + neutral greys for structure and UI chrome
-- Electric Teal for accent and secondary emphasis
-- Functional colors for alerts and status semantics
+- **Blueprint Blues** — primary brand actions and navigation
+- **Graphite + neutral greys** — structure and UI chrome
+- **Electric Teal** — the UI accent and secondary emphasis (UI only; never in the logo)
+- **Heritage Gold** — the logo shield border, and sparing heritage/premium accent
+- **Functional colors** — alerts and status semantics
 
 ## 2. Typography
 
-Primary font families:
+- **Display / headings (`--font-primary`):** `Barlow Semi Condensed` → falls back to `Noto Sans`, `sans-serif`.
+- **Body & UI (`--font-body`):** `Noto Sans` (400, 400i, 500, 600, 700, 700i) → `sans-serif`.
+- **Icon fonts:** `Material Symbols Round`, `Material Icons Two Tone`.
 
-- `Noto Sans` (regular + italic, bold + bold italic)
+Both text faces are **self-hosted** under `src/assets/fonts/` and loaded via `@font-face`
+(`@import`ed at the top of `styles.css`). Do not rely on system-installed fonts.
 
-Icon fonts:
+### Ratified Barlow display weight scale
 
-- `Material Icons Two Tone`
-- `Material Symbols Round`
+Only **three** Barlow Semi Condensed weights are hosted: **500 / 600 / 700**. These are the
+**only** valid weights for `--font-primary`. Requesting any other weight (100–400, 800, 900)
+has no matching `@font-face`, so the browser **synthesises** a faux weight — banned.
 
-Global behavior:
+| Token | Weight | Role |
+|---|---|---|
+| `--font-weight-display` | **700** (Bold) | `h1`, page titles, strong display emphasis |
+| `--font-weight-heading` | **600** (SemiBold) | `h2`–`h4`, card/section titles, overlines, labels, status chips, buttons |
+| `--font-weight-medium`  | **500** (Medium) | large or lighter display subheads where 600 is too heavy |
 
-- Universal fallback: `Noto Sans, sans-serif`
-- Body stack:  `Noto Sans`, sans-serif
+Use the tokens (defined in `styles.css` / `durion-theme.css`) rather than raw numbers, and
+never pair `--font-primary` with a weight outside {500, 600, 700}. Body text keeps the full
+Noto Sans range (400–700).
+
+> `'Michelin Unit Titling'` is **retired** — it is licensed to Michelin and was never shipped,
+> so it silently fell back to Noto Sans. Removed from the stack.
 
 ## 3. Core Color Tokens
 
-### Blueprint Blues
+See `theme-tokens.md` for full ramps. Canonical values (matching `styles.css`):
 
-| Token | Hex | Preview |
-| --- | --- | --- |
-| `--durion-blue-800` | `#1c2e48` | <span style="display:inline-block;width:64px;height:20px;background:#1c2e48;border:1px solid #ccc;"></span> |
-| `--durion-blue-700` | `#2b4c78` | <span style="display:inline-block;width:64px;height:20px;background:#2b4c78;border:1px solid #ccc;"></span> |
-| `--durion-blue-600` | `#355d92` | <span style="display:inline-block;width:64px;height:20px;background:#355d92;border:1px solid #ccc;"></span> |
-| `--durion-blue-500` | `#4d76b2` | <span style="display:inline-block;width:64px;height:20px;background:#4d76b2;border:1px solid #ccc;"></span> |
-| `--durion-blue-400` | `#668fc2` | <span style="display:inline-block;width:64px;height:20px;background:#668fc2;border:1px solid #ccc;"></span> |
-| `--durion-blue-300` | `#7fa4d1` | <span style="display:inline-block;width:64px;height:20px;background:#7fa4d1;border:1px solid #ccc;"></span> |
-| `--durion-blue-200` | `#aac4e4` | <span style="display:inline-block;width:64px;height:20px;background:#aac4e4;border:1px solid #ccc;"></span> |
-| `--durion-blue-100` | `#d3e3f6` | <span style="display:inline-block;width:64px;height:20px;background:#d3e3f6;border:1px solid #ccc;"></span> |
-| `--durion-blue-50` | `#f4f8fe` | <span style="display:inline-block;width:64px;height:20px;background:#f4f8fe;border:1px solid #ccc;"></span> |
+### Blueprint Blues
+`800 #1c2e48 · 700 #2b4c78 · 600 #355d92 · 500 #4d76b2 · 400 #668fc2 · 300 #7fa4d1 · 200 #aac4e4 · 100 #d3e3f6 · 50 #f4f8fe`
 
 ### Graphite
+`800 #333842 · 700 #444a55 · 600 #5a616e · 500 #727986 · 200 #d7d9dd · 100 #e7e8eb`
 
-| Token | Hex | Preview |
-| --- | --- | --- |
-| `--durion-graphite-800` | `#333842` | <span style="display:inline-block;width:64px;height:20px;background:#333842;border:1px solid #ccc;"></span> |
-| `--durion-graphite-700` | `#444a55` | <span style="display:inline-block;width:64px;height:20px;background:#444a55;border:1px solid #ccc;"></span> |
-| `--durion-graphite-600` | `#5a616e` | <span style="display:inline-block;width:64px;height:20px;background:#5a616e;border:1px solid #ccc;"></span> |
-| `--durion-graphite-500` | `#727986` | <span style="display:inline-block;width:64px;height:20px;background:#727986;border:1px solid #ccc;"></span> |
-| `--durion-graphite-200` | `#d7d9dd` | <span style="display:inline-block;width:64px;height:20px;background:#d7d9dd;border:1px solid #ccc;"></span> |
-| `--durion-graphite-100` | `#e7e8eb` | <span style="display:inline-block;width:64px;height:20px;background:#e7e8eb;border:1px solid #ccc;"></span> |
+### Electric Teal (UI accent)
+`600 #158f83 · 500 #1fa497 · 400 #2bbbad · 300 #55d7cc · 200 #a4e9e1 · 100 #d7f3f0`
 
-### Electric Teal
-
-| Token | Hex | Preview |
-| --- | --- | --- |
-| `--durion-teal-600` | `#158f83` | <span style="display:inline-block;width:64px;height:20px;background:#158f83;border:1px solid #ccc;"></span> |
-| `--durion-teal-500` | `#1fa497` | <span style="display:inline-block;width:64px;height:20px;background:#1fa497;border:1px solid #ccc;"></span> |
-| `--durion-teal-400` | `#2bbbad` | <span style="display:inline-block;width:64px;height:20px;background:#2bbbad;border:1px solid #ccc;"></span> |
-| `--durion-teal-300` | `#55d7cc` | <span style="display:inline-block;width:64px;height:20px;background:#55d7cc;border:1px solid #ccc;"></span> |
-| `--durion-teal-200` | `#a4e9e1` | <span style="display:inline-block;width:64px;height:20px;background:#a4e9e1;border:1px solid #ccc;"></span> |
-| `--durion-teal-100` | `#d7f3f0` | <span style="display:inline-block;width:64px;height:20px;background:#d7f3f0;border:1px solid #ccc;"></span> |
+### Heritage Gold (logo + heritage accent)
+`600 #a06a1a · 500 #cc9030 (canonical) · 400 #d8a449 · 300 #e3bd78 · 200 #efd6a8 · 100 #f8edd5`
 
 ### Neutrals
-
-| Token | Hex | Preview |
-| --- | --- | --- |
-| `--durion-grey-900` | `#121213` | <span style="display:inline-block;width:64px;height:20px;background:#121213;border:1px solid #ccc;"></span> |
-| `--durion-grey-800` | `#1f2022` | <span style="display:inline-block;width:64px;height:20px;background:#1f2022;border:1px solid #ccc;"></span> |
-| `--durion-grey-700` | `#3a3a3e` | <span style="display:inline-block;width:64px;height:20px;background:#3a3a3e;border:1px solid #ccc;"></span> |
-| `--durion-grey-500` | `#707078` | <span style="display:inline-block;width:64px;height:20px;background:#707078;border:1px solid #ccc;"></span> |
-| `--durion-grey-100` | `#f2f2f4` | <span style="display:inline-block;width:64px;height:20px;background:#f2f2f4;border:1px solid #ccc;"></span> |
+`900 #121213 · 800 #1f2022 · 700 #3a3a3e · 500 #707078 · 100 #f2f2f4`
 
 ### Functional
-
-| Token | Hex | Preview |
-| --- | --- | --- |
-| `--functional-error-red` | `#c84c47` | <span style="display:inline-block;width:64px;height:20px;background:#c84c47;border:1px solid #ccc;"></span> |
-| `--functional-warning` | `#e6a540` | <span style="display:inline-block;width:64px;height:20px;background:#e6a540;border:1px solid #ccc;"></span> |
-| `--functional-info-blue` | `#355d92` | <span style="display:inline-block;width:64px;height:20px;background:#355d92;border:1px solid #ccc;"></span> |
-| `--functional-success` | `#5bbe72` | <span style="display:inline-block;width:64px;height:20px;background:#5bbe72;border:1px solid #ccc;"></span> |
+`error #ba1a1a · warning #e6a540 · info #355d92 · success #2e7d32`
 
 ### Brand Semantic Tokens
-
 - `--brand-primary: var(--durion-blue-700)`
 - `--brand-primary-soft: var(--durion-blue-50)`
 - `--brand-secondary: var(--durion-graphite-700)`
-- `--brand-accent: var(--durion-teal-400)`
+- `--brand-accent: var(--durion-teal-400)` — UI accent
+- `--brand-gold: var(--durion-gold-500)` — heritage accent (not the UI accent)
 - `--brand-background: var(--durion-grey-100)`
 - `--brand-surface: #ffffff`
 
 ## 4. Theme Mapping
 
-Durion theme is applied via:
-
-- `html[data-brand="durion"][data-theme="light"]`
-- `html[data-brand="durion"][data-theme="dark"]`
-
-Mapped runtime tokens include:
-
-- Primary: `--primaryA400`, `--primaryA300`, `--primaryA100`, `--primary50`
-- Accent: `--accentA400`, `--accentA700`, `--accentA100`
-- Layout surfaces: `--themeBackground`, `--navBackground`, `--menuBackground`, `--cardBackground`, `--subMenuBackground`
-- Text: `--currentTextColor`, `--contrastTextColor`
-- Scrollbars: `--trackColor`, `--handleColor`
-
-Body adopts theme-level background and text color when `data-theme` is present.
+Applied via `[data-theme="light"]` (default) and `[data-theme="dark"]` on `<html>`.
+Runtime tokens (`--themeBackground`, `--navBackground`, `--cardBackground`,
+`--currentTextColor`, `--primaryA*`, `--accentA*`, `--goldA*`, `--trackColor`,
+`--handleColor`, and the extended set) flip per theme — consume these in components, never
+raw palette tokens. Full light/dark table in `theme-tokens.md`.
 
 ## 5. Component Styling Patterns
 
 ### Elevation
-
-Utility classes:
-
-- `.dur-elevation-1` through `.dur-elevation-4`
+Utility classes `.dur-elevation-1` … `.dur-elevation-4`.
+> The shipped code currently uses `.mic-elevation-*` (upstream-template drift) — rename to `.dur-*`.
 
 ### Alerts
-
-`.alert` variants:
-
-- `.alert-info`, `.alert-success`, `.alert-warning`, `.alert-error`, `.alert-critical`, `.alert-soft`
+`.alert` with `.alert-info`, `.alert-success`, `.alert-warning`, `.alert-error`,
+`.alert-critical`, `.alert-soft`.
 
 ### Links
+Underline-style border (`border-bottom: 2px`) using theme colors. Variants `.accent`, `.white`.
 
-- Default links use underline-style border (`border-bottom: 2px`) and theme colors
-- Variants: `.accent`, `.white`
-
-### Navigation and Sidebar
-
-- `.dur-navbar` uses themed nav background
-- `.dur-navbar.white` swaps to light menu style
-- `.dur-sidebar` primary item state uses `primary` token mapping
+### Navigation & Sidebar
+`.dur-navbar` (themed nav background; `.white` for light menu). `.dur-sidebar` primary item
+state uses the `primary` token mapping.
 
 ### Status Chips
-
-- `.dur-status` base style plus variants: `.primary`, `.valid`, `.warn`, `.error`
-- Dark theme override present for chip background
+`.dur-status` base + `.primary`, `.valid`, `.warn`, `.error`; dark-theme override present.
+> Shipped as `.mic-status` (drift) — rename to `.dur-status`.
 
 ### Content, Scrollbars, Tables, Timeline
-
-- Main content follows theme background/text tokens
-- Custom scrollbar track/thumb tokens
-- Table focus and row hover states mapped to primary tokens
-- Timeline dots use primary/accent colors
+Follow theme background/text tokens; custom scrollbar track/thumb; table focus + row hover
+mapped to primary tokens; timeline dots use primary/accent colors.
 
 ## 6. Asset Expectations
 
-Theme expects assets under relative paths:
+### Fonts
+Self-hosted under `src/assets/fonts/` — `barlow/` and `noto-sans/`, each with its own
+`@font-face` CSS. Keep `@import`s at the top of `styles.css`.
 
-- Fonts under `../assets/fonts/...`
-- Icon fonts under `../assets/fonts/icons/...`
+### Logo & brand assets
+- Place from the **supplied logo files** — never redraw, re-trace, or AI-regenerate the emblem.
+- Three approved lockups: **primary** (shield + wordmark), **icon/emblem**, **wordmark**.
+- **Clear space** ≥ ½ shield height on all sides. **Minimum size:** primary ≥ 120px wide, icon ≥ 32px.
+- Gold in the logo is **locked artwork** — do not recolor; do not sample it for UI (use `--goldA400`).
+- **Gap:** no reversed/white lockup exists yet. On dark backgrounds, place the mark on a light
+  plaque until a reversed version is produced. (The badge/banner protos are off-brand — they
+  redrew the emblem and dropped the gold border; retire them.)
 
-When integrating this theme, ensure those assets are available at the expected relative URLs.
+See the **Brand & Asset Guide** for full logo anatomy, misuse, and the pre-ship checklist.
 
 ## 7. Implementation Notes
 
-- **Contrast Compliance (ADR-0039):** All information-bearing layout elements must meet WCAG 2.2 AA contrast thresholds: 4.5:1 for small text (<18pt, or <14pt bold) and 3:1 for large text (≥18pt, or >=14pt bold). This applies across all states (normal, hover, focus, disabled, validation).
-- Keep token usage semantic (prefer `--brand-*`, `--primary*`, `--accent*`) over hardcoded hex in component code.
-- For new components, support both light and dark mappings by consuming runtime variables (`--themeBackground`, `--currentTextColor`, etc.).
-- Reuse existing utility classes (`.dur-elevation-*`, status/link variants) before introducing new variants.
+- **Contrast (ADR-0039):** all information-bearing elements meet WCAG 2.2 AA (4.5:1 small text
+  < 18pt/14pt bold; 3:1 large) across all states (normal, hover, focus, disabled, validation).
+- Keep token usage semantic (`--brand-*`, `--primary*`, `--accent*`, `--goldA*`) over hardcoded hex.
+- Support light **and** dark by consuming runtime variables (`--themeBackground`,
+  `--currentTextColor`, etc.).
+- **Do not** introduce Material-3 token names (`--color-*`, `--surface-container-*`, `--on-*`),
+  `--spacing-*`, `--typescale-*`, the `.mic-*` prefix, or literal `#cc9030` — these
+  are caught by the stylelint guardrail. Use the sanctioned equivalents (see `theme-tokens.md`).
+- Reuse existing utilities (`.dur-elevation-*`, status/link variants) before adding new ones.

--- a/design/source/durion-theme.css
+++ b/design/source/durion-theme.css
@@ -1,8 +1,12 @@
 /* ========================================================================= */
-/* DURION THEME                                                              */
+/* DURION THEME — design/source reference                                    */
+/*                                                                           */
+/* Regenerated to mirror src/styles.css (the single source of truth). Token  */
+/* values, light/dark mapping, and the gold + extended token sets here MUST   */
+/* match styles.css. The app toggles `data-theme` on <html> (see             */
+/* core/services/theme.service.ts); the old `data-brand="durion"` selectors   */
+/* are removed — the app never sets that attribute.                          */
 /* ========================================================================= */
-
-
 
 .material-icons-default {
   font-weight: normal;
@@ -26,8 +30,7 @@
   font-variation-settings: 'FILL' 1;
 }
 
-/* Global base */
-
+/* Global base — display face on body, body face everywhere else */
 html,
 body,
 app-root {
@@ -35,20 +38,20 @@ app-root {
   margin: 0;
   width: 100%;
   height: 100%;
-  background: #ffffff;
-  color: rgba(0, 0, 0, 0.87);
 }
 
 * {
-  font-family: 'Noto Sans', sans-serif;
+  font-family: var(--font-body);
 }
 
 body {
-  font-family: 'Barlow Semi Condensed', 'Noto Sans', sans-serif;
+  font-family: var(--font-primary);
+  background-color: var(--themeBackground);
+  color: var(--currentTextColor);
 }
 
 /* ========================================================================= */
-/* 1. DURION COLOR TOKENS                                                    */
+/* 1. RAW PALETTE TOKENS (mirror styles.css)                                 */
 /* ========================================================================= */
 
 :root {
@@ -79,6 +82,15 @@ body {
   --durion-teal-200: #a4e9e1;
   --durion-teal-100: #d7f3f0;
 
+  /* Heritage Gold — sampled from the primary logo shield */
+  --durion-gold-600: #a06a1a;
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list -- canonical token definition; everywhere else use --goldA400 */
+  --durion-gold-500: #cc9030;
+  --durion-gold-400: #d8a449;
+  --durion-gold-300: #e3bd78;
+  --durion-gold-200: #efd6a8;
+  --durion-gold-100: #f8edd5;
+
   /* Neutrals */
   --durion-grey-900: #121213;
   --durion-grey-800: #1f2022;
@@ -92,155 +104,186 @@ body {
   --functional-info-blue: #355d92;
   --functional-success: #2e7d32;
 
-  /* Status chips (generic names) */
-  --status-success-bg: #ceeac6;
-  --status-success-fg: #2e7d32;
-  --status-warn-bg: #f3c9bc;
-  --status-warn-fg: #b71c1c;
-  --status-error-bg: rgba(186, 26, 26, 0.12);
-  --status-error-fg: #ba1a1a;
-
-  /* Text */
-  --text-normal: rgba(0, 0, 0, 0.87);
-  --text-helper: rgba(0, 0, 0, 0.6);
-  --text-disabled: rgba(0, 0, 0, 0.54);
-  --text-error: #ba1a1a;
-  --text-normal-light: #ffffff;
-  --text-helper-light: rgba(255, 255, 255, 0.7);
-  --white-disabled-hover: rgba(255, 255, 255, 0.38);
-
-  /* Brand semantic */
+  /* Brand Semantic */
   --brand-primary: var(--durion-blue-700);
   --brand-primary-soft: var(--durion-blue-50);
   --brand-secondary: var(--durion-graphite-700);
   --brand-accent: var(--durion-teal-400);
+  --brand-gold: var(--durion-gold-500);
   --brand-background: var(--durion-grey-100);
   --brand-surface: #ffffff;
 
-  /* Dark mode variants */
-  --dark-bg: #101112;
-  --dark-surface: #181a1c;
-  --dark-text: #f1f1f3;
-  --dark-primary: #a5c7f1;
-  --dark-primary-strong: #1c2e48;
-  --dark-graphite: #8e939b;
-  --dark-teal: #55d7cc;
+  /* Typography */
+  --font-primary: 'Barlow Semi Condensed', 'Noto Sans', sans-serif;
+  --font-body: 'Noto Sans', sans-serif;
+
+  /* Ratified Barlow display weight scale (only 500/600/700 are hosted) */
+  --font-weight-display: 700;   /* h1 / page titles / strong emphasis */
+  --font-weight-heading: 600;   /* h2–h4, card titles, overlines, labels, chips, buttons */
+  --font-weight-medium: 500;    /* large/light display subheads */
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-base: 250ms ease;
 }
 
 /* ========================================================================= */
-/* 2. THEME MAPPING FOR DURION                                               */
+/* 2. RUNTIME THEME MAPPING (mirror styles.css)                              */
 /* ========================================================================= */
 
-/* Light theme */
-html[data-brand="durion"][data-theme="light"] {
+/* Light (default) */
+:root,
+[data-theme='light'] {
+  --themeBackground: var(--durion-grey-100);
+  --navBackground: var(--durion-blue-800);
+  --menuBackground: var(--durion-blue-700);
+  --subMenuBackground: var(--durion-blue-600);
+  --cardBackground: var(--brand-surface);
+  --currentTextColor: var(--durion-grey-900);
+  --contrastTextColor: #ffffff;
   --primaryA400: var(--brand-primary);
   --primaryA300: var(--durion-blue-500);
   --primaryA100: var(--durion-blue-100);
   --primary50: var(--durion-blue-50);
-
   --accentA400: var(--durion-teal-600);
   --accentA700: #006a6a;
   --accentA100: var(--durion-teal-100);
-  --warnA400: var(--functional-warning);
-
-  --themeBackground: var(--brand-background);
-  --navBackground: var(--primaryA400);
-  --menuBackground: #ffffff;
-  --cardBackground: #ffffff;
-  --subMenuBackground: var(--durion-grey-100);
-
-  --currentTextColor: var(--text-normal);
-  --contrastTextColor: var(--text-normal-light);
-
+  --goldA400: var(--durion-gold-600);
+  --goldA100: var(--durion-gold-100);
   --trackColor: var(--durion-graphite-200);
-  --handleColor: var(--primaryA400);
+  --handleColor: var(--durion-graphite-600);
+  /* Extended local tokens */
+  --border-color: var(--durion-graphite-200);
+  --input-background: #ffffff;
+  --input-border: var(--durion-graphite-200);
+  --input-focus-border: var(--durion-blue-500);
+  --input-placeholder-color: var(--handleColor);
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-nav: 2px 0 8px rgba(0, 0, 0, 0.12);
+  --chat-bubble-user-bg: var(--durion-blue-100);
+  --chat-bubble-system-bg: var(--durion-graphite-100);
+  --surface-variant: var(--brand-surface);
+  --surface-2: var(--brand-surface);
+  --surface-hover: rgba(0, 52, 111, 0.06);
+  --text-muted: var(--handleColor);
 }
 
-/* Dark theme */
-html[data-brand="durion"][data-theme="dark"] {
-  --primaryA400: var(--dark-primary);
-  --primaryA300: var(--dark-primary-strong);
-  --primaryA100: #d3e3ff;
-  --primary50: #202432;
-
-  --accentA400: var(--dark-teal);
-  --accentA700: #2aa89c;
-  --accentA100: #b7f1ea;
-  --warnA400: var(--functional-warning);
-
-  --themeBackground: var(--dark-bg);
-  --navBackground: var(--dark-primary-strong);
-  --menuBackground: var(--dark-surface);
-  --cardBackground: var(--dark-surface);
-  --subMenuBackground: #21242a;
-
-  --currentTextColor: var(--dark-text);
-  --contrastTextColor: #000000;
-
-  --trackColor: var(--dark-graphite);
-  --handleColor: var(--primaryA100);
-}
-
-/* Apply theme */
-html[data-brand="durion"][data-theme] body {
-  background-color: var(--themeBackground);
-  color: var(--currentTextColor);
+/* Dark */
+[data-theme='dark'] {
+  --themeBackground: var(--durion-grey-800);
+  --navBackground: var(--durion-grey-900);
+  --menuBackground: #16181c;
+  --subMenuBackground: var(--durion-graphite-800);
+  --cardBackground: var(--durion-grey-700);
+  --currentTextColor: #e8e9eb;
+  --contrastTextColor: #ffffff;
+  --primaryA400: var(--durion-blue-400);
+  --primaryA300: var(--durion-blue-300);
+  --primaryA100: var(--durion-blue-700);
+  --primary50: var(--durion-blue-800);
+  --accentA400: var(--durion-teal-300);
+  --accentA700: var(--durion-teal-400);
+  --accentA100: var(--durion-teal-600);
+  --goldA400: var(--durion-gold-300);
+  --goldA100: var(--durion-gold-600);
+  --trackColor: var(--durion-grey-700);
+  --handleColor: var(--durion-graphite-200);
+  --border-color: var(--durion-graphite-700);
+  --input-background: var(--durion-graphite-800);
+  --input-border: var(--durion-graphite-600);
+  --input-focus-border: var(--durion-blue-400);
+  --input-placeholder-color: var(--handleColor);
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-nav: 2px 0 8px rgba(0, 0, 0, 0.5);
+  --chat-bubble-user-bg: var(--durion-blue-700);
+  --chat-bubble-system-bg: var(--durion-graphite-700);
+  --surface-variant: var(--durion-graphite-800);
+  --surface-2: var(--cardBackground);
+  --surface-hover: rgba(255, 255, 255, 0.08);
+  --text-muted: var(--handleColor);
 }
 
 /* ========================================================================= */
-/* 3. UTILITIES & COMPONENT HOOKS (DURION)                                   */
+/* 3. UTILITIES & COMPONENT HOOKS                                            */
 /* ========================================================================= */
 
-/* Elevation */
+/* Elevation (mirror styles.css) */
 .dur-elevation-1 {
-  box-shadow: 0 4px 8px 0 rgba(102, 102, 102, 0.12);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 .dur-elevation-2 {
-  box-shadow: 0 8px 16px 0 rgba(102, 102, 102, 0.16);
+  box-shadow: var(--shadow-card);
 }
 
 .dur-elevation-3 {
-  box-shadow: 0 16px 32px 0 rgba(102, 102, 102, 0.2);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
 }
 
 .dur-elevation-4 {
-  box-shadow: 0 32px 64px 0 rgba(102, 102, 102, 0.32);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
 }
 
 .font-noto-sans {
-  font-family: 'Noto Sans', sans-serif;
+  font-family: var(--font-body);
 }
 
 /* Alerts */
 .alert {
-  color: var(--contrastTextColor);
-  border-radius: 4px;
-  padding: 8px 12px;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-sm);
   font-size: 0.875rem;
+  border-left: 4px solid transparent;
 }
 
 .alert.alert-info {
-  background-color: var(--primaryA400);
+  background: var(--primary50);
+  border-color: var(--functional-info-blue);
+  color: var(--functional-info-blue);
 }
 
 .alert.alert-success {
-  background-color: var(--functional-success);
+  background: color-mix(in srgb, var(--functional-success) 12%, transparent);
+  border-color: var(--functional-success);
+  color: var(--functional-success);
 }
 
 .alert.alert-warning {
-  background-color: var(--warnA400);
+  background: color-mix(in srgb, var(--functional-warning) 16%, transparent);
+  border-color: var(--functional-warning);
   color: var(--currentTextColor);
 }
 
-.alert.alert-error,
+.alert.alert-error {
+  background: color-mix(in srgb, var(--functional-error-red) 12%, transparent);
+  border-color: var(--functional-error-red);
+  color: var(--functional-error-red);
+}
+
 .alert.alert-critical {
-  background-color: var(--functional-error-red);
+  background: var(--functional-error-red);
+  border-color: #8b2020;
+  color: #ffffff;
 }
 
 .alert.alert-soft {
-  background-color: var(--accentA100);
-  color: var(--accentA700);
+  background: var(--cardBackground);
+  border-color: var(--border-color);
+  color: var(--currentTextColor);
 }
 
 /* Links */
@@ -282,8 +325,7 @@ a.white:focus {
 }
 
 /* Navbar */
-.dur-navbar .mat-toolbar,
-.dur-navbar .toolbar {
+.dur-navbar {
   color: #ffffff;
   background-color: var(--navBackground);
 }
@@ -291,11 +333,6 @@ a.white:focus {
 .dur-navbar.white {
   background-color: var(--menuBackground);
   color: var(--currentTextColor);
-}
-
-.dur-navbar.white .mat-mdc-tab-link:hover,
-.dur-navbar.white .mat-tab-link.mat-tab-label-active {
-  border-color: var(--primaryA400) !important;
 }
 
 /* Sidebar */
@@ -318,76 +355,53 @@ a.white:focus {
 }
 
 /* Status chips */
-.dur-status .mat-mdc-chip {
-  background-color: #ffffff;
-  color: var(--primaryA400);
+.dur-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px var(--space-2);
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-heading);
 }
 
-html[data-brand="durion"][data-theme="dark"] .dur-status .mat-mdc-chip {
-  background-color: #53565a;
+.dur-status.primary {
+  background: var(--primaryA100);
+  color: var(--brand-primary);
 }
 
-.dur-status.primary .mat-mdc-chip {
-  background-color: var(--primary50) !important;
+.dur-status.valid {
+  background: color-mix(in srgb, var(--functional-success) 12%, transparent);
+  color: var(--functional-success);
 }
 
-.dur-status.valid .mat-mdc-chip {
-  background-color: var(--status-success-bg) !important;
-  color: var(--status-success-fg) !important;
+.dur-status.warn {
+  background: color-mix(in srgb, var(--functional-warning) 16%, transparent);
+  color: var(--currentTextColor);
 }
 
-.dur-status.warn .mat-mdc-chip {
-  background-color: var(--status-warn-bg) !important;
-  color: var(--status-warn-fg) !important;
-}
-
-.dur-status.error .mat-mdc-chip {
-  background-color: var(--status-error-bg) !important;
-  color: var(--status-error-fg) !important;
+.dur-status.error {
+  background: color-mix(in srgb, var(--functional-error-red) 12%, transparent);
+  color: var(--functional-error-red);
 }
 
 /* Main content */
-dur-main-content,
 .main-content {
   background-color: var(--themeBackground);
   color: var(--currentTextColor);
 }
 
 /* Scrollbars */
-.os-scrollbar-track,
 .dur-scroll::-webkit-scrollbar-track {
-  background: var(--trackColor) !important;
+  background: var(--trackColor);
 }
 
-.os-scrollbar-handle,
 .dur-scroll::-webkit-scrollbar-thumb {
-  background: var(--handleColor) !important;
+  background: var(--handleColor);
   border-radius: 5px;
 }
 
-/* Tables */
-table.mat-mdc-table {
-  border: 1px solid transparent;
-}
-
-table.mat-mdc-table:focus {
-  outline: none;
-  border-color: var(--primaryA400);
-}
-
-tr.clickable:not(.mat-mdc-header-row):hover td {
-  background-color: var(--primary50) !important;
-}
-
 /* Timelines */
-dur-timeline-entry-dot {
-  background-color: var(--primaryA400);
-}
-
-dur-timeline-entry-dot.accent {
-  background-color: var(--accentA400);
-}
-
 .timeline-entry-card {
   background-color: var(--cardBackground);
 }

--- a/design/source/theme-tokens.md
+++ b/design/source/theme-tokens.md
@@ -1,12 +1,19 @@
 # Durion POS – Theme Token Inventory
 
-This file is the canonical token inventory for the Durion frontend design system. It documents every CSS custom property used in the application and should be read alongside `durion-style-guide.md` and `durion-theme.css`.
+> **v2 · June 2026 — reconciled to `src/styles.css`.** Corrections in this revision:
+> `--functional-error-red` `#c84c47 → #ba1a1a`; `--functional-success` `#5bbe72 → #2e7d32`;
+> added **Heritage Gold** ramp + `--brand-gold` + `--goldA400` / `--goldA100`; documented the
+> previously-unlisted extended tokens (`--surface-variant`, `--surface-2`, `--surface-hover`,
+> `--text-muted`); replaced the retired `'Michelin Unit Titling'` display font with
+> **Barlow Semi Condensed**.
 
-Tokens defined in `src/styles.css` fall into three tiers:
+This file is the canonical token inventory for the Durion frontend design system. It documents every CSS custom property used in the application and should be read alongside `durion-style-guide.md` and `src/styles.css`.
+
+Tokens defined in `src/styles.css` fall into three tiers.
 
 ## Tier 1 – Raw Palette Tokens
 
-Defined in `:root` and never changed by theme switching. Sourced directly from the Durion style guide.
+Defined in `:root` and never changed by theme switching.
 
 | Token | Value | Purpose |
 |---|---|---|
@@ -14,29 +21,63 @@ Defined in `:root` and never changed by theme switching. Sourced directly from t
 | `--durion-graphite-800 … 100` | See styles.css | Graphite grey ramp |
 | `--durion-teal-600 … 100` | See styles.css | Electric Teal ramp |
 | `--durion-grey-900 … 100` | See styles.css | Neutral ramp |
-| `--functional-error-red` | `#c84c47` | Error states |
+| `--durion-gold-600 … 100` | See styles.css | **Heritage Gold ramp (sampled from the logo shield, #cc9030)** |
+| `--functional-error-red` | `#ba1a1a` | Error states |
 | `--functional-warning` | `#e6a540` | Warning states |
 | `--functional-info-blue` | `#355d92` | Info states |
-| `--functional-success` | `#5bbe72` | Success states |
+| `--functional-success` | `#2e7d32` | Success states |
+
+### Heritage Gold ramp
+
+| Token | Hex | Note |
+|---|---|---|
+| `--durion-gold-600` | `#a06a1a` | Darkest — 4.6:1 on white, AA for text |
+| `--durion-gold-500` | `#cc9030` | **Canonical** — matches the shield border |
+| `--durion-gold-400` | `#d8a449` | |
+| `--durion-gold-300` | `#e3bd78` | |
+| `--durion-gold-200` | `#efd6a8` | |
+| `--durion-gold-100` | `#f8edd5` | Lightest — soft fill / wash |
+
+### Typography tokens
+
+| Token | Value | Purpose |
+|---|---|---|
+| `--font-primary` | `'Barlow Semi Condensed', 'Noto Sans', sans-serif` | Display / headings / overlines |
+| `--font-body` | `'Noto Sans', sans-serif` | Body & UI |
+| `--font-weight-display` | `700` | `h1` / page titles / strong emphasis |
+| `--font-weight-heading` | `600` | `h2`–`h4`, card titles, overlines, labels, chips, buttons |
+| `--font-weight-medium` | `500` | large / lighter display subheads |
+
+Both faces are self-hosted under `src/assets/fonts/` (`barlow/`, `noto-sans/`). **Only Barlow
+500 / 600 / 700 are hosted** — `--font-primary` must use one of those three weights (use the
+`--font-weight-*` tokens); any other weight synthesises a faux face and is banned.
+
+### Spacing & radius
+
+| Token | Value |
+|---|---|
+| `--space-1 / 2 / 3 / 4 / 5 / 6 / 8` | 0.25 / 0.5 / 0.75 / 1 / 1.25 / 1.5 / 2 rem |
+| `--radius-sm / md / lg` | 4 / 8 / 16 px |
+
+> `--space-5` (1.25rem) fills the 4 → 6 gap and **is** declared in `styles.css`. It is sanctioned.
 
 ## Tier 2 – Brand Semantic Tokens
 
-Stable aliases that map palette tokens to semantic roles. Shared across light and dark.
+Stable aliases mapping palette tokens to roles. Shared across light and dark.
 
-| Token | Light value | Purpose |
+| Token | Value | Purpose |
 |---|---|---|
 | `--brand-primary` | `--durion-blue-700` | Primary actions, nav |
 | `--brand-primary-soft` | `--durion-blue-50` | Subtle primary tones |
 | `--brand-secondary` | `--durion-graphite-700` | Secondary text/UI |
-| `--brand-accent` | `--durion-teal-400` | Accent / highlight |
+| `--brand-accent` | `--durion-teal-400` | **UI accent / highlight** |
+| `--brand-gold` | `--durion-gold-500` | **Heritage / premium accent — NOT the UI accent** |
 | `--brand-background` | `--durion-grey-100` | Page background |
 | `--brand-surface` | `#ffffff` | Card / modal surface |
 
 ## Tier 3 – Runtime Theme Tokens
 
-These tokens flip when `data-theme` attribute changes on `<html>`. Consume these in all component styles.
-
-### From Durion Style Guide
+These flip when `data-theme` changes on `<html>`. **Consume these in all component styles.**
 
 | Token | Light | Dark |
 |---|---|---|
@@ -47,33 +88,60 @@ These tokens flip when `data-theme` attribute changes on `<html>`. Consume these
 | `--cardBackground` | white | grey-700 |
 | `--currentTextColor` | grey-900 | `#e8e9eb` |
 | `--contrastTextColor` | white | white |
-| `--primaryA400` | blue-500 | blue-400 |
-| `--primaryA300` | blue-400 | blue-300 |
+| `--primaryA400` | blue-700 | blue-400 |
+| `--primaryA300` | blue-500 | blue-300 |
 | `--primaryA100` | blue-100 | blue-700 |
 | `--primary50` | blue-50 | blue-800 |
-| `--accentA400` | teal-400 | teal-300 |
-| `--accentA700` | teal-600 | teal-400 |
+| `--accentA400` | teal-600 | teal-300 |
+| `--accentA700` | `#006a6a` | teal-400 |
 | `--accentA100` | teal-100 | teal-600 |
+| `--goldA400` | gold-600 | gold-300 |
+| `--goldA100` | gold-100 | gold-600 |
 | `--trackColor` | graphite-200 | grey-700 |
 | `--handleColor` | graphite-600 | graphite-200 |
 
-### Extended Tokens (not in style guide – defined locally)
+> **Gold text/icons must use `--goldA400`** (theme-aware, AA in both modes). Raw
+> `--durion-gold-500` (`#cc9030`) fails AA on white — reserve the raw ramp for fills and
+> borders where you control the background.
+
+### Extended Tokens (defined locally — not brand-level)
 
 | Token | Light | Dark | Rationale |
 |---|---|---|---|
-| `--border-color` | graphite-200 | graphite-700 | Consistent border across all components |
+| `--border-color` | graphite-200 | graphite-700 | Consistent border across components |
 | `--input-background` | white | graphite-800 | Form field fill |
 | `--input-border` | graphite-200 | graphite-600 | Form field outline |
 | `--input-focus-border` | blue-500 | blue-400 | Focus ring color |
-| `--input-placeholder-color` | handleColor | handleColor | AA-compliant placeholder text color for inputs and textareas |
-| `--shadow-card` | rgba(0,0,0,0.08) | rgba(0,0,0,0.4) | Card elevation |
-| `--shadow-nav` | rgba(0,0,0,0.12) | rgba(0,0,0,0.5) | Sidebar shadow |
+| `--input-placeholder-color` | handleColor | handleColor | AA-compliant placeholder text |
+| `--shadow-card` | `0 2px 8px rgba(0,0,0,.08)` | `0 2px 8px rgba(0,0,0,.4)` | Card elevation |
+| `--shadow-nav` | `2px 0 8px rgba(0,0,0,.12)` | `2px 0 8px rgba(0,0,0,.5)` | Sidebar shadow |
 | `--chat-bubble-user-bg` | blue-100 | blue-700 | User message bubble |
 | `--chat-bubble-system-bg` | graphite-100 | graphite-700 | System message bubble |
+| `--surface-variant` | brand-surface | graphite-800 | Elevated surfaces (dropdowns/popovers/menus) |
+| `--surface-2` | brand-surface | cardBackground | Secondary elevated surface |
+| `--surface-hover` | `rgba(0,52,111,.06)` | `rgba(255,255,255,.08)` | Hover wash |
+| `--text-muted` | handleColor | handleColor | Muted / secondary text |
+
+## Unsanctioned tokens (do NOT use)
+
+Component CSS under `src/app/features` introduced Material-3-style names the system never
+defined; several have no fallback and render broken (transparent fills, default text), and
+are caught by the stylelint guardrail. Use the sanctioned token instead:
+
+| Unsanctioned | Use instead |
+|---|---|
+| `--color-primary` / `--color-secondary` / `--color-error` … | `--brand-primary` / `--brand-secondary` / `--functional-error-red` |
+| `--surface-container*` / `--surface-2` (M3 sense) / `--on-surface*` | `--cardBackground` / `--currentTextColor` |
+| `--secondary-container` / `--error-container` / `--on-*-container` | semantic Durion tokens |
+| `--typescale-*` | `--font-primary` / `--font-body` + explicit sizes |
+| `--spacing-1 / 2 / 4` | `--space-1 / 2 / 4` |
+| `.mic-elevation-*` / `.mic-status` | `.dur-elevation-*` / `.dur-status` |
+| `'Michelin Unit Titling'` | `'Barlow Semi Condensed'` |
+| literal `#cc9030` for text | `--goldA400` |
 
 ## Usage Guidelines
 
 - Always use Tier 3 tokens in component CSS. Fall back to Tier 2 for brand-level decisions.
 - Never hardcode hex values in component stylesheets.
-- When adding new runtime tokens, list them in this file under "Extended Tokens", providing both light and dark values.
-- **Contrast Compliance (ADR-0039):** Any token combination used for information-bearing text and its background MUST pass WCAG 2.2 AA contrast thresholds (4.5:1 for small text < 18pt/14pt bold, 3:1 for large text >= 18pt/14pt bold) across all states.
+- When adding a new runtime token, list it here under "Extended Tokens" with **both** light and dark values, and define it in `styles.css` — never inline an undefined name and rely on a fallback.
+- **Contrast Compliance (ADR-0039):** Any token combination used for information-bearing text and its background MUST pass WCAG 2.2 AA (4.5:1 small text < 18pt/14pt bold, 3:1 large text) across all states.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,299 +41,9 @@
         "axe-core": "^4.11.1",
         "eslint": "^10.2.0",
         "jsdom": "^27.1.0",
+        "stylelint": "^17.14.0",
         "typescript": "~5.9.2",
         "vitest": "^4.0.8"
-      }
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-accounting/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-bulk-loader/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-catalog/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-customer/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-inventory/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-invoice/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-location/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-order/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-people/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-security/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-shop-manager/dist": {
-      "extraneous": true
-    },
-    "../../durion-positivity-sdk-angular/packages/sdk-workorder/dist": {
-      "extraneous": true
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-accounting": {
-      "name": "@durion-sdk/accounting",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-bulk-loader/dist": {
-      "name": "@durion-sdk/bulk-loader",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-catalog": {
-      "name": "@durion-sdk/catalog",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-customer": {
-      "name": "@durion-sdk/customer",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-inventory": {
-      "name": "@durion-sdk/inventory",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-invoice": {
-      "name": "@durion-sdk/invoice",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-location": {
-      "name": "@durion-sdk/location",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-order": {
-      "name": "@durion-sdk/order",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-people": {
-      "name": "@durion-sdk/people",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-security": {
-      "name": "@durion-sdk/security",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-shop-manager": {
-      "name": "@durion-sdk/shop-manager",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "../durion-positivity-sdk-angular/packages/sdk-workorder": {
-      "name": "@durion-sdk/workorder",
-      "version": "0.1.0-alpha",
-      "extraneous": true,
-      "license": "Unlicense",
-      "devDependencies": {
-        "@angular/common": "^21.0.0",
-        "@angular/compiler": "^21.0.0",
-        "@angular/compiler-cli": "^21.0.0",
-        "@angular/core": "^21.0.0",
-        "@angular/platform-browser": "^21.0.0",
-        "ng-packagr": "^21.0.0",
-        "reflect-metadata": "^0.1.3",
-        "rxjs": "^7.4.0",
-        "typescript": ">=5.9.0 <6.0.0",
-        "zone.js": "^0.15.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "^21.0.0",
-        "rxjs": "^7.4.0"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -1269,6 +979,67 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@cacheable/memory": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.9.tgz",
+      "integrity": "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/utils": "^2.4.1",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/memory/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "dev": true,
@@ -1288,7 +1059,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dev": true,
       "funding": [
         {
@@ -1357,7 +1130,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
       "dev": true,
       "funding": [
         {
@@ -1395,6 +1170,76 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2416,6 +2261,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
       "dev": true,
@@ -3004,6 +2856,44 @@
       "peerDependencies": {
         "@angular/common": ">=16",
         "@angular/core": ">=16"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@npmcli/agent": {
@@ -4153,6 +4043,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "license": "MIT"
@@ -4709,6 +4612,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "dev": true,
@@ -4723,6 +4633,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/axe-core": {
@@ -4906,6 +4826,30 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/cacheable": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.5.tgz",
+      "integrity": "sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cacheable/memory": "^2.0.8",
+        "@cacheable/utils": "^2.4.1",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "license": "MIT",
@@ -4929,6 +4873,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -5105,6 +5059,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "dev": true,
@@ -5170,6 +5131,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "dev": true,
@@ -5181,6 +5169,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/css-select": {
@@ -5219,6 +5217,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssstyle": {
@@ -5426,6 +5437,16 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -5819,6 +5840,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "dev": true,
@@ -5843,6 +5894,26 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -6089,6 +6160,82 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
@@ -6103,6 +6250,19 @@
       "version": "4.2.11",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
@@ -6111,6 +6271,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/hasown": {
@@ -6130,6 +6303,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",
@@ -6159,6 +6339,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/htmlparser2": {
@@ -6302,6 +6495,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
@@ -6336,6 +6557,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -6384,6 +6612,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-object": {
@@ -6467,6 +6708,29 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "27.4.0",
@@ -6577,6 +6841,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "dev": true,
@@ -6588,6 +6862,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/listr2": {
       "version": "9.0.5",
@@ -6719,6 +7000,13 @@
     },
     "node_modules/lodash.throttle": {
       "version": "4.1.1",
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniqby": {
@@ -6854,6 +7142,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "dev": true,
@@ -6866,6 +7165,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "license": "MIT",
@@ -6874,6 +7186,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/micromatch": {
@@ -7105,7 +7427,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -7215,6 +7539,16 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/npm-bundled": {
@@ -7486,6 +7820,45 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json/node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "dev": true,
@@ -7638,7 +8011,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7656,7 +8031,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7693,6 +8068,27 @@
       "peerDependencies": {
         "postcss": "^8.4.31"
       }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -7754,6 +8150,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.15.0",
       "license": "BSD-3-Clause",
@@ -7769,6 +8185,27 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/range-parser": {
@@ -7820,6 +8257,16 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "dev": true,
@@ -7840,6 +8287,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rfdc": {
@@ -7932,6 +8390,30 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -8172,6 +8654,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "dev": true,
@@ -8314,7 +8809,9 @@
       }
     },
     "node_modules/string-width": {
-      "version": "8.2.0",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8353,10 +8850,234 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylelint": {
+      "version": "17.14.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.0.tgz",
+      "integrity": "sha512-8xkHPpdqYryeIsOgfsYTmr6cIeC4nLYWk5S8BPxpodq8mIuepggkMljsHewWfuAjj/+qpRKou2QerhjMH3iasg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.5",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.3",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.15",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.4",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.3.tgz",
+      "integrity": "sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.22"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.22",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+      "integrity": "sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^2.3.4",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tar": {
       "version": "7.5.13",
@@ -8563,6 +9284,19 @@
       "version": "6.21.0",
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "license": "MIT",
@@ -8614,6 +9348,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "13.0.0",
@@ -8963,6 +9704,19 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/ws": {
       "version": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "i18n:pseudo:generate": "node scripts/i18n/generate-pseudo-locale.mjs",
     "i18n:pseudo:check": "node scripts/i18n/generate-pseudo-locale.mjs --check",
     "i18n:check": "npm run i18n:check:missing && npm run i18n:pseudo:check",
-    "serve:ssr:durion-positivity-frontend": "npm run sdk:install && node dist/durion-positivity-frontend/server/server.mjs"
+    "serve:ssr:durion-positivity-frontend": "npm run sdk:install && node dist/durion-positivity-frontend/server/server.mjs",
+    "lint:css": "stylelint \"src/**/*.css\""
   },
   "prettier": {
     "printWidth": 100,
@@ -65,6 +66,7 @@
     "axe-core": "^4.11.1",
     "eslint": "^10.2.0",
     "jsdom": "^27.1.0",
+    "stylelint": "^17.14.0",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"
   }

--- a/src/app/features/accounting/pages/invoice-payment-status/invoice-payment-status-page.component.css
+++ b/src/app/features/accounting/pages/invoice-payment-status/invoice-payment-status-page.component.css
@@ -91,8 +91,8 @@
 }
 
 .ips-status-badge--paid {
-  background: var(--primary50);
-  color: var(--brand-primary);
+  background: color-mix(in srgb, var(--functional-success) 12%, transparent);
+  color: var(--functional-success);
 }
 
 .ips-status-badge--unpaid {

--- a/src/app/features/accounting/pages/invoice-payment-status/invoice-payment-status-page.component.css
+++ b/src/app/features/accounting/pages/invoice-payment-status/invoice-payment-status-page.component.css
@@ -2,7 +2,7 @@
   display: grid;
   gap: var(--space-6);
   padding: var(--space-6);
-  background: var(--surface-container-lowest, var(--durion-surface-container-lowest, var(--brand-surface)));
+  background: var(--cardBackground);
   color: var(--currentTextColor, var(--durion-on-surface, var(--durion-grey-900)));
 }
 
@@ -16,14 +16,14 @@
   font-size: 0.75rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--color-secondary, var(--brand-secondary));
+  color: var(--brand-secondary, var(--brand-secondary));
 }
 
 .ips-title {
   margin: 0;
   font-family: var(--font-primary);
   font-size: clamp(1.5rem, 2.2vw, 2.1rem);
-  color: var(--color-primary, var(--brand-primary));
+  color: var(--brand-primary, var(--brand-primary));
 }
 
 .display-lg {
@@ -31,7 +31,7 @@
   font-family: var(--font-primary);
   font-size: clamp(1.75rem, 3.5vw, 2.6rem);
   line-height: 1.1;
-  color: var(--color-primary, var(--brand-primary));
+  color: var(--brand-primary, var(--brand-primary));
 }
 
 .body-md {
@@ -51,7 +51,7 @@
   gap: var(--space-4);
   padding: var(--space-6);
   border-radius: var(--radius-lg);
-  background: var(--surface-container, var(--durion-surface-container, var(--brand-surface)));
+  background: var(--cardBackground);
   box-shadow: var(--shadow-card);
 }
 
@@ -86,23 +86,23 @@
   font-size: 0.8rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-  background: var(--surface-container-highest);
-  color: var(--on-surface);
+  background: var(--surface-variant);
+  color: var(--currentTextColor);
 }
 
 .ips-status-badge--paid {
-  background: var(--secondary-container);
-  color: var(--on-secondary-container);
+  background: var(--primary50);
+  color: var(--brand-primary);
 }
 
 .ips-status-badge--unpaid {
-  background: var(--error-container);
-  color: var(--on-error-container);
+  background: color-mix(in srgb, var(--functional-error-red) 12%, transparent);
+  color: var(--functional-error-red);
 }
 
 .ips-status-badge--partially-paid {
-  background: var(--surface-container-highest);
-  color: var(--on-surface);
+  background: var(--surface-variant);
+  color: var(--currentTextColor);
 }
 
 .ips-ingestion-row {
@@ -110,9 +110,9 @@
   gap: var(--space-4);
   padding: var(--space-5, 1.25rem);
   padding-left: 12px;
-  border-left: 2px solid var(--color-primary);
+  border-left: 2px solid var(--brand-primary);
   border-radius: var(--radius-md);
-  background: var(--surface-container-lowest, var(--durion-surface-container-lowest, var(--brand-surface)));
+  background: var(--cardBackground);
 }
 
 .ips-posting-refs {
@@ -120,9 +120,9 @@
   gap: var(--space-1);
   padding: var(--space-3);
   padding-left: 12px;
-  border-left: 2px solid var(--color-primary);
+  border-left: 2px solid var(--brand-primary);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--color-secondary, var(--brand-secondary)) 8%, transparent);
+  background: color-mix(in srgb, var(--brand-secondary, var(--brand-secondary)) 8%, transparent);
 }
 
 .ips-posting-refs__primary {
@@ -130,7 +130,7 @@
 }
 
 .ips-posting-refs__secondary {
-  color: var(--color-secondary, var(--brand-secondary));
+  color: var(--brand-secondary, var(--brand-secondary));
 }
 
 .ips-banner {
@@ -141,17 +141,17 @@
 }
 
 .ips-banner--error {
-  background: color-mix(in srgb, var(--color-error, var(--functional-error-red)) 18%, transparent);
-  color: var(--color-error, var(--functional-error-red));
+  background: color-mix(in srgb, var(--functional-error-red, var(--functional-error-red)) 18%, transparent);
+  color: var(--functional-error-red, var(--functional-error-red));
 }
 
 .ips-banner--critical {
-  background: color-mix(in srgb, var(--color-error, var(--functional-error-red)) 30%, transparent);
-  color: var(--color-error, var(--functional-error-red));
+  background: color-mix(in srgb, var(--functional-error-red, var(--functional-error-red)) 30%, transparent);
+  color: var(--functional-error-red, var(--functional-error-red));
 }
 
 .ips-banner--warning {
-  background: color-mix(in srgb, var(--color-warning, var(--functional-warning)) 20%, transparent);
+  background: color-mix(in srgb, var(--functional-warning, var(--functional-warning)) 20%, transparent);
   color: var(--currentTextColor, var(--durion-on-surface, var(--durion-grey-900)));
 }
 
@@ -170,17 +170,17 @@
 
 .ips-button:focus-visible,
 .ips-history-row:focus-visible {
-  outline: 2px solid var(--color-secondary, var(--brand-accent));
+  outline: 2px solid var(--brand-secondary, var(--brand-accent));
   outline-offset: 2px;
 }
 
 .ips-button--primary {
-  background: var(--color-primary, var(--brand-primary));
+  background: var(--brand-primary, var(--brand-primary));
   color: var(--contrastTextColor, var(--brand-surface));
 }
 
 .ips-button--secondary {
-  background: color-mix(in srgb, var(--color-secondary, var(--brand-secondary)) 16%, transparent);
+  background: color-mix(in srgb, var(--brand-secondary, var(--brand-secondary)) 16%, transparent);
   color: var(--currentTextColor, var(--durion-on-surface, var(--durion-grey-900)));
 }
 
@@ -192,7 +192,7 @@
   width: 100%;
   min-width: 44rem;
   border-collapse: collapse;
-  background: var(--surface-container, var(--durion-surface-container, var(--brand-surface)));
+  background: var(--cardBackground);
   border-radius: var(--radius-md);
   overflow: hidden;
 }
@@ -214,42 +214,42 @@
 }
 
 .ips-history-row:hover {
-  background: color-mix(in srgb, var(--color-secondary, var(--brand-secondary)) 10%, transparent);
+  background: color-mix(in srgb, var(--brand-secondary, var(--brand-secondary)) 10%, transparent);
 }
 
 .ips-event-detail {
-  padding: var(--spacing-4, 16px);
-  background: var(--surface-container-lowest);
-  margin-top: var(--spacing-2, 8px);
+  padding: var(--space-4, 16px);
+  background: var(--cardBackground);
+  margin-top: var(--space-2, 8px);
 }
 
 .ips-event-detail__title {
-  font-size: var(--typescale-title-sm-size, 0.875rem);
+  font-size: 0.875rem;
   font-weight: 600;
-  margin-bottom: var(--spacing-2, 8px);
-  color: var(--on-surface);
+  margin-bottom: var(--space-2, 8px);
+  color: var(--currentTextColor);
 }
 
 .ips-event-detail__fields {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: var(--spacing-1, 4px) var(--spacing-4, 16px);
+  gap: var(--space-1, 4px) var(--space-4, 16px);
 }
 
 .ips-event-detail__fields dt {
-  color: var(--on-surface-variant);
-  font-size: var(--typescale-label-sm-size, 0.75rem);
+  color: var(--text-muted);
+  font-size: 0.75rem;
 }
 
 .ips-event-detail__fields dd {
-  color: var(--on-surface);
-  font-size: var(--typescale-body-sm-size, 0.875rem);
+  color: var(--currentTextColor);
+  font-size: 0.875rem;
 }
 
 .ips-empty-state {
   padding: var(--space-4);
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--color-secondary, var(--brand-secondary)) 8%, transparent);
+  background: color-mix(in srgb, var(--brand-secondary, var(--brand-secondary)) 8%, transparent);
 }
 
 @media (max-width: 768px) {

--- a/src/app/features/auth/login.component.html
+++ b/src/app/features/auth/login.component.html
@@ -1,5 +1,5 @@
 <div class="login-page" [attr.data-theme]="null">
-  <div class="login-card mic-elevation-3">
+  <div class="login-card dur-elevation-3">
 
     <!-- Logo / Brand -->
     <div class="login-brand">

--- a/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.css
+++ b/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.css
@@ -19,13 +19,13 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-on-surface-muted, #57606a);
+  color: var(--text-muted);
   margin-bottom: 0.15rem;
 }
 
 .totals-grid__value {
   font-size: 0.9rem;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   word-break: break-word;
 }
 
@@ -49,15 +49,15 @@
 }
 
 .line-items__header {
-  background: var(--color-surface-container, #f1f5f9);
+  background: var(--cardBackground);
   font-weight: 600;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   border-bottom: 1px solid var(--color-outline-variant, #d0d7de);
 }
 
 .line-items__row { border-bottom: 1px solid var(--color-outline-variant, #d0d7de); }
 .line-items__row:last-child { border-bottom: none; }
-.line-items__row--alt { background: var(--color-surface-container-low, #f8fafb); }
+.line-items__row--alt { background: var(--cardBackground); }
 
 .line-total { text-align: right; font-weight: 500; }
 
@@ -69,8 +69,8 @@
   border-radius: 100px;
   font-size: 0.75rem;
   font-weight: 500;
-  background: var(--color-surface-container, #f1f5f9);
-  color: var(--color-on-surface-muted, #57606a);
+  background: var(--cardBackground);
+  color: var(--text-muted);
   border: 1px solid var(--color-outline-variant, #d0d7de);
 }
 .type-chip--part { background: #dbeafe; color: #1e40af; border-color: #1e40af; }
@@ -80,7 +80,7 @@
 /* ── Totals breakdown ───────────────────────────────────────────────────── */
 
 .totals-breakdown {
-  background: var(--color-surface-container, #f1f5f9);
+  background: var(--cardBackground);
   border: 1px solid var(--color-outline-variant, #d0d7de);
   border-radius: var(--radius-sm, 4px);
   padding: 0.75rem 1rem;
@@ -93,10 +93,10 @@
   justify-content: space-between;
   font-size: 0.875rem;
   padding: 0.3rem 0;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
-.totals-breakdown__row--discount .totals-breakdown__value { color: var(--color-success, #16a34a); }
+.totals-breakdown__row--discount .totals-breakdown__value { color: var(--functional-success, #16a34a); }
 
 .totals-breakdown__row--grand {
   border-top: 1px solid var(--color-outline-variant, #d0d7de);
@@ -107,7 +107,7 @@
 .totals-breakdown__value--grand {
   font-size: 1.1rem;
   font-weight: 700;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 /* ── Adjustment cards ───────────────────────────────────────────────────── */
@@ -120,7 +120,7 @@
   background: var(--color-surface, #fff);
 }
 
-.adjustment-card--alt { background: var(--color-surface-container-low, #f8fafb); }
+.adjustment-card--alt { background: var(--cardBackground); }
 
 .adjustment-card__header {
   display: flex;
@@ -132,7 +132,7 @@
 .adj-reason {
   font-size: 0.9rem;
   font-weight: 500;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   flex: 1;
 }
 
@@ -144,8 +144,8 @@
   text-align: right;
 }
 
-.adjustment-card__amount--debit { color: var(--color-error, #dc2626); }
-.adjustment-card__amount--credit { color: var(--color-success, #16a34a); }
+.adjustment-card__amount--debit { color: var(--functional-error-red, #dc2626); }
+.adjustment-card__amount--credit { color: var(--functional-success, #16a34a); }
 
 /* ── Traceability grid ──────────────────────────────────────────────────── */
 
@@ -161,13 +161,13 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-on-surface-muted, #57606a);
+  color: var(--text-muted);
   margin-bottom: 0.15rem;
 }
 
 .trace-grid__value {
   font-size: 0.875rem;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 .trace-grid__value--mono {
@@ -191,7 +191,7 @@
 .artifact-row__name {
   flex: 1;
   font-weight: 500;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 /* ── Form ───────────────────────────────────────────────────────────────── */
@@ -203,7 +203,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   margin-bottom: 0.35rem;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 .form-input {
@@ -214,7 +214,7 @@
   font-size: 0.875rem;
   font-family: inherit;
   background: var(--color-surface, #fff);
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 .form-input:focus {

--- a/src/app/features/billing/pages/payment-capture/payment-capture-page.component.css
+++ b/src/app/features/billing/pages/payment-capture/payment-capture-page.component.css
@@ -37,7 +37,7 @@
 
 .payment-capture__input {
   border: none;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   background: transparent;
   padding: var(--space-2) 0;

--- a/src/app/features/billing/pages/payment-void-refund/payment-void-refund-page.component.css
+++ b/src/app/features/billing/pages/payment-void-refund/payment-void-refund-page.component.css
@@ -55,7 +55,7 @@
 
 .pvm__input {
   border: none;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   background: transparent;
   padding: var(--space-2) 0;

--- a/src/app/features/billing/pages/receipt/receipt-page.component.css
+++ b/src/app/features/billing/pages/receipt/receipt-page.component.css
@@ -62,7 +62,7 @@
 
 .receipt__input {
   border: none;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   background: transparent;
   padding: var(--space-2) 0;

--- a/src/app/features/crm/pages/billing-rules/billing-rules.component.css
+++ b/src/app/features/crm/pages/billing-rules/billing-rules.component.css
@@ -58,16 +58,16 @@
   width: 100%;
   background: transparent;
   border: none;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   padding: 4px 0 6px;
   font: inherit;
-  color: var(--on-surface);
+  color: var(--currentTextColor);
   outline: none;
 }
 
 .billing-rules__input:focus {
-  border-bottom-color: var(--color-primary);
+  border-bottom-color: var(--brand-primary);
 }
 
 .billing-rules__field--toggle input {

--- a/src/app/features/crm/pages/crm-snapshot/crm-snapshot.component.css
+++ b/src/app/features/crm/pages/crm-snapshot/crm-snapshot.component.css
@@ -78,7 +78,7 @@
   margin: 0;
   font-size: var(--font-display-sm, 1.5rem);
   font-weight: 600;
-  color: var(--on-surface);
+  color: var(--currentTextColor);
   line-height: 1.2;
 }
 

--- a/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.css
+++ b/src/app/features/inventory/pages/by-location/location-overview/location-inventory-overview-page.component.css
@@ -76,13 +76,13 @@
 
 .picker-option:hover,
 .picker-option[aria-selected='true'] {
-  background: var(--color-primary-light, #e8f0fe);
+  background: var(--brand-primary-light, #e8f0fe);
 }
 
 /* Keyboard-active option (aria-activedescendant target). */
 .picker-option-active {
-  background: var(--color-primary-light, #e8f0fe);
-  outline: 2px solid var(--color-primary, #1a73e8);
+  background: var(--brand-primary-light, #e8f0fe);
+  outline: 2px solid var(--brand-primary, #1a73e8);
   outline-offset: -2px;
 }
 
@@ -240,13 +240,13 @@
 
 .typeahead-item:hover,
 .typeahead-item[aria-selected='true'] {
-  background: var(--color-primary-light, #e8f0fe);
+  background: var(--brand-primary-light, #e8f0fe);
 }
 
 /* Keyboard-active option (aria-activedescendant target). */
 .typeahead-item-active {
-  background: var(--color-primary-light, #e8f0fe);
-  outline: 2px solid var(--color-primary, #1a73e8);
+  background: var(--brand-primary-light, #e8f0fe);
+  outline: 2px solid var(--brand-primary, #1a73e8);
   outline-offset: -2px;
 }
 
@@ -276,7 +276,7 @@
   align-items: center;
   gap: 0.375rem;
   padding: 0.25rem 0.5rem;
-  background: var(--color-primary-light, #e8f0fe);
+  background: var(--brand-primary-light, #e8f0fe);
   border: 1px solid var(--border-color, #ccc);
   border-radius: 1rem;
   font-size: 0.8125rem;
@@ -304,7 +304,7 @@
 
 .chip-remove:hover,
 .chip-remove:focus-visible {
-  background: var(--color-primary, #1a73e8);
+  background: var(--brand-primary, #1a73e8);
   color: #fff;
 }
 
@@ -313,7 +313,7 @@
   padding: 0;
   border: none;
   background: none;
-  color: var(--color-primary, #1a73e8);
+  color: var(--brand-primary, #1a73e8);
   font-size: 0.8125rem;
   cursor: pointer;
 }

--- a/src/app/features/landing/landing-page.component.css
+++ b/src/app/features/landing/landing-page.component.css
@@ -272,7 +272,7 @@
 
 .feature-card:hover {
   transform: translateY(-2px);
-  box-shadow: var(--mic-elevation-3, 0 4px 16px rgba(0, 0, 0, 0.14));
+  box-shadow: var(--dur-elevation-3, 0 4px 16px rgba(0, 0, 0, 0.14));
 }
 
 /* Left accent bar per DESIGN.md "Content Grouping" rule */

--- a/src/app/features/order/pages/order-cancel/order-cancel-page.component.css
+++ b/src/app/features/order/pages/order-cancel/order-cancel-page.component.css
@@ -57,7 +57,7 @@
 
 .order-cancel__input {
   border: 0;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   background: transparent;
   padding-inline: 0;

--- a/src/app/features/order/pages/order-cart/order-cart-page.component.css
+++ b/src/app/features/order/pages/order-cart/order-cart-page.component.css
@@ -52,7 +52,7 @@
 
 .order-cart__input {
   border: 0;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   background: transparent;
   padding-inline: 0;

--- a/src/app/features/order/pages/price-override/price-override-page.component.css
+++ b/src/app/features/order/pages/price-override/price-override-page.component.css
@@ -56,7 +56,7 @@
 
 .price-override__input {
   border: 0;
-  border-bottom: 1px solid var(--on-surface-variant);
+  border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   padding-inline: 0;
   background: transparent;

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.css
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.css
@@ -99,12 +99,12 @@ label {
 }
 
 .btn--primary {
-  background: var(--color-primary, var(--brand-primary));
+  background: var(--brand-primary, var(--brand-primary));
   color: var(--contrastTextColor);
 }
 
 .btn--primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-primary, var(--brand-primary)) 88%, var(--durion-teal-500));
+  background: color-mix(in srgb, var(--brand-primary, var(--brand-primary)) 88%, var(--durion-teal-500));
 }
 
 .state-panel {

--- a/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
+++ b/src/app/features/security/pages/permissions/permissions-list/permissions-list-page.component.html
@@ -7,7 +7,7 @@
     <span class="readonly-label" [attr.aria-label]="'SECURITY.PERMISSIONS_LIST.READ_ONLY' | translate">{{ 'SECURITY.PERMISSIONS_LIST.READ_ONLY' | translate }}</span>
   </header>
 
-  <section class="list-panel mic-elevation-2" [attr.aria-label]="'SECURITY.PERMISSIONS_LIST.ARIAS.LISTING' | translate">
+  <section class="list-panel dur-elevation-2" [attr.aria-label]="'SECURITY.PERMISSIONS_LIST.ARIAS.LISTING' | translate">
     <div class="panel-accent" aria-hidden="true"></div>
 
     <div class="toolbar">

--- a/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
+++ b/src/app/features/security/pages/roles/role-detail/role-detail-page.component.html
@@ -10,7 +10,7 @@
   }
 
   @if (role(); as currentRole) {
-  <section class="role-summary mic-elevation-2">
+  <section class="role-summary dur-elevation-2">
     <div class="panel-accent" aria-hidden="true"></div>
     <header class="summary-header">
       <h1 id="role-detail-title">{{ 'SECURITY.ROLE_DETAIL.TITLE' | translate: { name: currentRole.name } }}</h1>
@@ -30,16 +30,16 @@
         <dt>{{ 'SECURITY.ROLE_DETAIL.STATUS' | translate }}</dt>
         <dd>
           @if (currentRole.status === 'INACTIVE') {
-          <span class="mic-status warn">{{ 'SECURITY.ROLE_DETAIL.STATUS_INACTIVE' | translate }}</span>
+          <span class="dur-status warn">{{ 'SECURITY.ROLE_DETAIL.STATUS_INACTIVE' | translate }}</span>
           } @else {
-          <span class="mic-status valid">{{ 'SECURITY.ROLE_DETAIL.STATUS_ACTIVE' | translate }}</span>
+          <span class="dur-status valid">{{ 'SECURITY.ROLE_DETAIL.STATUS_ACTIVE' | translate }}</span>
           }
         </dd>
       </div>
     </dl>
   </section>
 
-  <section class="permissions-panel mic-elevation-2" [attr.aria-label]="'SECURITY.ROLE_DETAIL.ARIAS.ROLE_PERMISSIONS' | translate">
+  <section class="permissions-panel dur-elevation-2" [attr.aria-label]="'SECURITY.ROLE_DETAIL.ARIAS.ROLE_PERMISSIONS' | translate">
     <div class="panel-accent" aria-hidden="true"></div>
 
     <header class="permissions-header">
@@ -104,7 +104,7 @@
 
   @if (showGrantModal()) {
   <section class="modal-backdrop">
-    <dialog class="modal-surface mic-elevation-4" open [attr.aria-label]="'SECURITY.ROLE_DETAIL.ARIAS.GRANT_DIALOG' | translate">
+    <dialog class="modal-surface dur-elevation-4" open [attr.aria-label]="'SECURITY.ROLE_DETAIL.ARIAS.GRANT_DIALOG' | translate">
       <header class="modal-header">
         <h2>{{ 'SECURITY.ROLE_DETAIL.GRANT_PERMISSIONS' | translate }}</h2>
         <p>{{ 'SECURITY.ROLE_DETAIL.GRANT_HELP' | translate }}</p>

--- a/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
+++ b/src/app/features/security/pages/roles/roles-list/roles-list-page.component.html
@@ -9,7 +9,7 @@
     </button>
   </header>
 
-  <section class="list-panel mic-elevation-2" [attr.aria-label]="'SECURITY.ROLES_LIST.ARIAS.LIST_PANEL' | translate">
+  <section class="list-panel dur-elevation-2" [attr.aria-label]="'SECURITY.ROLES_LIST.ARIAS.LIST_PANEL' | translate">
     <div class="panel-accent" aria-hidden="true"></div>
 
     <div class="toolbar">
@@ -84,7 +84,7 @@
 
   @if (showCreateModal()) {
   <section class="modal-backdrop">
-    <dialog class="modal-surface mic-elevation-4" open [attr.aria-label]="'SECURITY.ROLES_LIST.CREATE_ROLE' | translate">
+    <dialog class="modal-surface dur-elevation-4" open [attr.aria-label]="'SECURITY.ROLES_LIST.CREATE_ROLE' | translate">
       <header class="modal-header">
         <h2>{{ 'SECURITY.ROLES_LIST.CREATE_ROLE' | translate }}</h2>
         <p>{{ 'SECURITY.ROLES_LIST.CREATE_HELP' | translate }}</p>

--- a/src/app/features/security/pages/user-provision/user-provision-page.component.css
+++ b/src/app/features/security/pages/user-provision/user-provision-page.component.css
@@ -118,12 +118,12 @@ label {
 }
 
 .btn--primary {
-  background: var(--color-primary, var(--brand-primary));
+  background: var(--brand-primary, var(--brand-primary));
   color: var(--contrastTextColor);
 }
 
 .btn--primary:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--color-primary, var(--brand-primary)) 88%, var(--durion-teal-500));
+  background: color-mix(in srgb, var(--brand-primary, var(--brand-primary)) 88%, var(--durion-teal-500));
 }
 
 @media (max-width: 48rem) {

--- a/src/app/features/shell/components/rag-ingest-dialog/rag-ingest-dialog.component.css
+++ b/src/app/features/shell/components/rag-ingest-dialog/rag-ingest-dialog.component.css
@@ -100,15 +100,15 @@
 }
 
 .rag-status--success {
-  background: var(--color-success-bg, #ecfdf5);
-  border: 1px solid var(--color-success-border, #6ee7b7);
-  color: var(--color-success-text, #065f46);
+  background: color-mix(in srgb, var(--functional-success) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--functional-success) 40%, transparent);
+  color: var(--functional-success);
 }
 
 .rag-status--error {
-  background: var(--color-error-bg, #fef2f2);
-  border: 1px solid var(--color-error-border, #fca5a5);
-  color: var(--color-error-text, #991b1b);
+  background: color-mix(in srgb, var(--functional-error-red) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--functional-error-red) 40%, transparent);
+  color: var(--functional-error-red);
 }
 
 .rag-status__icon {
@@ -138,7 +138,7 @@
 }
 
 .rag-field__required {
-  color: var(--color-error-text, #991b1b);
+  color: var(--functional-error-red);
   margin-left: 2px;
 }
 
@@ -159,13 +159,13 @@
 .rag-field__input:focus,
 .rag-field__textarea:focus {
   outline: none;
-  border-color: var(--color-primary, #5b21b6);
+  border-color: var(--brand-primary, #5b21b6);
   box-shadow: 0 0 0 3px rgb(91 33 182 / 15%);
 }
 
 .rag-field__input[aria-invalid="true"],
 .rag-field__textarea[aria-invalid="true"] {
-  border-color: var(--color-error-border, #fca5a5);
+  border-color: color-mix(in srgb, var(--functional-error-red) 40%, transparent);
 }
 
 .rag-field__input:disabled,
@@ -183,7 +183,7 @@
 .rag-field__error {
   margin: 0;
   font-size: 0.8rem;
-  color: var(--color-error-text, #991b1b);
+  color: var(--functional-error-red);
 }
 
 /* Buttons */
@@ -204,13 +204,13 @@
 }
 
 .rag-btn--primary {
-  background: var(--color-primary, #5b21b6);
+  background: var(--brand-primary, #5b21b6);
   color: #fff;
-  border-color: var(--color-primary, #5b21b6);
+  border-color: var(--brand-primary, #5b21b6);
 }
 
 .rag-btn--primary:hover:not(:disabled) {
-  background: var(--color-primary-hover, #4c1d95);
+  background: var(--brand-primary-hover, #4c1d95);
 }
 
 .rag-btn--secondary {

--- a/src/app/features/shell/dashboard/dashboard.component.html
+++ b/src/app/features/shell/dashboard/dashboard.component.html
@@ -3,27 +3,27 @@
   <p>{{ 'SHELL.DASHBOARD.WELCOME_BODY' | translate }}</p>
 
   <div class="placeholder-cards">
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/workexec">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/workexec">
       <span class="card-icon" aria-hidden="true">W</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.WORKORDERS' | translate }}</span>
     </a>
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/crm">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/crm">
       <span class="card-icon" aria-hidden="true">C</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.CUSTOMERS' | translate }}</span>
     </a>
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/accounting">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/accounting">
       <span class="card-icon" aria-hidden="true">A</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.ACCOUNTING' | translate }}</span>
     </a>
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/shopmgmt/dispatch-board">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/shopmgmt/dispatch-board">
       <span class="card-icon" aria-hidden="true">S</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.SHOPMGMT' | translate }}</span>
     </a>
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/billing">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/billing">
       <span class="card-icon" aria-hidden="true">B</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.BILLING' | translate }}</span>
     </a>
-    <a class="placeholder-card mic-elevation-1" routerLink="/app/people">
+    <a class="placeholder-card dur-elevation-1" routerLink="/app/people">
       <span class="card-icon" aria-hidden="true">P</span>
       <span>{{ 'SHELL.DASHBOARD.CARD.PEOPLE' | translate }}</span>
     </a>

--- a/src/app/features/shopmgmt/pages/dispatch-board/dispatch-board-page.component.html
+++ b/src/app/features/shopmgmt/pages/dispatch-board/dispatch-board-page.component.html
@@ -6,7 +6,7 @@
     </div>
   </header>
 
-  <section class="board-panel mic-elevation-2" [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.PANEL_ARIA' | translate">
+  <section class="board-panel dur-elevation-2" [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.PANEL_ARIA' | translate">
     <div class="panel-accent" aria-hidden="true"></div>
 
     <div class="filter-bar">

--- a/src/app/features/workexec/pages/invoice-finalization/invoice-finalization-page.component.css
+++ b/src/app/features/workexec/pages/invoice-finalization/invoice-finalization-page.component.css
@@ -109,7 +109,7 @@
   resize: vertical;
   min-height: 4.5rem;
   border: none;
-  border-bottom: 1px solid var(--input-border, var(--on-surface-variant));
+  border-bottom: 1px solid var(--input-border);
   border-radius: 0;
   background: transparent;
   padding-left: 0;

--- a/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
+++ b/src/app/features/workexec/pages/workorder-change-requests/workorder-change-requests-page.component.css
@@ -53,9 +53,9 @@
   margin: 1rem 1.5rem;
   padding: 0.85rem 1rem;
   border-radius: var(--radius-sm, 4px);
-  background: var(--color-warning-surface, #fef3c7);
-  border: 1px solid var(--color-warning, #d97706);
-  color: var(--color-warning-on, #92400e);
+  background: color-mix(in srgb, var(--functional-warning) 16%, transparent);
+  border: 1px solid var(--functional-warning);
+  color: var(--currentTextColor);
   font-size: 0.875rem;
   line-height: 1.5;
 }

--- a/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.css
+++ b/src/app/features/workexec/pages/workorder-finalize/workorder-finalize-page.component.css
@@ -10,20 +10,20 @@
   margin: 1.5rem;
   padding: 1.5rem;
   border-radius: var(--radius-md, 8px);
-  background: var(--color-surface-container, #f1f5f9);
+  background: var(--cardBackground);
   border: 1px solid var(--color-outline-variant, #d0d7de);
 }
 
 .finalize-card__title {
   font-size: 1.1rem;
   font-weight: 600;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   margin-bottom: 0.5rem;
 }
 
 .finalize-card__desc {
   font-size: 0.875rem;
-  color: var(--color-on-surface-muted, #57606a);
+  color: var(--text-muted);
   margin-bottom: 1.25rem;
   line-height: 1.5;
 }
@@ -41,7 +41,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   margin-bottom: 0.35rem;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 .form-input {
@@ -53,7 +53,7 @@
   font-size: 0.875rem;
   font-family: inherit;
   background: var(--color-surface, #ffffff);
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 .form-input:focus {
@@ -79,7 +79,7 @@
 .section-heading {
   font-size: 1rem;
   font-weight: 600;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   margin-bottom: 1rem;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -36,6 +36,15 @@
   --durion-teal-200: #a4e9e1;
   --durion-teal-100: #d7f3f0;
 
+  /* Heritage Gold — sampled from the primary logo shield (#cc9030) */
+  --durion-gold-600: #a06a1a;  /* darkest — 4.6:1 on white, AA for text */
+  /* stylelint-disable-next-line declaration-property-value-disallowed-list -- canonical token definition; everywhere else use --goldA400 */
+  --durion-gold-500: #cc9030;  /* canonical — matches the shield border */
+  --durion-gold-400: #d8a449;
+  --durion-gold-300: #e3bd78;
+  --durion-gold-200: #efd6a8;
+  --durion-gold-100: #f8edd5;  /* lightest — soft fill / wash */
+
   /* Neutrals */
   --durion-grey-900: #121213;
   --durion-grey-800: #1f2022;
@@ -54,6 +63,7 @@
   --brand-primary-soft: var(--durion-blue-50);
   --brand-secondary: var(--durion-graphite-700);
   --brand-accent: var(--durion-teal-400);
+  --brand-gold: var(--durion-gold-500);
   --brand-background: var(--durion-grey-100);
   --brand-surface: #ffffff;
 
@@ -61,11 +71,17 @@
   --font-primary: 'Barlow Semi Condensed', 'Noto Sans', sans-serif;
   --font-body: 'Noto Sans', sans-serif;
 
+  /* Ratified Barlow display weight scale — only 500/600/700 are hosted */
+  --font-weight-display: 700;   /* h1 / page titles / strong emphasis */
+  --font-weight-heading: 600;   /* h2–h4, card titles, overlines, labels, chips, buttons */
+  --font-weight-medium: 500;    /* large / lighter display subheads */
+
   /* Spacing scale */
   --space-1: 0.25rem;
   --space-2: 0.5rem;
   --space-3: 0.75rem;
   --space-4: 1rem;
+  --space-5: 1.25rem;   /* fills the 4 → 6 gap */
   --space-6: 1.5rem;
   --space-8: 2rem;
 
@@ -96,6 +112,8 @@
   --accentA400: var(--durion-teal-600);
   --accentA700: #006a6a;
   --accentA100: var(--durion-teal-100);
+  --goldA400: var(--durion-gold-600);  /* heritage accent text/icon — 4.6:1 on white */
+  --goldA100: var(--durion-gold-100);  /* soft gold fill / wash */
   --trackColor: var(--durion-graphite-200);
   --handleColor: var(--durion-graphite-600); /* graphite-500 (#727986) fails 4.5:1 on white; graphite-600 (#5a616e) = 6.2:1 */
   /* Extended local tokens – see design/source/theme-tokens.md */
@@ -133,6 +151,8 @@
   --accentA400: var(--durion-teal-300);
   --accentA700: var(--durion-teal-400);
   --accentA100: var(--durion-teal-600);
+  --goldA400: var(--durion-gold-300);  /* lighter so it reads on dark surfaces (6.3:1) */
+  --goldA100: var(--durion-gold-600);  /* deep gold wash on dark */
   --trackColor: var(--durion-grey-700);
   --handleColor: var(--durion-graphite-200); /* graphite-500 (#727986) fails 4.5:1 on dark card (#3a3a3e); graphite-200 (#d7d9dd) = 7.9:1 */
   --border-color: var(--durion-graphite-700);
@@ -193,19 +213,19 @@ body {
 }
 
 /* ── Elevation Utilities ─────────────────────────────────────────────────── */
-.mic-elevation-1 {
+.dur-elevation-1 {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
-.mic-elevation-2 {
+.dur-elevation-2 {
   box-shadow: var(--shadow-card);
 }
 
-.mic-elevation-3 {
+.dur-elevation-3 {
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
 }
 
-.mic-elevation-4 {
+.dur-elevation-4 {
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
 }
 
@@ -254,7 +274,7 @@ body {
 }
 
 /* ── Status Chips ────────────────────────────────────────────────────────── */
-.mic-status {
+.dur-status {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -264,22 +284,22 @@ body {
   font-weight: 600;
 }
 
-.mic-status.primary {
+.dur-status.primary {
   background: var(--primaryA100);
   color: var(--brand-primary);
 }
 
-.mic-status.valid {
+.dur-status.valid {
   background: #edfaef;
   color: #2e7d3a;
 }
 
-.mic-status.warn {
+.dur-status.warn {
   background: #fef8ec;
   color: #8a5e0a;
 }
 
-.mic-status.error {
+.dur-status.error {
   background: #fbeaea;
   color: var(--functional-error-red);
 }
@@ -505,9 +525,9 @@ app-workorder-detail-page .alert--warn {
 }
 
 app-workorder-detail-page .alert--success {
-  background: var(--color-success-surface, #dcfce7);
-  color: var(--color-success, #16a34a);
-  border: 1px solid var(--color-success, #16a34a);
+  background: color-mix(in srgb, var(--functional-success) 12%, transparent);
+  color: var(--functional-success);
+  border: 1px solid var(--functional-success);
   border-radius: var(--radius-sm, 4px);
   padding: 0.75rem 1rem;
   font-size: 0.875rem;
@@ -563,13 +583,13 @@ app-workorder-detail-page .tab-badge {
 }
 
 app-workorder-detail-page .tab-badge--warning {
-  background: var(--color-warning, #f59e0b);
-  color: var(--color-on-warning, #1f2328);
+  background: var(--functional-warning, #f59e0b);
+  color: var(--currentTextColor, #1f2328);
 }
 
 app-workorder-detail-page .inline-error {
   font-size: 0.8rem;
-  color: var(--color-error, #dc2626);
+  color: var(--functional-error-red, #dc2626);
   margin-left: 0.5rem;
 }
 
@@ -577,14 +597,14 @@ app-workorder-detail-page .checklist-panel {
   margin: 1.25rem 1.5rem;
   padding: 1rem 1.25rem;
   border-radius: var(--radius-md, 8px);
-  background: var(--color-surface-container-low, #f8fafc);
+  background: var(--cardBackground);
   border: 1px solid var(--color-outline-variant, #d0d7de);
 }
 
 app-workorder-detail-page .checklist-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
   margin-bottom: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -611,15 +631,15 @@ app-workorder-detail-page .checklist-item__icon {
 }
 
 app-workorder-detail-page .checklist-item--ok .checklist-item__icon {
-  color: var(--color-success, #16a34a);
+  color: var(--functional-success, #16a34a);
 }
 
 app-workorder-detail-page .checklist-item--blocking .checklist-item__icon {
-  color: var(--color-error, #dc2626);
+  color: var(--functional-error-red, #dc2626);
 }
 
 app-workorder-detail-page .checklist-item--warning .checklist-item__icon {
-  color: var(--color-warning, #f59e0b);
+  color: var(--functional-warning, #f59e0b);
 }
 
 app-workorder-detail-page .checklist-item__label {
@@ -635,7 +655,7 @@ app-workorder-detail-page .form-label {
   font-size: 0.875rem;
   font-weight: 500;
   margin-bottom: 0.35rem;
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 app-workorder-detail-page .form-textarea {
@@ -647,7 +667,7 @@ app-workorder-detail-page .form-textarea {
   font-family: inherit;
   resize: vertical;
   background: var(--color-surface, #ffffff);
-  color: var(--color-on-surface, #1f2328);
+  color: var(--currentTextColor, #1f2328);
 }
 
 app-workorder-detail-page .form-textarea:focus {
@@ -657,7 +677,7 @@ app-workorder-detail-page .form-textarea:focus {
 }
 
 app-workorder-detail-page .required-mark {
-  color: var(--color-error, #dc2626);
+  color: var(--functional-error-red, #dc2626);
 }
 
 app-workorder-detail-page .failed-checks {
@@ -680,11 +700,11 @@ app-workorder-detail-page .failed-check__icon {
 }
 
 app-workorder-detail-page .failed-check--blocking .failed-check__icon {
-  color: var(--color-error, #dc2626);
+  color: var(--functional-error-red, #dc2626);
 }
 
 app-workorder-detail-page .failed-check--warning .failed-check__icon {
-  color: var(--color-warning, #f59e0b);
+  color: var(--functional-warning, #f59e0b);
 }
 
 app-party-detail .modal-backdrop {
@@ -950,9 +970,9 @@ app-invoice-payment-status-page .ips-skeleton {
   border-radius: var(--radius-sm);
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--surface-container, var(--durion-surface-container, var(--brand-surface))) 92%, transparent),
-    color-mix(in srgb, var(--color-secondary, var(--brand-secondary)) 14%, transparent),
-    color-mix(in srgb, var(--surface-container, var(--durion-surface-container, var(--brand-surface))) 92%, transparent)
+    color-mix(in srgb, var(--cardBackground) 92%, transparent),
+    color-mix(in srgb, var(--brand-secondary) 14%, transparent),
+    color-mix(in srgb, var(--cardBackground) 92%, transparent)
   );
   background-size: 220% 100%;
   animation: invoice-payment-status-shimmer 1.1s linear infinite;


### PR DESCRIPTION
## Summary

Executes `design/handoff/README.md` (steps 03–06 + source-doc replacement); fonts (01/02) already shipped.

- **Heritage Gold** — gold ramp (Tier1), `--brand-gold` (Tier2), theme-aware `--goldA400`/`--goldA100` (Tier3 light+dark) in `styles.css`. Logo artwork untouched.
- **`.mic-*` → `.dur-*`** — canonical Durion utility prefix (elevation, status); CSS + 6 templates, rename-only.
- **Component token cleanup** — codemod safe pass + manual judgment calls per handoff table (`--surface-container*`→`--cardBackground`, `--on-surface*`→`--currentTextColor`/`--text-muted`/`--border-color`, secondary/error-container status pairs, `--typescale-*`→literals). Fixed codemod over-matches that had laundered drift into undefined `--functional-*` names.
- **`--space-5`** — added `1.25rem` to the scale (sanctioned); ~100 call sites preserved, bare no-fallback usages fixed; docs + guardrail reconciled.
- **Stylelint guardrail** — root `.stylelintrc.json` + `lint:css` script. **0 warnings across 169 files.**
- **Source-of-truth docs** — replaced `durion-style-guide.md` + `theme-tokens.md`.
- **`durion-theme.css` regenerated** (open item #3) — mirrors `styles.css`; killed divergent menu/sub-menu/nav values; dropped dead `data-brand` selectors; added gold + extended tokens.
- **Barlow weight scale ratified** (open item #4) — hosted weights 500/600/700 only → `--font-weight-display/heading/medium` tokens + type spec; other weights banned (faux synthesis).

Deferred open items: reversed/white logo lockup (#1), retire badge/banner protos (#2) — need design assets, not code.

## Validation

- [ ] `npm run build`
- [ ] `npm run test`
- [x] `npm run lint:css` — green (0 warnings, 169 files)

## Accessibility Verification (Required for Changed UI)

Changes are token/prefix renames + theme-aware color-mix surfaces (no markup/flow change). Contrast preserved per ADR-0039; dark-mode-broken no-fallback tokens now resolve to real AA surfaces.

- [ ] Keyboard smoke on changed pages
- [ ] Screen-reader smoke on changed pages

## Notes / Follow-ups

- #1 reversed/white logo lockup — needs a reversed mark file (design).
- #2 retire badge & banner protos — rebuild from supplied icon (design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)