### PR TITLE
fix(a11y): valid phrasing children inside workexec <output> banners

### DIFF
--- a/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.html
+++ b/src/app/features/workexec/pages/approval-digital/approval-digital-page.component.html
@@ -94,10 +94,10 @@
 
       @if (submitState() === 'success') {
         <output class="success-panel">
-          <p class="success-heading">{{ 'WORKEXEC.APPROVAL.DIGITAL.SUCCESS_TITLE' | translate }}</p>
-          <p class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></p>
+          <span class="success-heading">{{ 'WORKEXEC.APPROVAL.DIGITAL.SUCCESS_TITLE' | translate }}</span>
+          <span class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></span>
           @if (estimate()!.approvedAt) {
-            <p class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.APPROVED_BY_AT' | translate: { by: estimate()!.signerName, at: (estimate()!.approvedAt | date:'medium') } }}</p>
+            <span class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.APPROVED_BY_AT' | translate: { by: estimate()!.signerName, at: (estimate()!.approvedAt | date:'medium') } }}</span>
           }
         </output>
       }

--- a/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.html
+++ b/src/app/features/workexec/pages/approval-in-person/approval-in-person-page.component.html
@@ -44,9 +44,9 @@
       </form>
       @if (submitState() === 'success') {
         <output class="success-panel">
-          <p class="success-heading">{{ 'WORKEXEC.APPROVAL.IN_PERSON.SUCCESS_TITLE' | translate }}</p>
-          <p class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></p>
-          @if (estimate()!.approvedAt) { <p class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.APPROVED_AT' | translate: { at: (estimate()!.approvedAt | date:'medium') } }}</p> }
+          <span class="success-heading">{{ 'WORKEXEC.APPROVAL.IN_PERSON.SUCCESS_TITLE' | translate }}</span>
+          <span class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></span>
+          @if (estimate()!.approvedAt) { <span class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.APPROVED_AT' | translate: { at: (estimate()!.approvedAt | date:'medium') } }}</span> }
         </output>
       }
     </div>

--- a/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.html
+++ b/src/app/features/workexec/pages/approval-partial/approval-partial-page.component.html
@@ -82,9 +82,9 @@
 
       @if (submitState() === 'success') {
         <output class="success-panel">
-          <p class="success-heading">{{ 'WORKEXEC.APPROVAL.PARTIAL.SUCCESS_TITLE' | translate }}</p>
-          <p class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></p>
-          @if (estimate()!.total != null) { <p>{{ 'WORKEXEC.APPROVAL.PARTIAL.APPROVED_TOTAL' | translate: { total: (estimate()!.total | currency) } }}</p> }
+          <span class="success-heading">{{ 'WORKEXEC.APPROVAL.PARTIAL.SUCCESS_TITLE' | translate }}</span>
+          <span class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip">{{ estimate()!.status }}</span></span>
+          @if (estimate()!.total != null) { <span>{{ 'WORKEXEC.APPROVAL.PARTIAL.APPROVED_TOTAL' | translate: { total: (estimate()!.total | currency) } }}</span> }
         </output>
       }
     </div>

--- a/src/app/features/workexec/pages/approval-submit/approval-submit-page.component.html
+++ b/src/app/features/workexec/pages/approval-submit/approval-submit-page.component.html
@@ -73,15 +73,15 @@
 
       @if (submitState() === 'success') {
         <output class="success-panel">
-          <p class="success-heading">{{ 'WORKEXEC.APPROVAL.SUBMIT.SUCCESS_TITLE' | translate }}</p>
-          <p class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip status-chip--pending">{{ estimate()!.status }}</span></p>
+          <span class="success-heading">{{ 'WORKEXEC.APPROVAL.SUBMIT.SUCCESS_TITLE' | translate }}</span>
+          <span class="estimate-meta">{{ 'WORKEXEC.APPROVAL.COMMON.STATUS_INLINE' | translate }} <span class="status-chip status-chip--pending">{{ estimate()!.status }}</span></span>
           @if (estimate()!.submittedAt) {
-            <p class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.SUBMITTED_BY_AT' | translate: { by: estimate()!.submittedBy, at: (estimate()!.submittedAt | date:'medium') } }}</p>
+            <span class="audit-meta">{{ 'WORKEXEC.APPROVAL.COMMON.SUBMITTED_BY_AT' | translate: { by: estimate()!.submittedBy, at: (estimate()!.submittedAt | date:'medium') } }}</span>
           }
-          <div class="form-actions">
+          <span class="form-actions">
             <a class="btn btn--ghost" [routerLink]="['/app/workexec/estimates', estimateId, 'approval', 'digital']">{{ 'WORKEXEC.APPROVAL.SUBMIT.CAPTURE_DIGITAL' | translate }}</a>
             <a class="btn btn--ghost" [routerLink]="['/app/workexec/estimates', estimateId, 'approval', 'in-person']">{{ 'WORKEXEC.APPROVAL.SUBMIT.IN_PERSON' | translate }}</a>
-          </div>
+          </span>
         </output>
       }
 

--- a/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.html
+++ b/src/app/features/workexec/pages/workorder-labor/workorder-labor-page.component.html
@@ -18,7 +18,7 @@
       @if (sessionState() === 'active' && activeSession()) {
         <output class="session-active" aria-live="polite">
           <span class="session-badge">{{ 'WORKEXEC.WORKORDER_LABOR.SESSION_ACTIVE' | translate }}</span>
-          <p class="hint-text">{{ 'WORKEXEC.WORKORDER_LABOR.STARTED' | translate: { at: (activeSession()!.startTime | date:'medium') } }}</p>
+          <span class="hint-text">{{ 'WORKEXEC.WORKORDER_LABOR.STARTED' | translate: { at: (activeSession()!.startTime | date:'medium') } }}</span>
           <button
             class="btn btn--warn"
             (click)="stopSession()"


### PR DESCRIPTION
Follow-up to #130 (issue #120).

`<output>` has a **phrasing-content** model, but the success/status banners introduced in #130 wrapped block `<p>`/`<div>` children — invalid HTML. This swaps those children to `<span>`; the panels are `display:flex; flex-direction:column`, which blockifies the spans, so rendering is byte-identical. Single-text `<output>` banners (detail/finalize/change-requests/estimate-create) are untouched.

Files: approval-submit, approval-digital, approval-in-person, approval-partial success panels + workorder-labor session-active.

## ⚠️ CI / build blocker — pre-existing, unrelated to this PR
The build currently fails on `master` (and therefore here) due to SDK type drift, not this change:
- `@durion-sdk/people` `EmployeeProfileDto` dropped `legalName` (now `firstName`/`lastName`/`preferredName`).
- `src/app/features/workexec/services/workexec.service.ts:986` → `emp.preferredName || emp.legalName` (TS2339)
- `src/app/features/people/services/people.service.spec.ts:124` → `legalName` (TS2353)

Needs a separate fix before this (or anything) can build green.

## Verification
- Change is HTML-only (tag swap, class-based CSS) — no TS/behavior impact; textContent unchanged.
- Full test run blocked by the SDK drift above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)