### PR TITLE
i18n(fr-CA): add 26 missing PEOPLE and LOCATION keys

### DIFF
--- a/src/assets/i18n/fr-CA.json
+++ b/src/assets/i18n/fr-CA.json
@@ -230,6 +230,10 @@
         "DATA_IMPORT": {
           "TITLE": "Importation de donnees",
           "DESCRIPTION": "Importer en masse des donnees de personnel et RH."
+        },
+        "DIRECTORY": {
+          "TITLE": "Répertoire",
+          "DESCRIPTION": "Recherchez et parcourez toutes les personnes du système."
         }
       },
       "CARD": {
@@ -276,6 +280,10 @@
         "IMPORT_PEOPLE": {
           "TITLE": "Importer le personnel",
           "DESCRIPTION": "Importer en masse les enregistrements de personnel et RH a partir d'un fichier CSV ou XLSX."
+        },
+        "DIRECTORY": {
+          "TITLE": "Répertoire des personnes",
+          "DESCRIPTION": "Consultez et filtrez toutes les personnes par type et statut."
         }
       },
       "FIELD": {
@@ -393,6 +401,35 @@
         "APPROVE": "Impossible d'approuver les entrées.",
         "REJECT": "Impossible de rejeter les entrées.",
         "ADJUSTMENT": "Impossible de créer l'ajustement."
+      }
+    },
+    "DIRECTORY": {
+      "TITLE": "Répertoire des personnes",
+      "SEARCH_PLACEHOLDER": "Rechercher par nom, courriel ou nom d’utilisateur…",
+      "FILTER": {
+        "ALL": "Tous",
+        "EMPLOYEE": "Employés",
+        "ACTIVE": "Actifs",
+        "INACTIVE": "Inactifs"
+      },
+      "COL": {
+        "NAME": "Nom",
+        "USERNAME": "Nom d’utilisateur",
+        "EMAIL": "Courriel",
+        "PHONE": "Téléphone",
+        "ACTIONS": "Actions"
+      },
+      "ACTION": {
+        "VIEW_PROFILE": "Voir le profil"
+      },
+      "LOADING": "Chargement des personnes…",
+      "EMPTY": "Aucune personne ne correspond à votre recherche.",
+      "CLEAR_SEARCH": "Effacer la recherche",
+      "PAGINATION": {
+        "PAGE_OF": "Page {{current}} sur {{total}}"
+      },
+      "ERROR": {
+        "LOAD": "Échec du chargement des personnes."
       }
     }
   },
@@ -800,7 +837,12 @@
         "LOAD": "Impossible de charger les emplacements.",
         "NAME_TYPE_REQUIRED": "Le nom et le type sont requis.",
         "CREATE": "Impossible de créer l'emplacement."
-      }
+      },
+      "CODE": "Code",
+      "STATUS_ACTIVE": "Actif",
+      "STATUS_INACTIVE": "Inactif",
+      "ADDRESS": "Adresse",
+      "TYPE_DESCRIPTION": "Description"
     },
     "BAYS": {
       "TITLE": "Baies",


### PR DESCRIPTION
## Summary
Back-fills the pre-existing fr-CA translation gap flagged in #108: 21 `PEOPLE.*` keys (People Directory landing + table) and 5 `LOCATION.LOCATIONS.*` keys.

- All three locales now aligned at **2703 keys**; `npm run i18n:check` passes (missing-keys + pseudo).
- Canadian-French conventions (`courriel`, `nom d'utilisateur`); `{{current}}/{{total}}` interpolation preserved.
- Additive diff only (verified byte-identical JSON round-trip before editing).

## Test plan
- [x] `npm run i18n:check` — PASS (es-US + fr-CA aligned, pseudo up to date)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)