### PR TITLE
fix(icons): render Material Symbols by codepoint + add sidebar icons

### DIFF
--- a/src/app/features/shell/components/chat-panel/chat-panel.component.html
+++ b/src/app/features/shell/components/chat-panel/chat-panel.component.html
@@ -1,7 +1,7 @@
 <section class="chat-panel" [attr.aria-label]="'SHELL.CHAT.PANEL_ARIA' | translate">
 
   <!-- Collapse control -->
-  <button type="button" class="chat-close-btn" (click)="close.emit()"
+  <button type="button" class="chat-close-btn" (click)="collapse.emit()"
     [attr.aria-label]="'SHELL.CHAT.CLOSE_ARIA' | translate" [title]="'SHELL.CHAT.CLOSE_ARIA' | translate">
     <span class="material-symbols-rounded" aria-hidden="true">{{ 'close' | msIcon }}</span>
   </button>

--- a/src/app/features/shell/components/chat-panel/chat-panel.component.html
+++ b/src/app/features/shell/components/chat-panel/chat-panel.component.html
@@ -3,7 +3,7 @@
   <!-- Collapse control -->
   <button type="button" class="chat-close-btn" (click)="close.emit()"
     [attr.aria-label]="'SHELL.CHAT.CLOSE_ARIA' | translate" [title]="'SHELL.CHAT.CLOSE_ARIA' | translate">
-    <span class="material-symbols-rounded" aria-hidden="true">close</span>
+    <span class="material-symbols-rounded" aria-hidden="true">{{ 'close' | msIcon }}</span>
   </button>
 
   <!-- Message list -->

--- a/src/app/features/shell/components/chat-panel/chat-panel.component.ts
+++ b/src/app/features/shell/components/chat-panel/chat-panel.component.ts
@@ -19,11 +19,12 @@ import { ChatStateService } from '../../services/chat-state.service';
 import { ChatApiService } from '../../services/chat-api.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { RagIngestDialogComponent } from '../rag-ingest-dialog/rag-ingest-dialog.component';
+import { MaterialSymbolPipe } from '../../../../shared/material-symbol.pipe';
 
 @Component({
   selector: 'app-chat-panel',
   standalone: true,
-  imports: [CommonModule, FormsModule, DatePipe, TranslatePipe, RagIngestDialogComponent],
+  imports: [CommonModule, FormsModule, DatePipe, TranslatePipe, RagIngestDialogComponent, MaterialSymbolPipe],
   templateUrl: './chat-panel.component.html',
   styleUrl: './chat-panel.component.css',
 })

--- a/src/app/features/shell/components/chat-panel/chat-panel.component.ts
+++ b/src/app/features/shell/components/chat-panel/chat-panel.component.ts
@@ -38,7 +38,7 @@ export class ChatPanelComponent implements AfterViewChecked {
   private readonly authService = inject(AuthService);
 
   /** Emitted when the user collapses the panel via its close button. */
-  readonly close = output<void>();
+  readonly collapse = output<void>();
 
   readonly isAdmin = computed(() => this.authService.hasAnyRole(['ROLE_ADMIN']));
   readonly showRagDialog = signal(false);

--- a/src/app/features/shell/components/header/header.component.html
+++ b/src/app/features/shell/components/header/header.component.html
@@ -28,7 +28,7 @@
       [class.active]="!chatCollapsed()"
       [attr.aria-label]="'SHELL.HEADER.CHAT_TOGGLE' | translate" [attr.aria-expanded]="!chatCollapsed()"
       [attr.aria-controls]="chatId()" [title]="'SHELL.HEADER.CHAT_TOGGLE' | translate">
-      <span class="material-symbols-rounded" aria-hidden="true">forum</span>
+      <span class="material-symbols-rounded" aria-hidden="true">{{ 'forum' | msIcon }}</span>
     </button>
 
     <button class="icon-btn" type="button" (click)="themeService.toggle()"

--- a/src/app/features/shell/components/header/header.component.ts
+++ b/src/app/features/shell/components/header/header.component.ts
@@ -3,11 +3,12 @@ import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { ThemeService } from '../../../../core/services/theme.service';
 import { AuthService }  from '../../../../core/services/auth.service';
 import { LocaleService } from '../../../../core/services/locale.service';
+import { MaterialSymbolPipe } from '../../../../shared/material-symbol.pipe';
 
 @Component({
   selector: 'app-shell-header',
   standalone: true,
-  imports: [TranslatePipe],
+  imports: [TranslatePipe, MaterialSymbolPipe],
   templateUrl: './header.component.html',
   styleUrl: './header.component.css',
 })

--- a/src/app/features/shell/components/nav/nav.component.html
+++ b/src/app/features/shell/components/nav/nav.component.html
@@ -4,7 +4,7 @@
   <a class="nav-item" [routerLink]="item.route" routerLinkActive="nav-item--active"
     [routerLinkActiveOptions]="{ exact: item.exact ?? false }" [attr.aria-label]="item.key | translate"
     [title]="item.key | translate">
-    <span class="nav-icon" aria-hidden="true">{{ item.icon }}</span>
+    <span class="nav-icon material-symbols-rounded" aria-hidden="true">{{ item.icon | msIcon }}</span>
     @if (!collapsed()) {
     <span class="nav-label">{{ item.key | translate }}</span>
     }

--- a/src/app/features/shell/components/nav/nav.component.ts
+++ b/src/app/features/shell/components/nav/nav.component.ts
@@ -2,10 +2,11 @@ import { Component, inject, input } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslatePipe } from '@ngx-translate/core';
 import { NavigationRegistryService } from '../../services/navigation-registry.service';
+import { MaterialSymbolPipe } from '../../../../shared/material-symbol.pipe';
 @Component({
   selector: 'app-shell-nav',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive, TranslatePipe],
+  imports: [RouterLink, RouterLinkActive, TranslatePipe, MaterialSymbolPipe],
   templateUrl: './nav.component.html',
   styleUrl: './nav.component.css',
 })

--- a/src/app/features/shell/dashboard/dashboard.component.html
+++ b/src/app/features/shell/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="dashboard">
   <!-- Assistant strip -->
   <section class="assistant" [attr.aria-label]="'SHELL.DASHBOARD.ASSISTANT.REGION_ARIA' | translate">
-    <span class="assistant-icon material-symbols-rounded" aria-hidden="true">forum</span>
+    <span class="assistant-icon material-symbols-rounded" aria-hidden="true">{{ 'forum' | msIcon }}</span>
     <input
       class="assistant-input"
       type="text"
@@ -19,7 +19,7 @@
       [attr.aria-label]="'SHELL.DASHBOARD.ASSISTANT.SEND_ARIA' | translate"
       (click)="submitAssistant()"
     >
-      <span class="material-symbols-rounded" aria-hidden="true">send</span>
+      <span class="material-symbols-rounded" aria-hidden="true">{{ 'send' | msIcon }}</span>
     </button>
   </section>
 
@@ -45,7 +45,7 @@
         <li>
           <a class="action-card" [routerLink]="action.route">
             <span class="action-tile" [class]="'tone-' + action.tone">
-              <span class="material-symbols-rounded" aria-hidden="true">{{ action.icon }}</span>
+              <span class="material-symbols-rounded" aria-hidden="true">{{ action.icon | msIcon }}</span>
             </span>
             <span class="action-body">
               <span class="action-label">{{ action.labelKey | translate }}</span>
@@ -68,13 +68,13 @@
           <li>
             <a class="recent-row" [routerLink]="item.route">
               <span class="recent-tile">
-                <span class="material-symbols-rounded" aria-hidden="true">{{ item.icon }}</span>
+                <span class="material-symbols-rounded" aria-hidden="true">{{ item.icon | msIcon }}</span>
               </span>
               <span class="recent-text">
                 <span class="recent-label">{{ item.labelKey | translate }}</span>
                 <span class="recent-meta">{{ item.metaKey | translate }}</span>
               </span>
-              <span class="recent-chevron material-symbols-rounded" aria-hidden="true">chevron_right</span>
+              <span class="recent-chevron material-symbols-rounded" aria-hidden="true">{{ 'chevron_right' | msIcon }}</span>
             </a>
           </li>
         }
@@ -87,9 +87,9 @@
         @for (area of favoriteAreas; track area.route) {
           <li>
             <a class="favorite-row" [routerLink]="area.route">
-              <span class="favorite-icon material-symbols-rounded" aria-hidden="true">{{ area.icon }}</span>
+              <span class="favorite-icon material-symbols-rounded" aria-hidden="true">{{ area.icon | msIcon }}</span>
               <span class="favorite-label">{{ area.labelKey | translate }}</span>
-              <span class="favorite-star material-symbols-rounded" aria-hidden="true">star</span>
+              <span class="favorite-star material-symbols-rounded" aria-hidden="true">{{ 'star' | msIcon }}</span>
             </a>
           </li>
         }

--- a/src/app/features/shell/dashboard/dashboard.component.ts
+++ b/src/app/features/shell/dashboard/dashboard.component.ts
@@ -4,6 +4,7 @@ import { RouterLink } from '@angular/router';
 import { finalize } from 'rxjs';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { AuthService } from '../../../core/services/auth.service';
+import { MaterialSymbolPipe } from '../../../shared/material-symbol.pipe';
 import { ChatStateService } from '../services/chat-state.service';
 import { ChatApiService } from '../services/chat-api.service';
 import { ChatUiService } from '../services/chat-ui.service';
@@ -45,7 +46,7 @@ interface FavoriteArea {
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [FormsModule, RouterLink, TranslatePipe],
+  imports: [FormsModule, RouterLink, TranslatePipe, MaterialSymbolPipe],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css',
 })

--- a/src/app/features/shell/services/navigation-registry.service.ts
+++ b/src/app/features/shell/services/navigation-registry.service.ts
@@ -3,18 +3,18 @@ import { AuthService } from '../../../core/services/auth.service';
 import { NavItem } from '../models/nav-item.model';
 
 const NAV_REGISTRY: NavItem[] = [
-  { key: 'SHELL.NAV.DASHBOARD', icon: 'D', route: '/app', exact: true, order: 1, group: 'main' },
-  { key: 'SHELL.NAV.WORKORDERS', icon: 'W', route: '/app/workexec', order: 2, group: 'main' },
-  { key: 'SHELL.NAV.CRM', icon: 'C', route: '/app/crm', order: 3, group: 'main' },
-  { key: 'SHELL.NAV.DISPATCH', icon: 'S', route: '/app/shopmgmt', order: 4, group: 'main' },
-  { key: 'SHELL.NAV.ACCOUNTING', icon: 'A', route: '/app/accounting', order: 5, group: 'main' },
-  { key: 'SHELL.NAV.BILLING', icon: 'B', route: '/app/billing', order: 6, group: 'main' },
-  { key: 'SHELL.NAV.PEOPLE', icon: 'P', route: '/app/people', order: 7, group: 'main' },
-  { key: 'SHELL.NAV.INVENTORY', icon: 'I', route: '/app/inventory', order: 8, group: 'main' },
-  { key: 'SHELL.NAV.PRODUCT', icon: 'Pr', route: '/app/product', order: 9, group: 'main' },
-  { key: 'SHELL.NAV.LOCATION', icon: 'L', route: '/app/location', order: 10, group: 'main' },
-  { key: 'SHELL.NAV.SECURITY', icon: 'S', route: '/app/security', roles: ['ROLE_ADMIN'], order: 11, group: 'admin' },
-  { key: 'SHELL.NAV.ADMIN', icon: 'Ad', route: '/app/admin', roles: ['ROLE_ADMIN'], order: 12, group: 'admin' },
+  { key: 'SHELL.NAV.DASHBOARD', icon: 'space_dashboard', route: '/app', exact: true, order: 1, group: 'main' },
+  { key: 'SHELL.NAV.WORKORDERS', icon: 'construction', route: '/app/workexec', order: 2, group: 'main' },
+  { key: 'SHELL.NAV.CRM', icon: 'groups', route: '/app/crm', order: 3, group: 'main' },
+  { key: 'SHELL.NAV.DISPATCH', icon: 'storefront', route: '/app/shopmgmt', order: 4, group: 'main' },
+  { key: 'SHELL.NAV.ACCOUNTING', icon: 'account_balance', route: '/app/accounting', order: 5, group: 'main' },
+  { key: 'SHELL.NAV.BILLING', icon: 'receipt_long', route: '/app/billing', order: 6, group: 'main' },
+  { key: 'SHELL.NAV.PEOPLE', icon: 'badge', route: '/app/people', order: 7, group: 'main' },
+  { key: 'SHELL.NAV.INVENTORY', icon: 'inventory_2', route: '/app/inventory', order: 8, group: 'main' },
+  { key: 'SHELL.NAV.PRODUCT', icon: 'category', route: '/app/product', order: 9, group: 'main' },
+  { key: 'SHELL.NAV.LOCATION', icon: 'location_city', route: '/app/location', order: 10, group: 'main' },
+  { key: 'SHELL.NAV.SECURITY', icon: 'shield', route: '/app/security', roles: ['ROLE_ADMIN'], order: 11, group: 'admin' },
+  { key: 'SHELL.NAV.ADMIN', icon: 'admin_panel_settings', route: '/app/admin', roles: ['ROLE_ADMIN'], order: 12, group: 'admin' },
 ];
 
 @Injectable({ providedIn: 'root' })

--- a/src/app/features/shell/shell.component.html
+++ b/src/app/features/shell/shell.component.html
@@ -24,7 +24,7 @@
       <!-- Top frame: Chat panel — collapsible, collapsed by default -->
       @if (!chatCollapsed()) {
       <div class="frame-chat" [id]="CHAT_ID">
-        <app-chat-panel (close)="toggleChat()" />
+        <app-chat-panel (collapse)="toggleChat()" />
       </div>
       }
 

--- a/src/app/shared/material-symbol.pipe.spec.ts
+++ b/src/app/shared/material-symbol.pipe.spec.ts
@@ -1,0 +1,28 @@
+import { MaterialSymbolPipe } from './material-symbol.pipe';
+
+describe('MaterialSymbolPipe', () => {
+  const pipe = new MaterialSymbolPipe();
+
+  it('maps a known icon name to its codepoint character', () => {
+    expect(pipe.transform('forum').codePointAt(0)).toBe(0xe0bf);
+    expect(pipe.transform('space_dashboard').codePointAt(0)).toBe(0xe66b);
+    expect(pipe.transform('close').codePointAt(0)).toBe(0xe14c);
+  });
+
+  it('returns a single-character glyph, not the ligature name', () => {
+    const glyph = pipe.transform('inventory_2');
+    expect(glyph.length).toBe(1);
+    expect(glyph).not.toContain('inventory');
+  });
+
+  it('returns an empty string for unknown names (no stray letters)', () => {
+    expect(pipe.transform('not_a_real_icon')).toBe('');
+    expect(pipe.transform('D')).toBe('');
+  });
+
+  it('handles null / undefined / empty input', () => {
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+    expect(pipe.transform('')).toBe('');
+  });
+});

--- a/src/app/shared/material-symbol.pipe.ts
+++ b/src/app/shared/material-symbol.pipe.ts
@@ -1,0 +1,46 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/**
+ * Material Symbols Rounded — name → glyph codepoint.
+ *
+ * The self-hosted font instance (v355) ships icon glyphs addressable by their
+ * Private-Use codepoint but WITHOUT usable `liga` ligature lookups, so the
+ * familiar ligature names ("forum", "send", …) render as plain letters. This
+ * pipe maps a readable icon name to its codepoint character so templates can
+ * keep using names. Add new entries here as icons are introduced; an unknown
+ * name resolves to an empty string (no glyph) rather than stray letters.
+ */
+const GLYPHS: Readonly<Record<string, string>> = {
+  // Navigation
+  space_dashboard: '\ue66b',
+  construction: '\uea3c',
+  groups: '\uf233',
+  storefront: '\uea12',
+  account_balance: '\ue84f',
+  receipt_long: '\uef6e',
+  badge: '\uea67',
+  inventory_2: '\ue1a1',
+  category: '\ue574',
+  location_city: '\ue7f1',
+  shield: '\ue75b',
+  admin_panel_settings: '\uef3d',
+  // Dashboard quick actions
+  assignment_add: '\uf848',
+  person_add: '\ue7fe',
+  payments: '\uef63',
+  event: '\ue24f',
+  // Shared UI
+  chevron_right: '\ue409',
+  star: '\ue838',
+  forum: '\ue0bf',
+  send: '\ue163',
+  close: '\ue14c',
+};
+
+@Pipe({ name: 'msIcon', standalone: true })
+export class MaterialSymbolPipe implements PipeTransform {
+  transform(name: string | null | undefined): string {
+    if (!name) return '';
+    return GLYPHS[name] ?? '';
+  }
+}


### PR DESCRIPTION
## Summary
Fixes Material Symbols rendering as **letters instead of icons**, and gives the **sidebar real icons**.

### Root cause
The self-hosted Material Symbols Rounded instance (v355) ships **no usable `liga` ligature lookups** (verified with fontTools: GSUB has only `rlig`, 0 type-4 lookups). So ligature names like `forum`/`send` never substitute to a glyph — and because the font's cmap also contains the Latin letters, you saw the **words**. The font *does* map every icon by its Private-Use **codepoint** (verified: `U+E0BF → forum` glyph, etc.).

### Fix
- New shared standalone **`MaterialSymbolPipe` (`msIcon`)** maps a readable icon name → its codepoint character. Unknown names resolve to `''` (no stray letters) — single source of truth for the icon set.
- Applied wherever icons render: dashboard, shell header (chat toggle), chat-panel (close).
- **Sidebar nav** now uses real Material Symbols (`space_dashboard`, `construction`, `groups`, `storefront`, `account_balance`, `receipt_long`, `badge`, `inventory_2`, `category`, `location_city`, `shield`, `admin_panel_settings`) through the same pipe, replacing the single-letter placeholders.

### Why codepoints, not ligatures
This font instance can't form ligatures at all; codepoints are the only reliable addressing for it and need no `font-feature-settings`. Keeps templates readable (names) while rendering glyphs.

## Test plan
- [x] `material-symbol.pipe.spec.ts` — name→codepoint, single-char glyph, unknown→'' , null/undefined
- [x] `npx ng test` shared + shell suites — 46 pass
- [x] `npx ng build --configuration development` — templates type-check clean

## Notes
- Builds on #111 (self-hosted font already in master).
- Icons are decorative (`aria-hidden`); nav items keep their translated `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
