### PR TITLE
[styles] Fix two AA contrast failures (teal button, success alert)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -526,7 +526,7 @@ app-workorder-detail-page .alert--warn {
 
 app-workorder-detail-page .alert--success {
   background: color-mix(in srgb, var(--functional-success) 12%, transparent);
-  color: var(--functional-success);
+  color: #1b5e20; /* functional-success (#2e7d32) is only 4.36:1 on its own tint; darker green = AA */
   border: 1px solid var(--functional-success);
   border-radius: var(--radius-sm, 4px);
   padding: 0.75rem 1rem;
@@ -789,12 +789,12 @@ app-party-detail .btn--sm {
 }
 
 app-party-detail .btn--primary {
-  background: var(--durion-teal-400);
+  background: #006a6a; /* teal-400 (#2bbbad) gives white only 2.4:1; darker teal = 6.4:1 AA */
   color: #fff;
 }
 
 app-party-detail .btn--primary:hover:not(:disabled) {
-  background: var(--durion-teal-500);
+  background: #00504f;
 }
 
 app-party-detail .btn--secondary {


### PR DESCRIPTION
## Summary

Scanned `styles.css` for rules that set **both** `color` and `background` to a resolvable value (literal hex or `var()` chain, light-theme tokens) and computed the WCAG ratio. Two real failures, both fixed:

| Rule | Was | Ratio | Now |
|---|---|---|---|
| `app-party-detail .btn--primary` | white on teal-400 `#2bbbad` | **2.38:1** | `#006a6a` base / `#00504f` hover → 6.4:1 |
| `app-workorder-detail-page .alert--success` | `#2e7d32` on its 12% tint | **4.36:1** | text `#1b5e20` → AA |

Note: the brand Electric Teal ramp is too light for white text at every tier (teal-600 only reaches ~4:1), which is why the button uses a darker teal — consistent with the existing `.btn--accent` accent gradient.

## Scan scope / limits
- Same-rule `color` + `background` pairs, light theme. Caught both real fails; other rules pass.
- Not covered (separate/systemic): inherited text color from a parent rule, dark-theme contrast of functional colors on dark surfaces (single-value `--functional-*` tokens — would need theme-aware variants), and gradient backgrounds.

## Validation
- [x] Contrast scan — 0 rules below 4.5:1
- [x] `npm run lint:css` — green (169 files, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)