### PR TITLE
fix(billing): point invoice artifact calls at the real pos-invoice route

### DIFF
--- a/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.ts
+++ b/src/app/features/billing/pages/invoice-detail/invoice-detail-page.component.ts
@@ -189,12 +189,13 @@ export class InvoiceDetailPageComponent implements OnInit {
   }
 
   downloadArtifact(artifactRefId: string, filename: string): void {
+    const invoiceId = this.invoiceId();
     this.billingService
-      .createArtifactDownloadToken(artifactRefId)
+      .createArtifactDownloadToken(invoiceId, artifactRefId)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
-          const url = res.downloadUrl ?? `${environment.apiBaseUrl}/billing/artifacts/${artifactRefId}/download?token=${res.downloadToken}`;
+          const url = res.downloadUrl ?? `${environment.apiBaseUrl}/invoice/v1/invoices/${invoiceId}/artifacts/${artifactRefId}/download?token=${res.downloadToken}`;
           const a = document.createElement('a');
           a.href = url;
           a.download = filename;

--- a/src/app/features/billing/services/billing-transport.service.spec.ts
+++ b/src/app/features/billing/services/billing-transport.service.spec.ts
@@ -138,7 +138,7 @@ describe('BillingTransportService', () => {
 
     service.loadInvoiceArtifacts('inv-001').subscribe();
 
-    expect(apiStub.get).toHaveBeenCalledWith('/billing/invoices/inv-001/artifacts');
+    expect(apiStub.get).toHaveBeenCalledWith('/invoice/v1/invoices/inv-001/artifacts');
   });
 
   it('elevates through the billing transport endpoint and emits the elevation token response', () => {
@@ -282,12 +282,12 @@ describe('BillingTransportService', () => {
     apiStub.post.mockReturnValueOnce(of(tokenResponse));
 
     let result: unknown;
-    service.createArtifactDownloadToken('artifact-001').subscribe(value => {
+    service.createArtifactDownloadToken('inv-001', 'artifact-001').subscribe(value => {
       result = value;
     });
 
     expect(apiStub.post).toHaveBeenCalledWith(
-      '/billing/artifacts/artifact-001/download-token',
+      '/invoice/v1/invoices/inv-001/artifacts/artifact-001/download-token',
       {},
     );
     expect(receiptServiceStub.generateReceipt).not.toHaveBeenCalled();

--- a/src/app/features/billing/services/billing-transport.service.ts
+++ b/src/app/features/billing/services/billing-transport.service.ts
@@ -54,7 +54,8 @@ export class BillingTransportService {
 
   loadInvoiceArtifacts(invoiceId: string): Observable<InvoiceArtifact[]> {
     // ADR-0041 temporary exception: SDK invoice transport does not yet expose artifact listing.
-    return this.api.get<InvoiceArtifact[]>(`/billing/invoices/${invoiceId}/artifacts`);
+    // Direct call to the pos-invoice route (gateway /invoice/** -> /v1/invoices/...).
+    return this.api.get<InvoiceArtifact[]>(`/invoice/v1/invoices/${invoiceId}/artifacts`);
   }
 
   elevate(password: string): Observable<{ elevationToken: string }> {
@@ -71,9 +72,13 @@ export class BillingTransportService {
     );
   }
 
-  createArtifactDownloadToken(artifactRefId: string): Observable<ArtifactDownloadToken> {
+  createArtifactDownloadToken(invoiceId: string, artifactRefId: string): Observable<ArtifactDownloadToken> {
     // ADR-0041 temporary exception: SDK does not yet expose artifact download-token creation.
-    return this.api.post<ArtifactDownloadToken>(`/billing/artifacts/${artifactRefId}/download-token`, {});
+    // Direct call to the pos-invoice route (gateway /invoice/** -> /v1/invoices/...).
+    return this.api.post<ArtifactDownloadToken>(
+      `/invoice/v1/invoices/${invoiceId}/artifacts/${artifactRefId}/download-token`,
+      {},
+    );
   }
 
   initiateAndCapturePayment(


### PR DESCRIPTION
## Summary

Third PR of the invoice-artifacts work (frontend). The invoice-detail page's artifact calls used placeholder `/billing/...` paths that have **no gateway route** (the gateway routes `/invoice/**`), so every `/artifacts` request returned **404**.

Point the direct (ADR-0041 exception) calls at the pos-invoice endpoints added in the backend PR:

| Call | Before | After |
|---|---|---|
| list | `/billing/invoices/{id}/artifacts` | `/invoice/v1/invoices/{id}/artifacts` |
| token | `/billing/artifacts/{ref}/download-token` | `/invoice/v1/invoices/{id}/artifacts/{ref}/download-token` |
| download | `/billing/artifacts/{ref}/download?token=` | `/invoice/v1/invoices/{id}/artifacts/{ref}/download?token=` |

## Notes

- `createArtifactDownloadToken` now takes `(invoiceId, artifactRefId)` and `downloadArtifact` threads `invoiceId`, because the backend nests download-token/download under the invoice and binds the signed token to invoice + artifact.
- These remain **ADR-0041 temporary exceptions** (direct `ApiBaseService` calls) until the `@durion-sdk/invoice` tarball is regenerated (CI) with the new artifact operations — at which point they can move to the SDK.
- Backend dependencies: invoice artifacts API PR (pos-invoice) + pos-documents deployment PR.

## Testing

- `billing-transport.service.spec.ts` — 12/12
- `invoice-detail-page.component.spec.ts` — 5/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)