### PR TITLE
Show technician name + employee number on workorder detail

### DIFF
--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.html
@@ -27,7 +27,7 @@
         @if (technicianName()) {
         <p class="wo-header__meta-item">
           <span class="wo-header__meta-label">Technician</span>
-          <span class="wo-header__meta-value">{{ technicianName() }}</span>
+          <span class="wo-header__meta-value">{{ technicianDisplay() }}</span>
         </p>
         } @else {
         <p class="wo-header__meta-item">

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
@@ -5,6 +5,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { vi } from 'vitest';
 import { WorkorderDetailPageComponent } from './workorder-detail-page.component';
 import { BASE_PATH } from '@durion-sdk/workorder';
+import { Configuration as PeopleConfiguration } from '@durion-sdk/people';
 import { environment } from '../../../../../environments/environment';
 
 const BASE = environment.apiBaseUrl;
@@ -43,6 +44,7 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
         provideHttpClientTesting(),
         { provide: ActivatedRoute, useValue: mockRoute },
         { provide: BASE_PATH, useValue: environment.apiBaseUrl },
+        { provide: PeopleConfiguration, useValue: new PeopleConfiguration({ basePath: environment.apiBaseUrl }) },
       ],
     }).compileComponents();
     fixture = TestBed.createComponent(WorkorderDetailPageComponent);
@@ -198,6 +200,61 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
       const assign = buttons.find(b => (b.textContent ?? '').includes('Assign Technician'));
       expect(approve).toBeUndefined();
       expect(assign?.disabled).toBe(false);
+    });
+  });
+
+  describe('technician header — name + employee number', () => {
+    const TECH_ID = 'tech-uuid-1';
+
+    /** Flush detail (with technician), the employee lookup, and changeRequests. */
+    function drainWithTechnician(employeeFlush: () => void): void {
+      http.expectOne(`${BASE}/v1/workorders/${WO_ID}/detail`).flush({
+        ...STUB_WORKORDER,
+        assignedTechnicianId: TECH_ID,
+        assignedTechnicianName: 'Jane Smith',
+      });
+      employeeFlush();
+      http.expectOne(`${BASE}/v1/workorders/${WO_ID}/changeRequests`).flush([]);
+    }
+
+    it('renders the technician name with employee number once the lookup resolves', () => {
+      fixture.detectChanges();
+      drainWithTechnician(() =>
+        http.expectOne(`${BASE}/v1/people/employees/${TECH_ID}`).flush({
+          id: TECH_ID,
+          legalName: 'Jane Smith',
+          employeeNumber: 'EMP-007',
+          status: 'ACTIVE',
+          hireDate: '2024-01-01',
+        }),
+      );
+      fixture.detectChanges();
+
+      expect(component.technicianDisplay()).toBe('Jane Smith · #EMP-007');
+      const value = fixture.nativeElement.querySelector('.wo-header__meta-value');
+      expect(value?.textContent ?? '').toContain('Jane Smith');
+      expect(value?.textContent ?? '').toContain('EMP-007');
+    });
+
+    it('falls back to the technician name alone when the employee lookup fails', () => {
+      fixture.detectChanges();
+      drainWithTechnician(() =>
+        http.expectOne(`${BASE}/v1/people/employees/${TECH_ID}`).flush(
+          { message: 'not found' },
+          { status: 404, statusText: 'Not Found' },
+        ),
+      );
+      fixture.detectChanges();
+
+      expect(component.technicianEmployeeNumber()).toBeNull();
+      expect(component.technicianDisplay()).toBe('Jane Smith');
+    });
+
+    it('does not call the employee endpoint when no technician is assigned', () => {
+      fixture.detectChanges();
+      drainInit(http);
+      http.expectNone(`${BASE}/v1/people/employees/${TECH_ID}`);
+      expect(component.technicianDisplay()).toBeNull();
     });
   });
 

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
@@ -156,6 +156,28 @@ export class WorkorderDetailPageComponent implements OnInit {
     null,
   );
 
+  /**
+   * Employee number for the assigned technician, resolved from the People
+   * domain (it is not present on the workorder payload). Null until/unless the
+   * lookup succeeds.
+   */
+  readonly technicianEmployeeNumber = signal<string | null>(null);
+
+  /**
+   * Header display for the assigned technician — name plus employee number when
+   * available (e.g. "Jane Smith · #EMP-001"), falling back to the name alone
+   * while the number resolves or if the technician has no employee profile.
+   * Null when no technician is assigned.
+   */
+  readonly technicianDisplay = computed(() => {
+    const name = this.technicianName();
+    if (!name) {
+      return null;
+    }
+    const employeeNumber = this.technicianEmployeeNumber();
+    return employeeNumber ? `${name} · #${employeeNumber}` : name;
+  });
+
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('workorderId') ?? '';
     this.workorderId.set(id);
@@ -172,6 +194,7 @@ export class WorkorderDetailPageComponent implements OnInit {
         next: (detail) => {
           this.workorder.set(detail);
           this.pageState.set('ready');
+          this.loadTechnicianEmployeeNumber(detail.primaryTechnicianId);
           if (this.activeTab() === 'audit') {
             this.loadTransitions(id);
           }
@@ -188,6 +211,24 @@ export class WorkorderDetailPageComponent implements OnInit {
           );
           this.pageState.set('error');
         },
+      });
+  }
+
+  /**
+   * Resolves the assigned technician's employee number for the header. No-op
+   * (clearing any prior value) when the work order has no assigned technician.
+   */
+  private loadTechnicianEmployeeNumber(technicianId: string | undefined): void {
+    this.technicianEmployeeNumber.set(null);
+    if (!technicianId) {
+      return;
+    }
+    this.service
+      .getTechnicianEmployeeNumber(technicianId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (employeeNumber) => this.technicianEmployeeNumber.set(employeeNumber),
+        error: () => this.technicianEmployeeNumber.set(null),
       });
   }
 

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.ts
@@ -223,13 +223,12 @@ export class WorkorderDetailPageComponent implements OnInit {
     if (!technicianId) {
       return;
     }
+    // getTechnicianEmployeeNumber resolves to null on failure (no error path), so
+    // a single next handler covers both the resolved and failed cases.
     this.service
       .getTechnicianEmployeeNumber(technicianId)
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (employeeNumber) => this.technicianEmployeeNumber.set(employeeNumber),
-        error: () => this.technicianEmployeeNumber.set(null),
-      });
+      .subscribe((employeeNumber) => this.technicianEmployeeNumber.set(employeeNumber));
   }
 
   private loadChangeRequests(id: string): void {

--- a/src/app/features/workexec/services/workexec.service.spec.ts
+++ b/src/app/features/workexec/services/workexec.service.spec.ts
@@ -27,6 +27,7 @@ import { vi } from 'vitest';
 import { WorkexecService } from './workexec.service';
 import { ApiBaseService } from '../../../core/services/api-base.service';
 import { BASE_PATH, EstimateSearchService, WorkorderSearchService } from '@durion-sdk/workorder';
+import { Configuration as PeopleConfiguration } from '@durion-sdk/people';
 import { environment } from '../../../../environments/environment';
 import {
   ConsumePickedItemsRequest,
@@ -61,6 +62,7 @@ describe('WorkexecService', () => {
         WorkexecService,
         ApiBaseService,
         { provide: BASE_PATH, useValue: environment.apiBaseUrl },
+        { provide: PeopleConfiguration, useValue: new PeopleConfiguration({ basePath: environment.apiBaseUrl }) },
         { provide: EstimateSearchService, useValue: estimateSearchStub },
         { provide: WorkorderSearchService, useValue: workorderSearchStub },
       ],
@@ -685,6 +687,26 @@ describe('WorkexecService', () => {
       expect(r.request.method).toBe('POST');
       r.flush({ workorderId: 'wo-1', itemId: 'part-1', itemType: 'PART', status: 'COMPLETED' });
       expect(status).toBe('COMPLETED');
+    });
+  });
+
+  describe('getTechnicianEmployeeNumber', () => {
+    it('gets /v1/people/employees/{id} and returns the employee number', () => {
+      let result: string | null | undefined;
+      service.getTechnicianEmployeeNumber('tech-1').subscribe(n => (result = n));
+      const r = http.expectOne(`${BASE}/v1/people/employees/tech-1`);
+      expect(r.request.method).toBe('GET');
+      r.flush({ id: 'tech-1', legalName: 'Jane Smith', employeeNumber: 'EMP-007', status: 'ACTIVE', hireDate: '2024-01-01' });
+      expect(result).toBe('EMP-007');
+    });
+
+    it('resolves to null when the employee lookup fails', () => {
+      let result: string | null | undefined;
+      service.getTechnicianEmployeeNumber('tech-1').subscribe(n => (result = n));
+      http
+        .expectOne(`${BASE}/v1/people/employees/tech-1`)
+        .flush({ message: 'not found' }, { status: 404, statusText: 'Not Found' });
+      expect(result).toBeNull();
     });
   });
 });

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { PeopleAvailabilityAPIService, PeopleAvailabilityResponse } from '@durion-sdk/people';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { EmployeeAPIService, PeopleAvailabilityAPIService, PeopleAvailabilityResponse } from '@durion-sdk/people';
 import { ApiBaseService } from '../../../core/services/api-base.service';
 import {
   ChangeRequestAPIService,
@@ -169,6 +169,7 @@ export class WorkexecService {
   private readonly workorderPartAdjustments = inject(WorkorderPartAdjustmentsService);
   private readonly timeTracking = inject(WorkexecTimeTrackingAPIService);
   private readonly peopleAvailability = inject(PeopleAvailabilityAPIService);
+  private readonly employeeApi = inject(EmployeeAPIService);
 
   /** Builds an options object carrying the Idempotency-Key header when a key is provided. */
   private idempotencyOptions(key?: string) {
@@ -964,6 +965,23 @@ export class WorkexecService {
       name: name || p.personId,
       role: p.role,
     };
+  }
+
+  /**
+   * operationId: getEmployee
+   * GET /v1/people/employees/{employeeId}
+   *
+   * Resolves a technician's unique employee number from the People domain. The
+   * workorder payload carries the technician id and display name but not the
+   * employee number, so the detail header enriches itself with this lookup
+   * keyed by the assigned technician id. Resolves to null when the technician
+   * has no employee profile or the call fails, so the name still renders alone.
+   */
+  getTechnicianEmployeeNumber(technicianId: string): Observable<string | null> {
+    return this.employeeApi.getEmployee(technicianId).pipe(
+      map(emp => emp.employeeNumber || null),
+      catchError(() => of(null)),
+    );
   }
 
   // ── CAP-005: Start Work (Story 224) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

On `/app/workexec/workorders/:id`, the technician header now shows the technician's **name + employee number** instead of the name alone (which fell back to the raw technician id when no name resolved).

The employee number is **not** carried on the workorder payload — it lives on the People domain's `EmployeeProfileDto`. So the header enriches itself with a follow-up lookup keyed by the assigned technician id.

## Why this data source

Two candidate sources were considered:
- **Assign-page roster** (`listTechniciansForLocation`) — ruled out: `LocationTechnician` exposes only `id`/`name`/`role` (no `employeeNumber`), and the detail page has no location id to query it with.
- **Employee API** (`getEmployee`, callable by technician id) — chosen: `GET /v1/people/employees/{id}` returns `EmployeeProfileDto.employeeNumber`. The assigned technician id is the person/employee id used across the People domain.

## Changes

- **`workexec.service.ts`** — added `getTechnicianEmployeeNumber(technicianId)`, resolving to the employee number or `null` (graceful `catchError`, so a missing/failed profile still renders the name).
- **`workorder-detail-page.component.ts`** — fetches the number after the workorder loads; new `technicianDisplay` computed renders `"Name · #EMP-001"`, falling back to the name alone while resolving / on failure. The existing **"Unassigned"** path is unchanged.
- **`workorder-detail-page.component.html`** — renders `technicianDisplay()`.
- **Specs** — 3 new component tests (resolved / lookup-failed / no-technician) and 2 new service tests.

## Testing

- Component spec: 14/14 passing
- Service spec: 42/42 passing

## Note

This component currently uses hardcoded English labels throughout (no `TranslatePipe` wired in), so `"Technician"`/`"Unassigned"` were left as-is for consistency rather than introducing i18n for a single line. Migrating the component's labels to i18n keys could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015SwNUqL38hEbNrxizyiHzV

---
_Generated by [Claude Code](https://claude.ai/code/session_015SwNUqL38hEbNrxizyiHzV)_