### PR TITLE
fix(people): migrate employee name to firstName/lastName (SDK drift)

### DIFF
--- a/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
+++ b/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
@@ -28,7 +28,7 @@
     <h2>Employee context</h2>
     <dl>
       <dt>Name</dt>
-      <dd>{{ employee()?.legalName }}</dd>
+      <dd>{{ employee()?.firstName }} {{ employee()?.lastName }}</dd>
       <dt>Status</dt>
       <dd>
         <span class="status-badge" [class.status-badge--active]="employee()?.status === 'ACTIVE'"

--- a/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.spec.ts
+++ b/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.spec.ts
@@ -11,7 +11,8 @@ import { PeopleService } from '../../services/people.service';
 
 const mockEmployee = {
   id: 'emp-001',
-  legalName: 'Jane Doe',
+  firstName: 'Jane',
+  lastName: 'Doe',
   status: 'ACTIVE',
   hireDate: '2020-01-01',
 };

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.html
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.html
@@ -39,18 +39,35 @@
       <legend>Personal details</legend>
 
       <div class="field-row"
-        [class.field-error--visible]="form.get('legalName')?.invalid && form.get('legalName')?.touched">
-        <label for="employee-legalName">Legal Name</label>
-        <input id="employee-legalName" type="text" formControlName="legalName" data-testid="legal-name-input"
-          autocomplete="name" />
-        @if (fieldErrors()['legalName']) {
-        <span class="field-error" role="alert" data-testid="field-error-legal-name">
-          {{ fieldErrors()['legalName'] }}
+        [class.field-error--visible]="form.get('firstName')?.invalid && form.get('firstName')?.touched">
+        <label for="employee-firstName">First Name</label>
+        <input id="employee-firstName" type="text" formControlName="firstName" data-testid="first-name-input"
+          autocomplete="given-name" />
+        @if (fieldErrors()['firstName']) {
+        <span class="field-error" role="alert" data-testid="field-error-first-name">
+          {{ fieldErrors()['firstName'] }}
         </span>
         }
-        @if (form.get('legalName')?.touched && form.get('legalName')?.invalid) {
-        <span class="field-error" role="alert" data-testid="validation-legal-name">
-          Legal name is required.
+        @if (form.get('firstName')?.touched && form.get('firstName')?.invalid) {
+        <span class="field-error" role="alert" data-testid="validation-first-name">
+          First name is required.
+        </span>
+        }
+      </div>
+
+      <div class="field-row"
+        [class.field-error--visible]="form.get('lastName')?.invalid && form.get('lastName')?.touched">
+        <label for="employee-lastName">Last Name</label>
+        <input id="employee-lastName" type="text" formControlName="lastName" data-testid="last-name-input"
+          autocomplete="family-name" />
+        @if (fieldErrors()['lastName']) {
+        <span class="field-error" role="alert" data-testid="field-error-last-name">
+          {{ fieldErrors()['lastName'] }}
+        </span>
+        }
+        @if (form.get('lastName')?.touched && form.get('lastName')?.invalid) {
+        <span class="field-error" role="alert" data-testid="validation-last-name">
+          Last name is required.
         </span>
         }
       </div>

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.spec.ts
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.spec.ts
@@ -11,7 +11,8 @@ import { PeopleService } from '../../services/people.service';
 
 const STUB_EMPLOYEE = {
   id: 'emp-1',
-  legalName: 'Jane Smith',
+  firstName: 'Jane',
+  lastName: 'Smith',
   employeeNumber: 'EMP-001',
   status: 'ACTIVE' as const,
   hireDate: '2024-03-01',
@@ -88,10 +89,10 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     const form = fixture.debugElement.query(By.css('form'));
     expect(form).toBeTruthy();
 
-    // No pre-filled legal-name value
-    const legalNameInput = fixture.debugElement.query(By.css('[data-testid="legal-name-input"]'));
-    expect(legalNameInput).toBeTruthy();
-    expect(legalNameInput.nativeElement.value).toBe('');
+    // No pre-filled first-name value
+    const firstNameInput = fixture.debugElement.query(By.css('[data-testid="first-name-input"]'));
+    expect(firstNameInput).toBeTruthy();
+    expect(firstNameInput.nativeElement.value).toBe('');
   });
 
   // ── T2: Edit route loads employee data ───────────────────────────────────
@@ -104,14 +105,16 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
   it('populates form fields with the loaded employee data', async () => {
     const { fixture } = await setupEdit('emp-1');
 
-    const legalNameInput = fixture.debugElement.query(By.css('[data-testid="legal-name-input"]'));
-    expect(legalNameInput.nativeElement.value).toBe(STUB_EMPLOYEE.legalName);
+    const firstNameInput = fixture.debugElement.query(By.css('[data-testid="first-name-input"]'));
+    expect(firstNameInput.nativeElement.value).toBe(STUB_EMPLOYEE.firstName);
+    const lastNameInput = fixture.debugElement.query(By.css('[data-testid="last-name-input"]'));
+    expect(lastNameInput.nativeElement.value).toBe(STUB_EMPLOYEE.lastName);
   });
 
   it('surfaces backend resolution warnings as a banner', async () => {
     vi.clearAllMocks();
     stubPeopleService.getEmployee.mockReturnValue(
-      of({ ...STUB_EMPLOYEE, warnings: ['Ambiguous duplicate match detected by legalName similarity'] }),
+      of({ ...STUB_EMPLOYEE, warnings: ['Ambiguous duplicate match detected by name similarity'] }),
     );
 
     await TestBed.configureTestingModule({
@@ -172,7 +175,7 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     const { fixture, component } = await setupNew();
 
     // Fill required fields so the form is valid
-    component.form.patchValue({ legalName: 'Jane', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
+    component.form.patchValue({ firstName: 'Jane', lastName: 'Doe', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
     fixture.detectChanges();
 
     // Trigger save
@@ -205,7 +208,7 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     const { fixture, component } = await setupNew();
 
     // Fill required fields so the form is valid
-    component.form.patchValue({ legalName: 'Jane', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
+    component.form.patchValue({ firstName: 'Jane', lastName: 'Doe', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
     fixture.detectChanges();
 
     (component as any).save?.();
@@ -222,22 +225,22 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
       throwError(() =>
         Object.assign(new Error('Bad Request'), {
           status: 400,
-          error: { errors: [{ field: 'legalName', message: 'Legal name is required' }] },
+          error: { errors: [{ field: 'firstName', message: 'First name is required' }] },
         })
       )
     );
     const { fixture, component } = await setupNew();
 
     // Fill required fields so the form is valid
-    component.form.patchValue({ legalName: 'Jane', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
+    component.form.patchValue({ firstName: 'Jane', lastName: 'Doe', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
     fixture.detectChanges();
 
     (component as any).save?.();
     fixture.detectChanges();
 
-    const fieldError = fixture.debugElement.query(By.css('[data-testid="field-error-legal-name"]'));
+    const fieldError = fixture.debugElement.query(By.css('[data-testid="field-error-first-name"]'));
     expect(fieldError).toBeTruthy();
-    expect(fieldError.nativeElement.textContent).toContain('Legal name is required');
+    expect(fieldError.nativeElement.textContent).toContain('First name is required');
   });
 
   // ── T8: Audit metadata display ───────────────────────────────────────────
@@ -288,8 +291,8 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     (component as any).save?.();
     fixture.detectChanges();
 
-    const legalNameError = fixture.debugElement.query(By.css('[data-testid="validation-legal-name"]'));
-    expect(legalNameError).toBeTruthy();
+    const firstNameError = fixture.debugElement.query(By.css('[data-testid="validation-first-name"]'));
+    expect(firstNameError).toBeTruthy();
 
     const statusError = fixture.debugElement.query(By.css('[data-testid="validation-employment-status"]'));
     expect(statusError).toBeTruthy();
@@ -322,7 +325,7 @@ describe('EmployeeProfilePageComponent [Story #152]', () => {
     fixture.detectChanges();
 
     // Fill required fields so form is valid before saving
-    component.form.patchValue({ legalName: 'Jane', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
+    component.form.patchValue({ firstName: 'Jane', lastName: 'Doe', employeeNumber: 'EMP-002', hireDate: '2024-01-01', status: 'ACTIVE' as any });
     fixture.detectChanges();
 
     // Trigger save to put component into saving state

--- a/src/app/features/people/pages/employee-profile/employee-profile-page.component.ts
+++ b/src/app/features/people/pages/employee-profile/employee-profile-page.component.ts
@@ -35,7 +35,8 @@ export class EmployeeProfilePageComponent implements OnInit {
   readonly saveSuccess = signal(false);
 
   readonly form = new FormGroup({
-    legalName: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    firstName: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    lastName: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     employeeNumber: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     status: new FormControl<CreateEmployeeRequestStatusEnum | ''>('', {
       nonNullable: true,
@@ -70,7 +71,8 @@ export class EmployeeProfilePageComponent implements OnInit {
         next: (emp) => {
           this.employee.set(emp);
           this.form.patchValue({
-            legalName: emp.legalName ?? '',
+            firstName: emp.firstName ?? '',
+            lastName: emp.lastName ?? '',
             employeeNumber: emp.employeeNumber ?? '',
             status: this.toCreateStatus(emp.status),
             hireDate: emp.hireDate ?? '',
@@ -97,7 +99,7 @@ export class EmployeeProfilePageComponent implements OnInit {
     this.fieldErrors.set({});
     this.saving.set(true);
 
-    const { legalName, employeeNumber, status, hireDate, email, phone } = this.form.getRawValue();
+    const { firstName, lastName, employeeNumber, status, hireDate, email, phone } = this.form.getRawValue();
     const contactInfo = (email || phone) ? {
       primaryEmail: email || undefined,
       primaryPhone: phone || undefined,
@@ -112,7 +114,8 @@ export class EmployeeProfilePageComponent implements OnInit {
       }
 
       this.peopleService.updateEmployee(employeeId, {
-        legalName,
+        firstName,
+        lastName,
         employeeNumber,
         status: (status || 'ACTIVE') as UpdateEmployeeRequestStatusEnum,
         hireDate,
@@ -133,7 +136,8 @@ export class EmployeeProfilePageComponent implements OnInit {
     }
 
     this.peopleService.createEmployee({
-      legalName,
+      firstName,
+      lastName,
       employeeNumber,
       status: status as CreateEmployeeRequestStatusEnum,
       hireDate,

--- a/src/app/features/people/services/people.service.spec.ts
+++ b/src/app/features/people/services/people.service.spec.ts
@@ -79,7 +79,8 @@ describe('PeopleService', () => {
   it('getEmployee() delegates to EmployeeAPIService.getEmployee', () => {
     const response: EmployeeProfileDto = {
       id: 'emp-1',
-      legalName: 'Jane Doe',
+      firstName: 'Jane',
+      lastName: 'Doe',
       employeeNumber: 'EMP-1',
       status: EmployeeProfileDtoStatusEnum.Active,
       hireDate: '2026-05-01',
@@ -93,14 +94,16 @@ describe('PeopleService', () => {
 
   it('createEmployee() delegates to EmployeeAPIService.createEmployee', () => {
     const request: CreateEmployeeRequest = {
-      legalName: 'Jane Doe',
+      firstName: 'Jane',
+      lastName: 'Doe',
       employeeNumber: 'EMP-1',
       status: CreateEmployeeRequestStatusEnum.Active,
       hireDate: '2026-05-01',
     };
     const response: EmployeeProfileDto = {
       id: 'emp-1',
-      legalName: 'Jane Doe',
+      firstName: 'Jane',
+      lastName: 'Doe',
       employeeNumber: 'EMP-1',
       status: EmployeeProfileDtoStatusEnum.Active,
       hireDate: '2026-05-01',
@@ -114,14 +117,16 @@ describe('PeopleService', () => {
 
   it('updateEmployee() delegates to EmployeeAPIService.updateEmployee', () => {
     const request: UpdateEmployeeRequest = {
-      legalName: 'Updated Name',
+      firstName: 'Updated',
+      lastName: 'Name',
       employeeNumber: 'EMP-1',
       status: UpdateEmployeeRequestStatusEnum.Active,
       hireDate: '2026-05-01',
     };
     const response: EmployeeProfileDto = {
       id: 'emp-1',
-      legalName: 'Updated Name',
+      firstName: 'Updated',
+      lastName: 'Name',
       employeeNumber: 'EMP-1',
       status: EmployeeProfileDtoStatusEnum.Active,
       hireDate: '2026-05-01',
@@ -135,7 +140,7 @@ describe('PeopleService', () => {
 
   it('disableEmployee() delegates to EmployeeAPIService.disableEmployee', () => {
     const request = { assignmentEndDate: '2026-05-31' };
-    employeeApiStub.disableEmployee.mockReturnValue(of({ id: 'emp-1', legalName: 'Jane Doe' }));
+    employeeApiStub.disableEmployee.mockReturnValue(of({ id: 'emp-1', firstName: 'Jane', lastName: 'Doe' }));
 
     service.disableEmployee('emp-1', request).subscribe();
 

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
@@ -240,7 +240,8 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
       drainWithTechnician(() =>
         http.expectOne(`${BASE}/v1/people/employees/${TECH_ID}`).flush({
           id: TECH_ID,
-          legalName: 'Jane Smith',
+          firstName: 'Jane',
+          lastName: 'Smith',
           employeeNumber: 'EMP-007',
           status: 'ACTIVE',
           hireDate: '2024-01-01',

--- a/src/app/features/workexec/services/workexec.service.spec.ts
+++ b/src/app/features/workexec/services/workexec.service.spec.ts
@@ -696,16 +696,16 @@ describe('WorkexecService', () => {
       service.getTechnicianProfile('tech-1').subscribe(p => (result = p));
       const r = http.expectOne(`${BASE}/v1/people/employees/tech-1`);
       expect(r.request.method).toBe('GET');
-      r.flush({ id: 'tech-1', legalName: 'Jane Smith', employeeNumber: 'EMP-007', status: 'ACTIVE', hireDate: '2024-01-01' });
+      r.flush({ id: 'tech-1', firstName: 'Jane', lastName: 'Smith', employeeNumber: 'EMP-007', status: 'ACTIVE', hireDate: '2024-01-01' });
       expect(result).toEqual({ name: 'Jane Smith', employeeNumber: 'EMP-007' });
     });
 
-    it('prefers the preferred name over the legal name', () => {
+    it('prefers the preferred name over the full name', () => {
       let result: { name: string | null; employeeNumber: string | null } | undefined;
       service.getTechnicianProfile('tech-1').subscribe(p => (result = p));
       http
         .expectOne(`${BASE}/v1/people/employees/tech-1`)
-        .flush({ id: 'tech-1', legalName: 'Jane Smith', preferredName: 'Janie', employeeNumber: 'EMP-007', status: 'ACTIVE', hireDate: '2024-01-01' });
+        .flush({ id: 'tech-1', firstName: 'Jane', lastName: 'Smith', preferredName: 'Janie', employeeNumber: 'EMP-007', status: 'ACTIVE', hireDate: '2024-01-01' });
       expect(result?.name).toBe('Janie');
     });
 

--- a/src/app/features/workexec/services/workexec.service.ts
+++ b/src/app/features/workexec/services/workexec.service.ts
@@ -983,7 +983,7 @@ export class WorkexecService {
   ): Observable<{ name: string | null; employeeNumber: string | null }> {
     return this.employeeApi.getEmployee(technicianId).pipe(
       map(emp => ({
-        name: emp.preferredName || emp.legalName || null,
+        name: emp.preferredName || [emp.firstName, emp.lastName].filter(Boolean).join(' ') || null,
         employeeNumber: emp.employeeNumber || null,
       })),
       catchError(() => of({ name: null, employeeNumber: null })),


### PR DESCRIPTION
Unblocks the build on `master` (and PR #132).

## Problem
The installed `@durion-sdk/people` contract replaced the single `legalName` field with required `firstName` + `lastName` across `EmployeeProfileDto`, `CreateEmployeeRequest`, and `UpdateEmployeeRequest`. The app still referenced `legalName`, so the build failed against the current SDK:
- `workexec.service.ts:986` — `emp.legalName` (TS2339)
- `people.service.spec.ts` — `legalName` in typed DTO fixtures (TS2353)
- plus the entire employee-profile form, which was built on `legalName`.

## Change
- **employee-profile**: split the single "Legal Name" field into **First Name** + **Last Name** controls/inputs (both required). Load, create, and update payloads now use `firstName`/`lastName`. Validation + field-error `data-testid`s updated (`first-name`/`last-name`).
- **employee-offboard**: name displays `{firstName} {lastName}`.
- **workexec `getTechnicianProfile`**: `preferredName || `${firstName} ${lastName}``.
- Updated people + workexec specs/fixtures to the new contract.
- Party (CRM) `legalName` is a separate, unaffected field — left as-is.

## Verification
- `npx ng test --include people --include workexec --no-watch` → **356/356 pass**
- Build compiles against the current SDK.

## Merge order
Merge this first; then PR #132 (output content-model) will go green on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)