### PR TITLE
i18n(es-US,fr-CA): translate 135 English-copy values

### DIFF
--- a/src/assets/i18n/es-US.json
+++ b/src/assets/i18n/es-US.json
@@ -1268,20 +1268,20 @@
       "REVERSAL": "Reversión"
     },
     "INGESTION_MONITOR_LIST": {
-      "OVERLINE": "Ingestion Monitor",
-      "TITLE": "Ingestion Events",
-      "SUBTITLE": "Monitor ingestion envelope processing status",
-      "FILTERS_LABEL": "Ingestion filters",
-      "FILTER_EVENT_TYPE": "Event type",
-      "ERROR": "Failed to load ingestion events.",
-      "EMPTY": "No ingestion events match the selected filters.",
-      "TABLE_ARIA": "Ingestion events table",
-      "TABLE_CAPTION": "Ingestion events",
-      "STATUS_ARIA": "Ingestion status",
-      "COL_EVENT_ID": "Event ID",
-      "COL_EVENT_TYPE": "Event type",
+      "OVERLINE": "Monitor de ingestión",
+      "TITLE": "Eventos de ingestión",
+      "SUBTITLE": "Supervisar el estado de procesamiento de sobres de ingestión",
+      "FILTERS_LABEL": "Filtros de ingestión",
+      "FILTER_EVENT_TYPE": "Tipo de evento",
+      "ERROR": "No se pudieron cargar los eventos de ingestión.",
+      "EMPTY": "Ningún evento de ingestión coincide con los filtros seleccionados.",
+      "TABLE_ARIA": "Tabla de eventos de ingestión",
+      "TABLE_CAPTION": "Eventos de ingestión",
+      "STATUS_ARIA": "Estado de ingestión",
+      "COL_EVENT_ID": "ID de evento",
+      "COL_EVENT_TYPE": "Tipo de evento",
       "COL_STATUS": "Status",
-      "COL_RECEIVED_AT": "Received at",
+      "COL_RECEIVED_AT": "Recibido el",
       "STATUS": {
         "RECEIVED": "Received",
         "PROCESSING": "Processing",
@@ -1293,24 +1293,24 @@
       }
     },
     "INGESTION_MONITOR_DETAIL": {
-      "OVERLINE": "Ingestion Monitor",
-      "TITLE": "Ingestion Event Detail",
-      "ERROR": "Failed to load event detail.",
-      "FIELD_EVENT_ID": "Event ID",
-      "FIELD_EVENT_TYPE": "Event type",
+      "OVERLINE": "Monitor de ingestión",
+      "TITLE": "Detalle del evento de ingestión",
+      "ERROR": "No se pudo cargar el detalle del evento.",
+      "FIELD_EVENT_ID": "ID de evento",
+      "FIELD_EVENT_TYPE": "Tipo de evento",
       "FIELD_STATUS": "Status",
-      "FIELD_RECEIVED_AT": "Received at",
+      "FIELD_RECEIVED_AT": "Recibido el",
       "PAYLOAD": "Payload",
-      "PAYLOAD_RESTRICTED": "Payload is restricted for your permissions.",
-      "RETRY_TITLE": "Retry Processing",
-      "RETRY_JUSTIFICATION": "Retry justification",
-      "HISTORY_TITLE": "Reprocessing History",
-      "HISTORY_EMPTY": "No reprocessing attempts recorded.",
-      "HISTORY_TABLE_ARIA": "Reprocessing history table",
-      "HISTORY_TABLE_CAPTION": "Reprocessing attempts",
-      "HISTORY_COL_ATTEMPT": "Attempt ID",
-      "HISTORY_COL_AT": "Attempted at",
-      "HISTORY_COL_BY": "Triggered by",
+      "PAYLOAD_RESTRICTED": "La carga útil está restringida para sus permisos.",
+      "RETRY_TITLE": "Reintentar procesamiento",
+      "RETRY_JUSTIFICATION": "Justificación del reintento",
+      "HISTORY_TITLE": "Historial de reprocesamiento",
+      "HISTORY_EMPTY": "No hay intentos de reprocesamiento registrados.",
+      "HISTORY_TABLE_ARIA": "Tabla del historial de reprocesamiento",
+      "HISTORY_TABLE_CAPTION": "Intentos de reprocesamiento",
+      "HISTORY_COL_ATTEMPT": "ID de intento",
+      "HISTORY_COL_AT": "Intentado el",
+      "HISTORY_COL_BY": "Activado por",
       "HISTORY_COL_OUTCOME": "Outcome",
       "STATUS": {
         "RECEIVED": "Received",
@@ -1328,46 +1328,46 @@
     },
     "EVENT_ENVELOPE_CONTRACT": {
       "OVERLINE": "Contract",
-      "TITLE": "Event Envelope Contract",
-      "TABS_ARIA": "Event contract tabs",
+      "TITLE": "Contrato de sobre de evento",
+      "TABS_ARIA": "Pestañas del contrato de evento",
       "TAB_FIELDS": "Fields",
-      "TAB_TRACEABILITY": "Traceability IDs",
+      "TAB_TRACEABILITY": "ID de trazabilidad",
       "TAB_EXAMPLES": "Examples",
-      "EMPTY_FIELDS": "No contract fields are available.",
-      "EMPTY_TRACEABILITY": "No traceability IDs are available.",
-      "EMPTY_EXAMPLES": "No examples are available.",
-      "FIELDS_TABLE_ARIA": "Contract fields table",
-      "FIELDS_TABLE_CAPTION": "Envelope field definitions",
-      "TRACE_TABLE_ARIA": "Traceability IDs table",
-      "TRACE_TABLE_CAPTION": "Traceability identifier definitions",
+      "EMPTY_FIELDS": "No hay campos de contrato disponibles.",
+      "EMPTY_TRACEABILITY": "No hay ID de trazabilidad disponibles.",
+      "EMPTY_EXAMPLES": "No hay ejemplos disponibles.",
+      "FIELDS_TABLE_ARIA": "Tabla de campos del contrato",
+      "FIELDS_TABLE_CAPTION": "Definiciones de campos del sobre",
+      "TRACE_TABLE_ARIA": "Tabla de ID de trazabilidad",
+      "TRACE_TABLE_CAPTION": "Definiciones de identificadores de trazabilidad",
       "COL_NAME": "Name",
       "COL_TYPE": "Type",
       "COL_REQUIRED": "Required"
     },
     "INGESTION_SUBMIT": {
-      "OVERLINE": "Operations Tool",
-      "TITLE": "Submit Ingestion Event",
-      "INTERNAL_TOOL_NOTICE": "This is an internal accounting operations tool.",
-      "FIELD_EVENT_ID": "Event ID",
-      "FIELD_EVENT_TYPE": "Event type",
-      "FIELD_ORGANIZATION_ID": "Organization ID",
-      "FIELD_SOURCE_SYSTEM": "Source system",
-      "FIELD_PAYLOAD": "Payload JSON",
-      "SUBMIT": "Submit event",
-      "ERROR": "Submission failed. Verify data and try again.",
-      "EMPTY": "Populate the form and submit an event.",
-      "RESULT_TITLE": "Submission Result",
-      "RESULT_EVENT_ID": "Submitted event ID"
+      "OVERLINE": "Herramienta de operaciones",
+      "TITLE": "Enviar evento de ingestión",
+      "INTERNAL_TOOL_NOTICE": "Esta es una herramienta interna de operaciones contables.",
+      "FIELD_EVENT_ID": "ID de evento",
+      "FIELD_EVENT_TYPE": "Tipo de evento",
+      "FIELD_ORGANIZATION_ID": "ID de organización",
+      "FIELD_SOURCE_SYSTEM": "Sistema de origen",
+      "FIELD_PAYLOAD": "JSON de carga útil",
+      "SUBMIT": "Enviar evento",
+      "ERROR": "El envío falló. Verifique los datos e inténtelo de nuevo.",
+      "EMPTY": "Complete el formulario y envíe un evento.",
+      "RESULT_TITLE": "Resultado del envío",
+      "RESULT_EVENT_ID": "ID del evento enviado"
     },
     "POSTING_RULES_LIST": {
-      "OVERLINE": "Posting Rules",
-      "TITLE": "Posting Rule Sets",
-      "NEW_RULE_SET": "New rule set",
-      "EMPTY": "No posting rule sets found.",
-      "TABLE_ARIA": "Posting rule sets table",
-      "TABLE_CAPTION": "Posting rule sets",
+      "OVERLINE": "Reglas de contabilización",
+      "TITLE": "Conjuntos de reglas de contabilización",
+      "NEW_RULE_SET": "Nuevo conjunto de reglas",
+      "EMPTY": "No se encontraron conjuntos de reglas de contabilización.",
+      "TABLE_ARIA": "Tabla de conjuntos de reglas de contabilización",
+      "TABLE_CAPTION": "Conjuntos de reglas de contabilización",
       "COL_NAME": "Name",
-      "COL_EVENT_TYPE": "Event type",
+      "COL_EVENT_TYPE": "Tipo de evento",
       "COL_VERSION": "Version",
       "COL_STATUS": "Status",
       "STATUS": {
@@ -1377,8 +1377,8 @@
       }
     },
     "POSTING_RULES_DETAIL": {
-      "OVERLINE": "Posting Rules",
-      "TITLE": "Posting Rule Set Detail",
+      "OVERLINE": "Reglas de contabilización",
+      "TITLE": "Detalle del conjunto de reglas de contabilización",
       "EMPTY": "No hay detalles de reglas de contabilización.",
       "FIELD_ID": "ID del conjunto de reglas",
       "FIELD_NAME": "Nombre",
@@ -1393,33 +1393,33 @@
       "COL_PUBLISHED_BY": "Publicado por"
     },
     "PAYMENT_APPLY": {
-      "OVERLINE": "Accounts Receivable",
-      "TITLE": "Apply Payment",
-      "FIELD_PAYMENT_ID": "Payment ID",
-      "FIELD_APPLICATIONS": "Applications JSON",
-      "SUBMIT": "Apply payment",
-      "ERROR": "Unable to apply payment.",
-      "EMPTY": "Provide allocation data to apply payment.",
-      "RESULT_TITLE": "Application Result",
-      "RESULT_PAYMENT_ID": "Payment ID",
-      "RESULT_TOTAL": "Payment total",
-      "RESULT_APPLIED": "Applied total"
+      "OVERLINE": "Cuentas por cobrar",
+      "TITLE": "Aplicar pago",
+      "FIELD_PAYMENT_ID": "ID de pago",
+      "FIELD_APPLICATIONS": "JSON de aplicaciones",
+      "SUBMIT": "Aplicar pago",
+      "ERROR": "No se pudo aplicar el pago.",
+      "EMPTY": "Proporcione datos de asignación para aplicar el pago.",
+      "RESULT_TITLE": "Resultado de la aplicación",
+      "RESULT_PAYMENT_ID": "ID de pago",
+      "RESULT_TOTAL": "Total del pago",
+      "RESULT_APPLIED": "Total aplicado"
     },
     "CREDIT_MEMO_CREATE": {
-      "OVERLINE": "Accounts Receivable",
-      "TITLE": "Create Credit Memo",
-      "FIELD_ORIGINAL_INVOICE_ID": "Original invoice ID",
-      "FIELD_CUSTOMER_ID": "Customer ID",
-      "FIELD_CREDIT_AMOUNT": "Credit amount",
-      "FIELD_OUTSTANDING_BALANCE": "Outstanding balance",
-      "FIELD_REASON_CODE": "Reason code",
+      "OVERLINE": "Cuentas por cobrar",
+      "TITLE": "Crear nota de crédito",
+      "FIELD_ORIGINAL_INVOICE_ID": "ID de factura original",
+      "FIELD_CUSTOMER_ID": "ID de cliente",
+      "FIELD_CREDIT_AMOUNT": "Importe del crédito",
+      "FIELD_OUTSTANDING_BALANCE": "Saldo pendiente",
+      "FIELD_REASON_CODE": "Código de motivo",
       "FIELD_JUSTIFICATION_NOTE": "Justification",
-      "SUBMIT": "Create credit memo",
-      "ERROR": "Unable to create credit memo.",
-      "EMPTY": "Enter required fields to create a credit memo.",
-      "RESULT_TITLE": "Credit Memo Created",
-      "RESULT_CREDIT_MEMO_ID": "Credit memo ID",
-      "RESULT_TOTAL": "Total amount"
+      "SUBMIT": "Crear nota de crédito",
+      "ERROR": "No se pudo crear la nota de crédito.",
+      "EMPTY": "Ingrese los campos obligatorios para crear una nota de crédito.",
+      "RESULT_TITLE": "Nota de crédito creada",
+      "RESULT_CREDIT_MEMO_ID": "ID de nota de crédito",
+      "RESULT_TOTAL": "Importe total"
     },
     "CREDIT_MEMO_LIST": {
       "OVERLINE": "Cuentas por Cobrar",
@@ -1498,26 +1498,26 @@
       }
     },
     "VENDOR_PAYMENT_NEW": {
-      "OVERLINE": "Accounts Payable",
-      "TITLE": "New Vendor Payment",
-      "BILLS_TITLE": "Open Bills",
-      "LOAD_BILLS": "Load bills",
-      "EMPTY_BILLS": "No bills loaded for this vendor.",
-      "BILLS_TABLE_ARIA": "Vendor bills table",
-      "BILLS_TABLE_CAPTION": "Open vendor bills",
-      "COL_BILL_NUMBER": "Bill number",
-      "COL_DUE_DATE": "Due date",
-      "COL_OPEN_AMOUNT": "Open amount",
-      "FIELD_VENDOR_ID": "Vendor ID",
-      "FIELD_GROSS_AMOUNT": "Gross amount",
+      "OVERLINE": "Cuentas por pagar",
+      "TITLE": "Nuevo pago a proveedor",
+      "BILLS_TITLE": "Facturas pendientes",
+      "LOAD_BILLS": "Cargar facturas",
+      "EMPTY_BILLS": "No hay facturas cargadas para este proveedor.",
+      "BILLS_TABLE_ARIA": "Tabla de facturas de proveedor",
+      "BILLS_TABLE_CAPTION": "Facturas de proveedor pendientes",
+      "COL_BILL_NUMBER": "Número de factura",
+      "COL_DUE_DATE": "Fecha de vencimiento",
+      "COL_OPEN_AMOUNT": "Importe pendiente",
+      "FIELD_VENDOR_ID": "ID de proveedor",
+      "FIELD_GROSS_AMOUNT": "Importe bruto",
       "FIELD_CURRENCY": "Currency",
-      "FIELD_PAYMENT_METHOD": "Payment method",
-      "FIELD_PAYMENT_REF": "Payment reference",
-      "FIELD_ALLOCATIONS": "Allocations JSON",
-      "SUBMIT": "Submit payment",
-      "ERROR": "Unable to submit vendor payment.",
-      "RESULT_TITLE": "Vendor Payment Result",
-      "RESULT_PAYMENT_ID": "Payment ID",
+      "FIELD_PAYMENT_METHOD": "Método de pago",
+      "FIELD_PAYMENT_REF": "Referencia de pago",
+      "FIELD_ALLOCATIONS": "JSON de asignaciones",
+      "SUBMIT": "Enviar pago",
+      "ERROR": "No se pudo enviar el pago al proveedor.",
+      "RESULT_TITLE": "Resultado del pago a proveedor",
+      "RESULT_PAYMENT_ID": "ID de pago",
       "RESULT_STATUS": "Status"
     },
     "VENDOR_PAYMENT_LIST": {
@@ -1580,7 +1580,7 @@
         },
         "REPORTS": {
           "TITLE": "Reports",
-          "DESCRIPTION": "Read-only accounting reports."
+          "DESCRIPTION": "Informes contables de solo lectura."
         }
       },
       "CARD": {
@@ -1645,8 +1645,8 @@
           "DESCRIPTION": "Abre la vista detallada de una nota de crédito específica por ID."
         },
         "LABOR_OVERHEAD": {
-          "TITLE": "Labor & Overhead Cost Report",
-          "DESCRIPTION": "Monthly + YTD labor and overhead costs by location and fiscal year, from posted GL data."
+          "TITLE": "Informe de costos de mano de obra y gastos generales",
+          "DESCRIPTION": "Costos mensuales y acumulados del año de mano de obra y gastos generales por ubicación y año fiscal, a partir de los datos contabilizados del libro mayor."
         }
       },
       "FIELD": {
@@ -2603,14 +2603,14 @@
       }
     },
     "FINDERS": {
-      "TITLE": "Find a record",
-      "ESTIMATE_LABEL": "Find estimate",
-      "ESTIMATE_PLACEHOLDER": "Search by customer name or estimate id",
-      "WORKORDER_LABEL": "Find workorder",
-      "WORKORDER_PLACEHOLDER": "Search by customer name or workorder id",
+      "TITLE": "Buscar un registro",
+      "ESTIMATE_LABEL": "Buscar presupuesto",
+      "ESTIMATE_PLACEHOLDER": "Buscar por nombre de cliente o ID de presupuesto",
+      "WORKORDER_LABEL": "Buscar orden de trabajo",
+      "WORKORDER_PLACEHOLDER": "Buscar por nombre de cliente o ID de orden de trabajo",
       "LOADING": "Searching…",
-      "EMPTY": "No matches found",
-      "ERROR": "Search failed. Please try again."
+      "EMPTY": "No se encontraron coincidencias",
+      "ERROR": "La búsqueda falló. Inténtelo de nuevo."
     },
     "APPROVAL": {
       "COMMON": {
@@ -4151,8 +4151,8 @@
       "SKU_FILTER": {
         "LABEL": "SKU",
         "PLACEHOLDER": "ej. SKU-001",
-        "ARIA_LABEL": "Filter by SKU",
-        "CLEAR_ARIA_LABEL": "Clear SKU filter"
+        "ARIA_LABEL": "Filtrar por SKU",
+        "CLEAR_ARIA_LABEL": "Borrar filtro de SKU"
       },
       "PRODUCT_FILTER": {
         "LABEL": "Buscar por nombre o SKU",
@@ -4164,47 +4164,47 @@
       },
       "SITE_TREE": {
         "BREADCRUMB": {
-          "ARIA": "Page breadcrumb",
-          "OVERVIEW": "Inventory by Location"
+          "ARIA": "Ruta de navegación de la página",
+          "OVERVIEW": "Inventario por ubicación"
         },
         "TOTALS": {
-          "ARIA": "Site totals",
+          "ARIA": "Totales del sitio",
           "ON_HAND": "On Hand",
           "ALLOCATED": "Allocated",
           "AVAILABLE": "Available",
           "OVER_ALLOCATED": "Over-Allocated"
         },
         "CONTROLS": {
-          "ARIA": "Tree controls",
-          "INCLUDE_EMPTY": "Show empty locations"
+          "ARIA": "Controles del árbol",
+          "INCLUDE_EMPTY": "Mostrar ubicaciones vacías"
         },
         "STATE": {
-          "EMPTY": "No storage locations found for this site."
+          "EMPTY": "No se encontraron ubicaciones de almacenamiento para este sitio."
         },
         "ERROR": {
-          "NOT_FOUND": "Site not found. It may have been removed or the link is stale.",
-          "FORBIDDEN": "You do not have permission to view inventory for this site.",
-          "UPSTREAM_DOWN": "The location service is temporarily unavailable. Please retry.",
-          "UPSTREAM_DOWN_BANNER": "Location service unavailable — data shown may be stale.",
-          "UNKNOWN": "An unexpected error occurred loading site inventory."
+          "NOT_FOUND": "Sitio no encontrado. Es posible que se haya eliminado o que el enlace esté obsoleto.",
+          "FORBIDDEN": "No tiene permiso para ver el inventario de este sitio.",
+          "UPSTREAM_DOWN": "El servicio de ubicaciones no está disponible temporalmente. Inténtelo de nuevo.",
+          "UPSTREAM_DOWN_BANNER": "Servicio de ubicaciones no disponible: los datos mostrados pueden estar obsoletos.",
+          "UNKNOWN": "Ocurrió un error inesperado al cargar el inventario del sitio."
         },
         "BADGE": {
-          "OVER_ALLOCATED": "Over-allocated: available is negative",
-          "OVER_ALLOCATED_ARIA": "Over-allocated locations",
-          "INACTIVE_STOCK": "Inactive location has stock"
+          "OVER_ALLOCATED": "Sobreasignado: la disponibilidad es negativa",
+          "OVER_ALLOCATED_ARIA": "Ubicaciones sobreasignadas",
+          "INACTIVE_STOCK": "La ubicación inactiva tiene existencias"
         },
         "TREE": {
-          "ARIA": "Site storage location inventory tree",
-          "CAPTION": "Storage locations with inventory quantities",
+          "ARIA": "Árbol de inventario de ubicaciones de almacenamiento del sitio",
+          "CAPTION": "Ubicaciones de almacenamiento con cantidades de inventario",
           "EXPAND": "Expand",
           "COLLAPSE": "Collapse",
           "COL": {
             "NAME": "Location",
             "TYPE": "Type",
             "STATUS": "Status",
-            "OWN_ON_HAND": "Own On Hand",
-            "OWN_ALLOCATED": "Own Allocated",
-            "OWN_AVAILABLE": "Own Available",
+            "OWN_ON_HAND": "Existencias propias",
+            "OWN_ALLOCATED": "Asignado propio",
+            "OWN_AVAILABLE": "Disponible propio",
             "ROLLED_UP_ON_HAND": "Rolled-Up On Hand",
             "ROLLED_UP_ALLOCATED": "Rolled-Up Allocated",
             "ROLLED_UP_AVAILABLE": "Rolled-Up Available"

--- a/src/assets/i18n/fr-CA.json
+++ b/src/assets/i18n/fr-CA.json
@@ -1268,20 +1268,20 @@
       "REVERSAL": "Contrepassation"
     },
     "INGESTION_MONITOR_LIST": {
-      "OVERLINE": "Ingestion Monitor",
-      "TITLE": "Ingestion Events",
-      "SUBTITLE": "Monitor ingestion envelope processing status",
-      "FILTERS_LABEL": "Ingestion filters",
-      "FILTER_EVENT_TYPE": "Event type",
-      "ERROR": "Failed to load ingestion events.",
-      "EMPTY": "No ingestion events match the selected filters.",
-      "TABLE_ARIA": "Ingestion events table",
-      "TABLE_CAPTION": "Ingestion events",
-      "STATUS_ARIA": "Ingestion status",
-      "COL_EVENT_ID": "Event ID",
-      "COL_EVENT_TYPE": "Event type",
+      "OVERLINE": "Moniteur d’ingestion",
+      "TITLE": "Événements d’ingestion",
+      "SUBTITLE": "Surveiller l’état de traitement des enveloppes d’ingestion",
+      "FILTERS_LABEL": "Filtres d’ingestion",
+      "FILTER_EVENT_TYPE": "Type d’événement",
+      "ERROR": "Échec du chargement des événements d’ingestion.",
+      "EMPTY": "Aucun événement d’ingestion ne correspond aux filtres sélectionnés.",
+      "TABLE_ARIA": "Tableau des événements d’ingestion",
+      "TABLE_CAPTION": "Événements d’ingestion",
+      "STATUS_ARIA": "État d’ingestion",
+      "COL_EVENT_ID": "ID d’événement",
+      "COL_EVENT_TYPE": "Type d’événement",
       "COL_STATUS": "Status",
-      "COL_RECEIVED_AT": "Received at",
+      "COL_RECEIVED_AT": "Reçu le",
       "STATUS": {
         "RECEIVED": "Received",
         "PROCESSING": "Processing",
@@ -1293,24 +1293,24 @@
       }
     },
     "INGESTION_MONITOR_DETAIL": {
-      "OVERLINE": "Ingestion Monitor",
-      "TITLE": "Ingestion Event Detail",
-      "ERROR": "Failed to load event detail.",
-      "FIELD_EVENT_ID": "Event ID",
-      "FIELD_EVENT_TYPE": "Event type",
+      "OVERLINE": "Moniteur d’ingestion",
+      "TITLE": "Détail de l’événement d’ingestion",
+      "ERROR": "Échec du chargement du détail de l’événement.",
+      "FIELD_EVENT_ID": "ID d’événement",
+      "FIELD_EVENT_TYPE": "Type d’événement",
       "FIELD_STATUS": "Status",
-      "FIELD_RECEIVED_AT": "Received at",
+      "FIELD_RECEIVED_AT": "Reçu le",
       "PAYLOAD": "Payload",
-      "PAYLOAD_RESTRICTED": "Payload is restricted for your permissions.",
-      "RETRY_TITLE": "Retry Processing",
-      "RETRY_JUSTIFICATION": "Retry justification",
-      "HISTORY_TITLE": "Reprocessing History",
-      "HISTORY_EMPTY": "No reprocessing attempts recorded.",
-      "HISTORY_TABLE_ARIA": "Reprocessing history table",
-      "HISTORY_TABLE_CAPTION": "Reprocessing attempts",
-      "HISTORY_COL_ATTEMPT": "Attempt ID",
-      "HISTORY_COL_AT": "Attempted at",
-      "HISTORY_COL_BY": "Triggered by",
+      "PAYLOAD_RESTRICTED": "La charge utile est restreinte pour vos permissions.",
+      "RETRY_TITLE": "Relancer le traitement",
+      "RETRY_JUSTIFICATION": "Justification de la relance",
+      "HISTORY_TITLE": "Historique de retraitement",
+      "HISTORY_EMPTY": "Aucune tentative de retraitement enregistrée.",
+      "HISTORY_TABLE_ARIA": "Tableau de l’historique de retraitement",
+      "HISTORY_TABLE_CAPTION": "Tentatives de retraitement",
+      "HISTORY_COL_ATTEMPT": "ID de tentative",
+      "HISTORY_COL_AT": "Tenté le",
+      "HISTORY_COL_BY": "Déclenché par",
       "HISTORY_COL_OUTCOME": "Outcome",
       "STATUS": {
         "RECEIVED": "Received",
@@ -1328,46 +1328,46 @@
     },
     "EVENT_ENVELOPE_CONTRACT": {
       "OVERLINE": "Contract",
-      "TITLE": "Event Envelope Contract",
-      "TABS_ARIA": "Event contract tabs",
+      "TITLE": "Contrat d’enveloppe d’événement",
+      "TABS_ARIA": "Onglets du contrat d’événement",
       "TAB_FIELDS": "Fields",
-      "TAB_TRACEABILITY": "Traceability IDs",
+      "TAB_TRACEABILITY": "ID de traçabilité",
       "TAB_EXAMPLES": "Examples",
-      "EMPTY_FIELDS": "No contract fields are available.",
-      "EMPTY_TRACEABILITY": "No traceability IDs are available.",
-      "EMPTY_EXAMPLES": "No examples are available.",
-      "FIELDS_TABLE_ARIA": "Contract fields table",
-      "FIELDS_TABLE_CAPTION": "Envelope field definitions",
-      "TRACE_TABLE_ARIA": "Traceability IDs table",
-      "TRACE_TABLE_CAPTION": "Traceability identifier definitions",
+      "EMPTY_FIELDS": "Aucun champ de contrat disponible.",
+      "EMPTY_TRACEABILITY": "Aucun ID de traçabilité disponible.",
+      "EMPTY_EXAMPLES": "Aucun exemple disponible.",
+      "FIELDS_TABLE_ARIA": "Tableau des champs du contrat",
+      "FIELDS_TABLE_CAPTION": "Définitions des champs de l’enveloppe",
+      "TRACE_TABLE_ARIA": "Tableau des ID de traçabilité",
+      "TRACE_TABLE_CAPTION": "Définitions des identifiants de traçabilité",
       "COL_NAME": "Name",
       "COL_TYPE": "Type",
       "COL_REQUIRED": "Required"
     },
     "INGESTION_SUBMIT": {
-      "OVERLINE": "Operations Tool",
-      "TITLE": "Submit Ingestion Event",
-      "INTERNAL_TOOL_NOTICE": "This is an internal accounting operations tool.",
-      "FIELD_EVENT_ID": "Event ID",
-      "FIELD_EVENT_TYPE": "Event type",
-      "FIELD_ORGANIZATION_ID": "Organization ID",
-      "FIELD_SOURCE_SYSTEM": "Source system",
-      "FIELD_PAYLOAD": "Payload JSON",
-      "SUBMIT": "Submit event",
-      "ERROR": "Submission failed. Verify data and try again.",
-      "EMPTY": "Populate the form and submit an event.",
-      "RESULT_TITLE": "Submission Result",
-      "RESULT_EVENT_ID": "Submitted event ID"
+      "OVERLINE": "Outil d’exploitation",
+      "TITLE": "Soumettre un événement d’ingestion",
+      "INTERNAL_TOOL_NOTICE": "Ceci est un outil interne d’exploitation comptable.",
+      "FIELD_EVENT_ID": "ID d’événement",
+      "FIELD_EVENT_TYPE": "Type d’événement",
+      "FIELD_ORGANIZATION_ID": "ID d’organisation",
+      "FIELD_SOURCE_SYSTEM": "Système source",
+      "FIELD_PAYLOAD": "JSON de charge utile",
+      "SUBMIT": "Soumettre l’événement",
+      "ERROR": "Échec de la soumission. Vérifiez les données et réessayez.",
+      "EMPTY": "Remplissez le formulaire et soumettez un événement.",
+      "RESULT_TITLE": "Résultat de la soumission",
+      "RESULT_EVENT_ID": "ID de l’événement soumis"
     },
     "POSTING_RULES_LIST": {
-      "OVERLINE": "Posting Rules",
-      "TITLE": "Posting Rule Sets",
-      "NEW_RULE_SET": "New rule set",
-      "EMPTY": "No posting rule sets found.",
-      "TABLE_ARIA": "Posting rule sets table",
-      "TABLE_CAPTION": "Posting rule sets",
+      "OVERLINE": "Règles de comptabilisation",
+      "TITLE": "Ensembles de règles de comptabilisation",
+      "NEW_RULE_SET": "Nouvel ensemble de règles",
+      "EMPTY": "Aucun ensemble de règles de comptabilisation trouvé.",
+      "TABLE_ARIA": "Tableau des ensembles de règles de comptabilisation",
+      "TABLE_CAPTION": "Ensembles de règles de comptabilisation",
       "COL_NAME": "Name",
-      "COL_EVENT_TYPE": "Event type",
+      "COL_EVENT_TYPE": "Type d’événement",
       "COL_VERSION": "Version",
       "COL_STATUS": "Status",
       "STATUS": {
@@ -1393,33 +1393,33 @@
       "COL_PUBLISHED_BY": "Publié par"
     },
     "PAYMENT_APPLY": {
-      "OVERLINE": "Accounts Receivable",
-      "TITLE": "Apply Payment",
-      "FIELD_PAYMENT_ID": "Payment ID",
-      "FIELD_APPLICATIONS": "Applications JSON",
-      "SUBMIT": "Apply payment",
-      "ERROR": "Unable to apply payment.",
-      "EMPTY": "Provide allocation data to apply payment.",
-      "RESULT_TITLE": "Application Result",
-      "RESULT_PAYMENT_ID": "Payment ID",
-      "RESULT_TOTAL": "Payment total",
-      "RESULT_APPLIED": "Applied total"
+      "OVERLINE": "Comptes clients",
+      "TITLE": "Appliquer le paiement",
+      "FIELD_PAYMENT_ID": "ID de paiement",
+      "FIELD_APPLICATIONS": "JSON des applications",
+      "SUBMIT": "Appliquer le paiement",
+      "ERROR": "Impossible d’appliquer le paiement.",
+      "EMPTY": "Fournissez les données d’allocation pour appliquer le paiement.",
+      "RESULT_TITLE": "Résultat de l’application",
+      "RESULT_PAYMENT_ID": "ID de paiement",
+      "RESULT_TOTAL": "Total du paiement",
+      "RESULT_APPLIED": "Total appliqué"
     },
     "CREDIT_MEMO_CREATE": {
-      "OVERLINE": "Accounts Receivable",
-      "TITLE": "Create Credit Memo",
-      "FIELD_ORIGINAL_INVOICE_ID": "Original invoice ID",
-      "FIELD_CUSTOMER_ID": "Customer ID",
-      "FIELD_CREDIT_AMOUNT": "Credit amount",
-      "FIELD_OUTSTANDING_BALANCE": "Outstanding balance",
-      "FIELD_REASON_CODE": "Reason code",
+      "OVERLINE": "Comptes clients",
+      "TITLE": "Créer une note de crédit",
+      "FIELD_ORIGINAL_INVOICE_ID": "ID de la facture d’origine",
+      "FIELD_CUSTOMER_ID": "ID du client",
+      "FIELD_CREDIT_AMOUNT": "Montant du crédit",
+      "FIELD_OUTSTANDING_BALANCE": "Solde impayé",
+      "FIELD_REASON_CODE": "Code de motif",
       "FIELD_JUSTIFICATION_NOTE": "Justification",
-      "SUBMIT": "Create credit memo",
-      "ERROR": "Unable to create credit memo.",
-      "EMPTY": "Enter required fields to create a credit memo.",
-      "RESULT_TITLE": "Credit Memo Created",
-      "RESULT_CREDIT_MEMO_ID": "Credit memo ID",
-      "RESULT_TOTAL": "Total amount"
+      "SUBMIT": "Créer une note de crédit",
+      "ERROR": "Impossible de créer la note de crédit.",
+      "EMPTY": "Saisissez les champs requis pour créer une note de crédit.",
+      "RESULT_TITLE": "Note de crédit créée",
+      "RESULT_CREDIT_MEMO_ID": "ID de la note de crédit",
+      "RESULT_TOTAL": "Montant total"
     },
     "CREDIT_MEMO_LIST": {
       "OVERLINE": "Comptes clients",
@@ -1498,26 +1498,26 @@
       }
     },
     "VENDOR_PAYMENT_NEW": {
-      "OVERLINE": "Accounts Payable",
-      "TITLE": "New Vendor Payment",
-      "BILLS_TITLE": "Open Bills",
-      "LOAD_BILLS": "Load bills",
-      "EMPTY_BILLS": "No bills loaded for this vendor.",
-      "BILLS_TABLE_ARIA": "Vendor bills table",
-      "BILLS_TABLE_CAPTION": "Open vendor bills",
-      "COL_BILL_NUMBER": "Bill number",
-      "COL_DUE_DATE": "Due date",
-      "COL_OPEN_AMOUNT": "Open amount",
-      "FIELD_VENDOR_ID": "Vendor ID",
-      "FIELD_GROSS_AMOUNT": "Gross amount",
+      "OVERLINE": "Comptes fournisseurs",
+      "TITLE": "Nouveau paiement au fournisseur",
+      "BILLS_TITLE": "Factures ouvertes",
+      "LOAD_BILLS": "Charger les factures",
+      "EMPTY_BILLS": "Aucune facture chargée pour ce fournisseur.",
+      "BILLS_TABLE_ARIA": "Tableau des factures du fournisseur",
+      "BILLS_TABLE_CAPTION": "Factures fournisseur ouvertes",
+      "COL_BILL_NUMBER": "Numéro de facture",
+      "COL_DUE_DATE": "Date d’échéance",
+      "COL_OPEN_AMOUNT": "Montant ouvert",
+      "FIELD_VENDOR_ID": "ID du fournisseur",
+      "FIELD_GROSS_AMOUNT": "Montant brut",
       "FIELD_CURRENCY": "Currency",
-      "FIELD_PAYMENT_METHOD": "Payment method",
-      "FIELD_PAYMENT_REF": "Payment reference",
-      "FIELD_ALLOCATIONS": "Allocations JSON",
-      "SUBMIT": "Submit payment",
-      "ERROR": "Unable to submit vendor payment.",
-      "RESULT_TITLE": "Vendor Payment Result",
-      "RESULT_PAYMENT_ID": "Payment ID",
+      "FIELD_PAYMENT_METHOD": "Mode de paiement",
+      "FIELD_PAYMENT_REF": "Référence de paiement",
+      "FIELD_ALLOCATIONS": "JSON des allocations",
+      "SUBMIT": "Soumettre le paiement",
+      "ERROR": "Impossible de soumettre le paiement au fournisseur.",
+      "RESULT_TITLE": "Résultat du paiement au fournisseur",
+      "RESULT_PAYMENT_ID": "ID de paiement",
       "RESULT_STATUS": "Status"
     },
     "VENDOR_PAYMENT_LIST": {
@@ -1580,7 +1580,7 @@
         },
         "REPORTS": {
           "TITLE": "Reports",
-          "DESCRIPTION": "Read-only accounting reports."
+          "DESCRIPTION": "Rapports comptables en lecture seule."
         }
       },
       "CARD": {
@@ -1645,8 +1645,8 @@
           "DESCRIPTION": "Ouvrez la vue détaillée d'un avoir spécifique par ID."
         },
         "LABOR_OVERHEAD": {
-          "TITLE": "Labor & Overhead Cost Report",
-          "DESCRIPTION": "Monthly + YTD labor and overhead costs by location and fiscal year, from posted GL data."
+          "TITLE": "Rapport des coûts de main-d’œuvre et frais généraux",
+          "DESCRIPTION": "Coûts mensuels et cumulatifs annuels de main-d’œuvre et frais généraux par emplacement et exercice, à partir des données comptabilisées du grand livre."
         }
       },
       "FIELD": {
@@ -2603,14 +2603,14 @@
       }
     },
     "FINDERS": {
-      "TITLE": "Find a record",
-      "ESTIMATE_LABEL": "Find estimate",
-      "ESTIMATE_PLACEHOLDER": "Search by customer name or estimate id",
-      "WORKORDER_LABEL": "Find workorder",
-      "WORKORDER_PLACEHOLDER": "Search by customer name or workorder id",
+      "TITLE": "Trouver un enregistrement",
+      "ESTIMATE_LABEL": "Trouver une estimation",
+      "ESTIMATE_PLACEHOLDER": "Rechercher par nom de client ou ID d’estimation",
+      "WORKORDER_LABEL": "Trouver un bon de travail",
+      "WORKORDER_PLACEHOLDER": "Rechercher par nom de client ou ID de bon de travail",
       "LOADING": "Searching…",
-      "EMPTY": "No matches found",
-      "ERROR": "Search failed. Please try again."
+      "EMPTY": "Aucune correspondance trouvée",
+      "ERROR": "La recherche a échoué. Veuillez réessayer."
     },
     "APPROVAL": {
       "COMMON": {
@@ -4151,8 +4151,8 @@
       "SKU_FILTER": {
         "LABEL": "SKU",
         "PLACEHOLDER": "p. ex. SKU-001",
-        "ARIA_LABEL": "Filter by SKU",
-        "CLEAR_ARIA_LABEL": "Clear SKU filter"
+        "ARIA_LABEL": "Filtrer par UGS",
+        "CLEAR_ARIA_LABEL": "Effacer le filtre UGS"
       },
       "PRODUCT_FILTER": {
         "LABEL": "Rechercher par nom ou SKU",
@@ -4164,47 +4164,47 @@
       },
       "SITE_TREE": {
         "BREADCRUMB": {
-          "ARIA": "Page breadcrumb",
-          "OVERVIEW": "Inventory by Location"
+          "ARIA": "Fil d’Ariane de la page",
+          "OVERVIEW": "Inventaire par emplacement"
         },
         "TOTALS": {
-          "ARIA": "Site totals",
+          "ARIA": "Totaux du site",
           "ON_HAND": "On Hand",
           "ALLOCATED": "Allocated",
           "AVAILABLE": "Available",
           "OVER_ALLOCATED": "Over-Allocated"
         },
         "CONTROLS": {
-          "ARIA": "Tree controls",
-          "INCLUDE_EMPTY": "Show empty locations"
+          "ARIA": "Contrôles de l’arborescence",
+          "INCLUDE_EMPTY": "Afficher les emplacements vides"
         },
         "STATE": {
-          "EMPTY": "No storage locations found for this site."
+          "EMPTY": "Aucun emplacement de stockage trouvé pour ce site."
         },
         "ERROR": {
-          "NOT_FOUND": "Site not found. It may have been removed or the link is stale.",
-          "FORBIDDEN": "You do not have permission to view inventory for this site.",
-          "UPSTREAM_DOWN": "The location service is temporarily unavailable. Please retry.",
-          "UPSTREAM_DOWN_BANNER": "Location service unavailable — data shown may be stale.",
-          "UNKNOWN": "An unexpected error occurred loading site inventory."
+          "NOT_FOUND": "Site introuvable. Il a peut-être été supprimé ou le lien est obsolète.",
+          "FORBIDDEN": "Vous n’avez pas la permission de voir l’inventaire de ce site.",
+          "UPSTREAM_DOWN": "Le service d’emplacement est temporairement indisponible. Veuillez réessayer.",
+          "UPSTREAM_DOWN_BANNER": "Service d’emplacement indisponible — les données affichées peuvent être obsolètes.",
+          "UNKNOWN": "Une erreur inattendue s’est produite lors du chargement de l’inventaire du site."
         },
         "BADGE": {
-          "OVER_ALLOCATED": "Over-allocated: available is negative",
-          "OVER_ALLOCATED_ARIA": "Over-allocated locations",
-          "INACTIVE_STOCK": "Inactive location has stock"
+          "OVER_ALLOCATED": "Surallouée : la disponibilité est négative",
+          "OVER_ALLOCATED_ARIA": "Emplacements suralloués",
+          "INACTIVE_STOCK": "L’emplacement inactif contient du stock"
         },
         "TREE": {
-          "ARIA": "Site storage location inventory tree",
-          "CAPTION": "Storage locations with inventory quantities",
+          "ARIA": "Arborescence de l’inventaire des emplacements de stockage du site",
+          "CAPTION": "Emplacements de stockage avec quantités d’inventaire",
           "EXPAND": "Expand",
           "COLLAPSE": "Collapse",
           "COL": {
             "NAME": "Location",
             "TYPE": "Type",
             "STATUS": "Status",
-            "OWN_ON_HAND": "Own On Hand",
-            "OWN_ALLOCATED": "Own Allocated",
-            "OWN_AVAILABLE": "Own Available",
+            "OWN_ON_HAND": "En main (propre)",
+            "OWN_ALLOCATED": "Alloué (propre)",
+            "OWN_AVAILABLE": "Disponible (propre)",
             "ROLLED_UP_ON_HAND": "Rolled-Up On Hand",
             "ROLLED_UP_ALLOCATED": "Rolled-Up Allocated",
             "ROLLED_UP_AVAILABLE": "Rolled-Up Available"


### PR DESCRIPTION
### Why hints rendered English
Locale switching works correctly (`LocaleService` → `translate.use(es-US/fr-CA)`). The problem was the **data**: a set of es-US / fr-CA keys stored the English source string verbatim — they were authored as English placeholders and never translated. The `| translate` pipe faithfully returns whatever the active-locale JSON holds, so those strings showed English in every locale. No English-fallback was involved.

`i18n:check` couldn't catch this — it flags *missing keys* and *hardcoded template strings*, not a key whose translation is an untranslated English copy.

### Scope
135 es-US + 134 fr-CA multi-word English-copy values, concentrated in:
- `WORKEXEC.FINDERS` — the workexec search hints/placeholders/empty/error states
- `INVENTORY.BY_LOCATION`
- `ACCOUNTING.*` — ingestion monitor, posting rules, payment apply, credit memo, vendor payment, reports

True cross-locale cognates (`Total`, `Subtotal`, fr `Session active`) left unchanged. Keyset stays aligned (3227 keys); `en-US` untouched so `qps-ploc` is unaffected.

### Verification
- `npm run i18n:check` — PASS (keysets aligned, hardcoded clean, pseudo up to date)
- Post-fix audit: 0 remaining es identical-prose, 1 fr (the legit `Session active` cognate)

> ⚠️ Translations are machine-assisted — **FLAGGED FOR NATIVE REVIEW**.