### PR TITLE
chore(icons): nav icon size + icon-coverage guard test

### DIFF
--- a/src/app/features/shell/components/nav/nav.component.css
+++ b/src/app/features/shell/components/nav/nav.component.css
@@ -56,7 +56,11 @@
 }
 
 .nav-icon {
-  font-size: 1.1rem;
+  /* Intentional Material Symbol size for the rail; overrides the global
+     .material-symbols-rounded 24px default on purpose (the component-scoped
+     selector wins under emulated encapsulation). */
+  font-size: 1.375rem;
+  line-height: 1;
   flex-shrink: 0;
   width: 24px;
   text-align: center;

--- a/src/app/features/shell/icon-coverage.spec.ts
+++ b/src/app/features/shell/icon-coverage.spec.ts
@@ -1,0 +1,72 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { JwtClaims } from '../../core/models/auth.models';
+import { AuthService } from '../../core/services/auth.service';
+import { MaterialSymbolPipe } from '../../shared/material-symbol.pipe';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { ChatApiService } from './services/chat-api.service';
+import { NavigationRegistryService } from './services/navigation-registry.service';
+
+/**
+ * Guard against icon-name drift: every Material Symbol name referenced by the
+ * data-driven sources (nav registry, dashboard action/recent/favorite arrays)
+ * and the fixed template literals must resolve through the msIcon pipe to a
+ * real glyph. An unmapped name resolves to '' (invisible) with no other build
+ * signal, so this test is the signal.
+ */
+describe('Material Symbol icon coverage', () => {
+  const pipe = new MaterialSymbolPipe();
+
+  // Icon names hard-coded in templates (header chat toggle, chat-panel close,
+  // dashboard assistant/chevron/star). Keep in sync if those literals change.
+  const TEMPLATE_LITERAL_ICONS = ['forum', 'send', 'close', 'chevron_right', 'star'];
+
+  function assertResolves(name: string, source: string): void {
+    const glyph = pipe.transform(name);
+    expect(glyph, `icon "${name}" (${source}) is not mapped in the msIcon GLYPHS table`).not.toBe('');
+    expect(glyph.length, `icon "${name}" (${source}) did not resolve to a single glyph`).toBe(1);
+  }
+
+  it('maps every nav-registry icon', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: { hasAnyRole: () => true } },
+      ],
+    });
+    const registry = TestBed.inject(NavigationRegistryService);
+    const items = registry.visibleNavItems();
+    expect(items.length).toBeGreaterThan(0);
+    for (const item of items) {
+      assertResolves(item.icon, `nav:${item.key}`);
+    }
+  });
+
+  it('maps every dashboard icon', () => {
+    TestBed.configureTestingModule({
+      imports: [DashboardComponent, TranslateModule.forRoot()],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: { currentUserClaims: signal<JwtClaims | null>(null) } },
+        { provide: ChatApiService, useValue: { sendMessage: () => ({ subscribe: () => ({}) }) } },
+      ],
+    });
+    const cmp = TestBed.createComponent(DashboardComponent).componentInstance;
+    const names = [
+      ...cmp.quickActions.map(a => a.icon),
+      ...cmp.recentItems.map(r => r.icon),
+      ...cmp.favoriteAreas.map(f => f.icon),
+    ];
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      assertResolves(name, 'dashboard');
+    }
+  });
+
+  it('maps every fixed template-literal icon', () => {
+    for (const name of TEMPLATE_LITERAL_ICONS) {
+      assertResolves(name, 'template-literal');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Follow-ups from the high-effort review of #112.

### Fixes
1. **Nav icon size (CONFIRMED finding)** — the global `.material-symbols-rounded` `24px` was silently overridden by the component-scoped `.nav-icon` (`1.1rem`) under emulated encapsulation, so nav icons rendered undersized/inconsistent. Made the rail size **intentional (`1.375rem`)** and documented why it overrides the global default.
2. **Silent blank-icon drift (CONFIRMED)** — `msIcon` returns `''` for any name absent from its hand-curated `GLYPHS` map, so a typo or new icon disappears with no build/lint/test signal. Added an **icon-coverage guard test** asserting every icon name used by the nav registry, the dashboard arrays, and the fixed template literals resolves to a real single-glyph character. Drift now fails the build.

### Deferred (issues filed)
- **#113** — generate the codepoint map from the upstream `.codepoints` file (remove hand-curation).
- **#114** — collapsed-nav text fallback if the icon font fails to load (low risk; self-hosted).

### Already addressed in #112
- `close` output → renamed `collapse` (S7651).
- "unused import" (S1128) was a false positive (used in `imports[]`).

## Test plan
- [x] `icon-coverage.spec.ts` — 3 guard tests pass (nav, dashboard, literals)
- [x] `stylelint` nav.component.css — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
