### PR TITLE
refactor(chat): shared ChatSendService + lint target + control-flow migration (#110)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -132,6 +132,15 @@
               "src/test-proxy-zone.setup.ts"
             ]
           }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
         }
       }
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,51 @@
+// @ts-check
+// Flat ESLint config for the Angular 21 app. Run via `npm run lint` (→ `ng lint`).
+// TS files get @eslint/js + typescript-eslint + @angular-eslint recommendations;
+// component inline templates and *.html files get the Angular template rules.
+const eslint = require('@eslint/js');
+const tseslint = require('typescript-eslint');
+const angular = require('angular-eslint');
+
+module.exports = tseslint.config(
+  {
+    // Build output and generated assets — never linted.
+    ignores: ['dist/**', 'coverage/**', '.angular/**', 'node_modules/**'],
+  },
+  {
+    files: ['**/*.ts'],
+    extends: [
+      eslint.configs.recommended,
+      ...tseslint.configs.recommended,
+      ...angular.configs.tsRecommended,
+    ],
+    processor: angular.processInlineTemplates,
+    rules: {
+      // Allow intentionally-unused identifiers when prefixed with `_`
+      // (placeholder params, destructured drops, caught-and-ignored errors).
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      '@angular-eslint/directive-selector': [
+        'error',
+        { type: 'attribute', prefix: 'app', style: 'camelCase' },
+      ],
+      '@angular-eslint/component-selector': [
+        'error',
+        { type: 'element', prefix: 'app', style: 'kebab-case' },
+      ],
+    },
+  },
+  {
+    files: ['**/*.html'],
+    extends: [
+      ...angular.configs.templateRecommended,
+      ...angular.configs.templateAccessibility,
+    ],
+    rules: {},
+  },
+);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,8 +8,10 @@ const angular = require('angular-eslint');
 
 module.exports = tseslint.config(
   {
-    // Build output and generated assets — never linted.
-    ignores: ['dist/**', 'coverage/**', '.angular/**', 'node_modules/**'],
+    // Build output, generated assets, and the static bootstrap document — never linted.
+    // src/index.html is plain HTML, not an Angular component template; the template
+    // parser + a11y rules would raise false positives on it.
+    ignores: ['dist/**', 'coverage/**', '.angular/**', 'node_modules/**', 'src/index.html'],
   },
   {
     files: ['**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@angular/build": "^21.1.5",
         "@angular/cli": "^21.1.5",
         "@angular/compiler-cli": "^21.1.0",
-        "@eslint/js": "^9.39.4",
+        "@eslint/js": "^10.0.1",
         "@types/express": "^5.0.1",
         "@types/node": "^20.17.19",
         "@types/uuid": "^10.0.0",
@@ -1885,16 +1885,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "zone.js": "^0.16.1"
       },
       "devDependencies": {
+        "@angular-eslint/builder": "^21.4.0",
         "@angular-eslint/eslint-plugin": "^21.3.1",
         "@angular-eslint/eslint-plugin-template": "^21.3.1",
         "@angular-eslint/schematics": "^21.3.1",
@@ -35,15 +36,18 @@
         "@angular/build": "^21.1.5",
         "@angular/cli": "^21.1.5",
         "@angular/compiler-cli": "^21.1.0",
+        "@eslint/js": "^9.39.4",
         "@types/express": "^5.0.1",
         "@types/node": "^20.17.19",
         "@types/uuid": "^10.0.0",
+        "angular-eslint": "^21.4.0",
         "axe-core": "^4.11.1",
         "eslint": "^10.2.0",
         "jsdom": "^27.1.0",
         "stylelint": "^17.14.0",
         "stylelint-value-no-unknown-custom-properties": "^6.1.1",
         "typescript": "~5.9.2",
+        "typescript-eslint": "^8.62.0",
         "vitest": "^4.0.8"
       }
     },
@@ -305,18 +309,36 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular-eslint/builder": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-21.4.0.tgz",
+      "integrity": "sha512-3kgGmrVaCYbLtDjC8g4BmMBbdz4thsOB8/NYly8JtXM8EuDZEk5Pz6VTRpJR02ARprwayraTTmhyvq6OGBlQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
+        "@angular-devkit/core": ">= 21.0.0 < 22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cli": ">= 21.0.0 < 22.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
       "version": "21.3.1",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "21.3.1",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-21.4.0.tgz",
+      "integrity": "sha512-mow2DMj+xBvGl5t7jzC34R8YfbHbaGNyCNFzpovtl9qc0JbuqLyg6htmt8xb05f8ZjATOr4nz0ESt6HV4c51hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "21.3.1",
-        "@angular-eslint/utils": "21.3.1",
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/utils": "21.4.0",
         "ts-api-utils": "^2.1.0"
       },
       "peerDependencies": {
@@ -343,21 +365,103 @@
         "typescript": "*"
       }
     },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-21.4.0.tgz",
+      "integrity": "sha512-/3H4BPbQ1BHJkkrUsfusZtmHc+qiFWBBZ9UDPWah4xZMjflexOK9U4GYeH7nMjcuyqFnIlMMeJJNwNLGt/hmdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-eslint/eslint-plugin/node_modules/@angular-eslint/utils": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-21.4.0.tgz",
+      "integrity": "sha512-7pi+Ga7QmdH5Ig/diau6fR5L4yubgKr9TOjdCg7OeuE/zo0O3osTCNT6JOodzS/iQM1kSCJFDoIBKFeUOttiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
     "node_modules/@angular-eslint/schematics": {
-      "version": "21.3.1",
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-21.4.0.tgz",
+      "integrity": "sha512-crD6Hfxs7x5bN9FCqTZI7uVSiGvprfCS3MCPOpyIQl87bRr/9aNhnicJ3ROUHv+2A713BgPHIgiCII/bxzrfPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
         "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
-        "@angular-eslint/eslint-plugin": "21.3.1",
-        "@angular-eslint/eslint-plugin-template": "21.3.1",
+        "@angular-eslint/eslint-plugin": "21.4.0",
+        "@angular-eslint/eslint-plugin-template": "21.4.0",
         "ignore": "7.0.5",
         "semver": "7.7.4",
         "strip-json-comments": "3.1.1"
       },
       "peerDependencies": {
         "@angular/cli": ">= 21.0.0 < 22.0.0"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-21.4.0.tgz",
+      "integrity": "sha512-/3H4BPbQ1BHJkkrUsfusZtmHc+qiFWBBZ9UDPWah4xZMjflexOK9U4GYeH7nMjcuyqFnIlMMeJJNwNLGt/hmdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/eslint-plugin-template": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-21.4.0.tgz",
+      "integrity": "sha512-sJEHx2WYnvOgPpzP1eHnUdRS06zgKmRxbiIR0JiCcaSen5iv1HlsMieXy//FS9TtNW+abHOy4UtDuGuSPflPFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/utils": "21.4.0",
+        "aria-query": "5.3.2",
+        "axobject-query": "4.1.0"
+      },
+      "peerDependencies": {
+        "@angular-eslint/template-parser": "21.4.0",
+        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/template-parser": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-21.4.0.tgz",
+      "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "eslint-scope": "9.1.2"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/utils": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-21.4.0.tgz",
+      "integrity": "sha512-7pi+Ga7QmdH5Ig/diau6fR5L4yubgKr9TOjdCg7OeuE/zo0O3osTCNT6JOodzS/iQM1kSCJFDoIBKFeUOttiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/template-parser": {
@@ -1778,6 +1882,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -4210,14 +4327,69 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4232,13 +4404,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4249,10 +4422,11 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4264,11 +4438,37 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4278,15 +4478,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4305,15 +4506,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4328,12 +4530,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4346,9 +4549,10 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -4575,6 +4779,87 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/angular-eslint": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-21.4.0.tgz",
+      "integrity": "sha512-LH7bWmtJvsubzwPoztnl1pWgI5X0VrfGTUITGSYcwn2J+SXuN/avzrKrxJmhUiIrNvLtfV+18GG6xZS1IGZdKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
+        "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
+        "@angular-eslint/builder": "21.4.0",
+        "@angular-eslint/eslint-plugin": "21.4.0",
+        "@angular-eslint/eslint-plugin-template": "21.4.0",
+        "@angular-eslint/schematics": "21.4.0",
+        "@angular-eslint/template-parser": "21.4.0",
+        "@typescript-eslint/types": "^8.0.0",
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cli": ">= 21.0.0 < 22.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*",
+        "typescript-eslint": "^8.0.0"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/bundled-angular-compiler": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-21.4.0.tgz",
+      "integrity": "sha512-/3H4BPbQ1BHJkkrUsfusZtmHc+qiFWBBZ9UDPWah4xZMjflexOK9U4GYeH7nMjcuyqFnIlMMeJJNwNLGt/hmdg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/eslint-plugin-template": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-21.4.0.tgz",
+      "integrity": "sha512-sJEHx2WYnvOgPpzP1eHnUdRS06zgKmRxbiIR0JiCcaSen5iv1HlsMieXy//FS9TtNW+abHOy4UtDuGuSPflPFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/utils": "21.4.0",
+        "aria-query": "5.3.2",
+        "axobject-query": "4.1.0"
+      },
+      "peerDependencies": {
+        "@angular-eslint/template-parser": "21.4.0",
+        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/template-parser": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-21.4.0.tgz",
+      "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "eslint-scope": "9.1.2"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
+      }
+    },
+    "node_modules/angular-eslint/node_modules/@angular-eslint/utils": {
+      "version": "21.4.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-21.4.0.tgz",
+      "integrity": "sha512-7pi+Ga7QmdH5Ig/diau6fR5L4yubgKr9TOjdCg7OeuE/zo0O3osTCNT6JOodzS/iQM1kSCJFDoIBKFeUOttiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "21.4.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "*"
       }
     },
     "node_modules/ansi-escapes": {
@@ -9348,6 +9633,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "i18n:pseudo:check": "node scripts/i18n/generate-pseudo-locale.mjs --check",
     "i18n:check": "npm run i18n:check:missing && npm run i18n:check:hardcoded && npm run i18n:pseudo:check",
     "serve:ssr:durion-positivity-frontend": "npm run sdk:install && node dist/durion-positivity-frontend/server/server.mjs",
+    "lint": "ng lint",
+    "lint:fix": "ng lint --fix",
     "lint:css": "stylelint \"src/**/*.css\"",
     "icons:generate": "node scripts/icons/generate-glyph-map.mjs",
     "icons:check": "node scripts/icons/generate-glyph-map.mjs --check"
@@ -56,6 +58,7 @@
     "zone.js": "^0.16.1"
   },
   "devDependencies": {
+    "@angular-eslint/builder": "^21.4.0",
     "@angular-eslint/eslint-plugin": "^21.3.1",
     "@angular-eslint/eslint-plugin-template": "^21.3.1",
     "@angular-eslint/schematics": "^21.3.1",
@@ -63,15 +66,18 @@
     "@angular/build": "^21.1.5",
     "@angular/cli": "^21.1.5",
     "@angular/compiler-cli": "^21.1.0",
+    "@eslint/js": "^9.39.4",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",
     "@types/uuid": "^10.0.0",
+    "angular-eslint": "^21.4.0",
     "axe-core": "^4.11.1",
     "eslint": "^10.2.0",
     "jsdom": "^27.1.0",
     "stylelint": "^17.14.0",
     "stylelint-value-no-unknown-custom-properties": "^6.1.1",
     "typescript": "~5.9.2",
+    "typescript-eslint": "^8.62.0",
     "vitest": "^4.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@angular/build": "^21.1.5",
     "@angular/cli": "^21.1.5",
     "@angular/compiler-cli": "^21.1.0",
-    "@eslint/js": "^9.39.4",
+    "@eslint/js": "^10.0.1",
     "@types/express": "^5.0.1",
     "@types/node": "^20.17.19",
     "@types/uuid": "^10.0.0",

--- a/src/app/features/accounting/pages/event-envelope-contract/event-envelope-contract-page.component.ts
+++ b/src/app/features/accounting/pages/event-envelope-contract/event-envelope-contract-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -11,7 +11,7 @@ type ContractTab = 'fields' | 'traceability' | 'examples';
 @Component({
   selector: 'app-event-envelope-contract-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './event-envelope-contract-page.component.html',
   styleUrl: './event-envelope-contract-page.component.css',
 })

--- a/src/app/features/accounting/pages/ingestion-submit/ingestion-submit-page.component.ts
+++ b/src/app/features/accounting/pages/ingestion-submit/ingestion-submit-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -39,7 +39,7 @@ type SubmitState = 'idle' | 'submitting' | 'success' | 'error' | 'forbidden';
 @Component({
   selector: 'app-ingestion-submit-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './ingestion-submit-page.component.html',
   styleUrl: './ingestion-submit-page.component.css',
 })

--- a/src/app/features/accounting/pages/posting-rules/posting-rules-list/posting-rules-list-page.component.ts
+++ b/src/app/features/accounting/pages/posting-rules/posting-rules-list/posting-rules-list-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
@@ -11,7 +11,7 @@ type RulesState = 'loading' | 'ready' | 'error' | 'forbidden';
 @Component({
   selector: 'app-posting-rules-list-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './posting-rules-list-page.component.html',
   styleUrl: './posting-rules-list-page.component.css',
 })

--- a/src/app/features/accounting/pages/reports/labor-overhead/labor-overhead-report-page.component.ts
+++ b/src/app/features/accounting/pages/reports/labor-overhead/labor-overhead-report-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import {
   ChangeDetectionStrategy,
   Component,
@@ -20,7 +20,7 @@ const YEAR_SPAN = 5;
 @Component({
   selector: 'app-labor-overhead-report-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, LocationPickerComponent],
+  imports: [TranslatePipe, LocationPickerComponent],
   templateUrl: './labor-overhead-report-page.component.html',
   styleUrl: './labor-overhead-report-page.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/auth/login.component.ts
+++ b/src/app/features/auth/login.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from '../../core/services/auth.service';
 import { ThemeService } from '../../core/services/theme.service';
@@ -9,7 +9,7 @@ import { ThemeService } from '../../core/services/theme.service';
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './login.component.html',
   styleUrl: './login.component.css',
 })

--- a/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
+++ b/src/app/features/crm/components/customer-lookup/customer-lookup.component.ts
@@ -1,7 +1,7 @@
 import {
   Component, inject, signal, forwardRef, Input, DestroyRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, of } from 'rxjs';
@@ -23,7 +23,7 @@ const MAX_SUGGESTIONS = 12;
 @Component({
   selector: 'app-customer-lookup',
   standalone: true,
-  imports: [CommonModule],
+  imports: [],
   templateUrl: './customer-lookup.component.html',
   styleUrl: './customer-lookup.component.css',
   providers: [

--- a/src/app/features/crm/pages/billing-rules/billing-rules.component.ts
+++ b/src/app/features/crm/pages/billing-rules/billing-rules.component.ts
@@ -6,7 +6,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -18,7 +18,7 @@ import {
 @Component({
   selector: 'app-billing-rules',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './billing-rules.component.html',
   styleUrl: './billing-rules.component.css',
 })

--- a/src/app/features/crm/pages/create-commercial-account/create-commercial-account.component.ts
+++ b/src/app/features/crm/pages/create-commercial-account/create-commercial-account.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { CrmService } from '../../services/crm.service';
 import {
   BillingTermsRef,
@@ -13,7 +13,7 @@ type PageState = 'idle' | 'loading-terms' | 'terms-error' | 'checking' | 'duplic
 @Component({
   selector: 'app-create-commercial-account',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './create-commercial-account.component.html',
   styleUrl: './create-commercial-account.component.css',
 })

--- a/src/app/features/crm/pages/create-individual-person/create-individual-person.component.ts
+++ b/src/app/features/crm/pages/create-individual-person/create-individual-person.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { CrmService } from '../../services/crm.service';
 
 type PageState = 'idle' | 'submitting' | 'success' | 'error' | 'access-denied';
@@ -9,7 +9,7 @@ type PageState = 'idle' | 'submitting' | 'success' | 'error' | 'access-denied';
 @Component({
   selector: 'app-create-individual-person',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './create-individual-person.component.html',
   styleUrl: './create-individual-person.component.css',
 })

--- a/src/app/features/crm/pages/create-vehicle/create-vehicle.component.ts
+++ b/src/app/features/crm/pages/create-vehicle/create-vehicle.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { CrmService } from '../../services/crm.service';
 
 type PageState = 'idle' | 'submitting' | 'success' | 'error' | 'access-denied';
@@ -9,7 +9,7 @@ type PageState = 'idle' | 'submitting' | 'success' | 'error' | 'access-denied';
 @Component({
   selector: 'app-create-vehicle',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './create-vehicle.component.html',
   styleUrl: './create-vehicle.component.css',
 })

--- a/src/app/features/crm/pages/crm-snapshot/crm-snapshot.component.ts
+++ b/src/app/features/crm/pages/crm-snapshot/crm-snapshot.component.ts
@@ -6,7 +6,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -25,7 +25,7 @@ const MAX_SUGGESTIONS = 8;
 @Component({
   selector: 'app-crm-snapshot',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './crm-snapshot.component.html',
   styleUrl: './crm-snapshot.component.css',
 })

--- a/src/app/features/crm/pages/customer-list/customer-list.component.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal, computed, OnInit, DestroyRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CommonModule } from '@angular/common';
+
 import { Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -14,7 +14,7 @@ type SortDir = 'asc' | 'desc';
 @Component({
   selector: 'app-customer-list',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './customer-list.component.html',
   styleUrl: './customer-list.component.css',
 })

--- a/src/app/features/crm/pages/merge-parties/merge-parties.component.ts
+++ b/src/app/features/crm/pages/merge-parties/merge-parties.component.ts
@@ -5,7 +5,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -19,7 +19,7 @@ import {
 @Component({
   selector: 'app-merge-parties',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './merge-parties.component.html',
   styleUrl: './merge-parties.component.css',
 })

--- a/src/app/features/crm/pages/party-detail/party-detail.component.ts
+++ b/src/app/features/crm/pages/party-detail/party-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, DestroyRef, inject, signal, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -17,7 +17,7 @@ type EditState    = 'view' | 'editing' | 'saving';
 @Component({
   selector: 'app-party-detail',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [ReactiveFormsModule],
   templateUrl: './party-detail.component.html',
   styleUrl: './party-detail.component.css',
 })

--- a/src/app/features/inventory/pages/availability/availability.component.ts
+++ b/src/app/features/inventory/pages/availability/availability.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal, computed } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -17,7 +17,7 @@ const MAX_SUGGESTIONS = 8;
 @Component({
   selector: 'app-inventory-availability',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, FormsModule],
+  imports: [TranslatePipe, FormsModule],
   templateUrl: './availability.component.html',
   styleUrl: './availability.component.css',
 })

--- a/src/app/features/inventory/pages/counts/adjustment-approvals/adjustment-approvals.component.ts
+++ b/src/app/features/inventory/pages/counts/adjustment-approvals/adjustment-approvals.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -14,7 +14,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-adjustment-approvals',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './adjustment-approvals.component.html',
   styleUrl: './adjustment-approvals.component.css',
 })

--- a/src/app/features/inventory/pages/counts/count-execute/count-execute.component.ts
+++ b/src/app/features/inventory/pages/counts/count-execute/count-execute.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -15,7 +15,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-count-execute',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './count-execute.component.html',
   styleUrl: './count-execute.component.css',
 })

--- a/src/app/features/inventory/pages/counts/cycle-count-plan-form/cycle-count-plan-form-page.component.ts
+++ b/src/app/features/inventory/pages/counts/cycle-count-plan-form/cycle-count-plan-form-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -12,7 +12,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'submitting' | 'error';
 @Component({
   selector: 'app-cycle-count-plan-form-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, RouterLink],
+  imports: [TranslatePipe, RouterLink],
   templateUrl: './cycle-count-plan-form-page.component.html',
   styleUrl: './cycle-count-plan-form-page.component.css',
 })

--- a/src/app/features/inventory/pages/fulfillment/consume-picked-items/consume-picked-items-page.component.ts
+++ b/src/app/features/inventory/pages/fulfillment/consume-picked-items/consume-picked-items-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'submitting' | 'success' | 'erro
 @Component({
   selector: 'app-consume-picked-items-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './consume-picked-items-page.component.html',
   styleUrls: ['./consume-picked-items-page.component.css'],
 })

--- a/src/app/features/inventory/pages/fulfillment/pick-execute/pick-execute-page.component.ts
+++ b/src/app/features/inventory/pages/fulfillment/pick-execute/pick-execute-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'picking' | 'complete' | 'error'
 @Component({
   selector: 'app-pick-execute-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './pick-execute-page.component.html',
   styleUrls: ['./pick-execute-page.component.css'],
 })

--- a/src/app/features/inventory/pages/fulfillment/return-to-stock/return-to-stock-page.component.ts
+++ b/src/app/features/inventory/pages/fulfillment/return-to-stock/return-to-stock-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, computed, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
@@ -18,7 +18,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'submitting' | 'success' | 'erro
 @Component({
   selector: 'app-return-to-stock-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, RouterLink],
+  imports: [TranslatePipe, RouterLink],
   templateUrl: './return-to-stock-page.component.html',
   styleUrls: ['./return-to-stock-page.component.css'],
 })

--- a/src/app/features/inventory/pages/fulfillment/shortage-resolution/shortage-resolution-page.component.ts
+++ b/src/app/features/inventory/pages/fulfillment/shortage-resolution/shortage-resolution-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterLink } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'submitting' | 'resolved' | 'err
 @Component({
   selector: 'app-shortage-resolution-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, RouterLink],
+  imports: [TranslatePipe, RouterLink],
   templateUrl: './shortage-resolution-page.component.html',
   styleUrls: ['./shortage-resolution-page.component.css'],
 })

--- a/src/app/features/inventory/pages/ledger/ledger-detail/ledger-detail.component.ts
+++ b/src/app/features/inventory/pages/ledger/ledger-detail/ledger-detail.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-ledger-detail',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './ledger-detail.component.html',
   styleUrl: './ledger-detail.component.css',
 })

--- a/src/app/features/inventory/pages/ledger/ledger-list/ledger-list.component.ts
+++ b/src/app/features/inventory/pages/ledger/ledger-list/ledger-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -16,7 +16,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-ledger-list',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, FormsModule],
+  imports: [TranslatePipe, FormsModule],
   templateUrl: './ledger-list.component.html',
   styleUrl: './ledger-list.component.css',
 })

--- a/src/app/features/inventory/pages/purchase-orders/po-detail/po-detail.component.ts
+++ b/src/app/features/inventory/pages/purchase-orders/po-detail/po-detail.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-po-detail',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './po-detail.component.html',
   styleUrl: './po-detail.component.css',
 })

--- a/src/app/features/inventory/pages/purchase-orders/po-form/po-form.component.ts
+++ b/src/app/features/inventory/pages/purchase-orders/po-form/po-form.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -16,7 +16,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-po-form',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, FormsModule],
+  imports: [TranslatePipe, FormsModule],
   templateUrl: './po-form.component.html',
   styleUrl: './po-form.component.css',
 })

--- a/src/app/features/inventory/pages/purchase-orders/po-list/po-list.component.ts
+++ b/src/app/features/inventory/pages/purchase-orders/po-list/po-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-po-list',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './po-list.component.html',
   styleUrl: './po-list.component.css',
 })

--- a/src/app/features/inventory/pages/putaway/putaway-execute/putaway-execute.component.ts
+++ b/src/app/features/inventory/pages/putaway/putaway-execute/putaway-execute.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -12,7 +12,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-putaway-execute',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './putaway-execute.component.html',
   styleUrl: './putaway-execute.component.css',
 })

--- a/src/app/features/inventory/pages/putaway/putaway-task-list/putaway-task-list.component.ts
+++ b/src/app/features/inventory/pages/putaway/putaway-task-list/putaway-task-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
@@ -11,7 +11,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-putaway-task-list',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './putaway-task-list.component.html',
   styleUrl: './putaway-task-list.component.css',
 })

--- a/src/app/features/inventory/pages/receiving/cross-dock-receive/cross-dock-receive-page.component.ts
+++ b/src/app/features/inventory/pages/receiving/cross-dock-receive/cross-dock-receive-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -15,7 +15,7 @@ type PageState = 'idle' | 'loading' | 'ready' | 'reviewing' | 'submitting' | 'su
 @Component({
   selector: 'app-cross-dock-receive-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './cross-dock-receive-page.component.html',
   styleUrl: './cross-dock-receive-page.component.css',
 })

--- a/src/app/features/inventory/pages/receiving/receive-into-staging/receive-into-staging.component.ts
+++ b/src/app/features/inventory/pages/receiving/receive-into-staging/receive-into-staging.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -18,7 +18,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-receive-into-staging',
   standalone: true,
-  imports: [CommonModule, TranslatePipe, FormsModule],
+  imports: [TranslatePipe, FormsModule],
   templateUrl: './receive-into-staging.component.html',
   styleUrl: './receive-into-staging.component.css',
 })

--- a/src/app/features/inventory/pages/replenishment/replenishment-task-list/replenishment-task-list.component.ts
+++ b/src/app/features/inventory/pages/replenishment/replenishment-task-list/replenishment-task-list.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -10,7 +10,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-replenishment-task-list',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './replenishment-task-list.component.html',
   styleUrl: './replenishment-task-list.component.css',
 })

--- a/src/app/features/location/components/location-picker/location-picker.component.ts
+++ b/src/app/features/location/components/location-picker/location-picker.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import {
   ChangeDetectionStrategy,
   Component,
@@ -33,7 +33,7 @@ let pickerSeq = 0;
 @Component({
   selector: 'app-location-picker',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './location-picker.component.html',
   styleUrl: './location-picker.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/location/pages/bays/bays-page.component.ts
+++ b/src/app/features/location/pages/bays/bays-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -10,7 +10,7 @@ import { LocationPickerComponent } from '../../components/location-picker/locati
 @Component({
   selector: 'app-bays-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe, LocationPickerComponent],
+  imports: [ReactiveFormsModule, TranslatePipe, LocationPickerComponent],
   templateUrl: './bays-page.component.html',
   styleUrl: './bays-page.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/location/pages/locations/locations-page.component.ts
+++ b/src/app/features/location/pages/locations/locations-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -22,7 +22,7 @@ interface LocationItem {
 @Component({
   selector: 'app-locations-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './locations-page.component.html',
   styleUrl: './locations-page.component.css',
 })

--- a/src/app/features/location/pages/mobile-units/mobile-units-page.component.ts
+++ b/src/app/features/location/pages/mobile-units/mobile-units-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -10,7 +10,7 @@ import { LocationPickerComponent } from '../../components/location-picker/locati
 @Component({
   selector: 'app-mobile-units-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe, LocationPickerComponent],
+  imports: [ReactiveFormsModule, TranslatePipe, LocationPickerComponent],
   templateUrl: './mobile-units-page.component.html',
   styleUrl: './mobile-units-page.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/people/components/person-lookup/person-lookup.component.ts
+++ b/src/app/features/people/components/person-lookup/person-lookup.component.ts
@@ -1,7 +1,7 @@
 import {
   ChangeDetectionStrategy, Component, inject, signal, forwardRef, Input, DestroyRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -33,7 +33,7 @@ export type PersonLookupType = 'ALL' | 'EMPLOYEE' | 'ACTIVE' | 'INACTIVE';
 @Component({
   selector: 'app-person-lookup',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './person-lookup.component.html',
   styleUrl: './person-lookup.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/people/pages/directory/people-directory-page.component.ts
+++ b/src/app/features/people/pages/directory/people-directory-page.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { Subject, Subscription } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
@@ -38,7 +38,7 @@ const FILTER_OPTIONS: FilterOption[] = [
   selector: 'app-people-directory-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, RouterLink, TranslatePipe],
+  imports: [RouterLink, TranslatePipe],
   templateUrl: './people-directory-page.component.html',
   styleUrl: './people-directory-page.component.css',
 })

--- a/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
+++ b/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
@@ -70,7 +70,7 @@
       </p>
       <footer class="modal-footer">
         <button type="button" class="btn btn--ghost" data-testid="offboard-cancel-btn" [disabled]="submitting()"
-          (click)="cancelConfirmDialog()" autofocus>
+          (click)="cancelConfirmDialog()">
           Cancel
         </button>
         <button type="button" class="btn btn--danger" data-testid="offboard-confirm-btn" [disabled]="submitting()"

--- a/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
+++ b/src/app/features/people/pages/employee-offboard/employee-offboard-page.component.html
@@ -69,10 +69,15 @@
         This action is destructive and cannot be undone from this screen.
       </p>
       <footer class="modal-footer">
+        <!-- autofocus moves focus into this non-native role="alertdialog" on open (Cancel is the
+             safe default for a destructive confirm); no JS focus-trap exists, so this is the only
+             mechanism placing keyboard/SR users inside the modal. ADR-0029 keyboard-flow. -->
+        <!-- eslint-disable @angular-eslint/template/no-autofocus -->
         <button type="button" class="btn btn--ghost" data-testid="offboard-cancel-btn" [disabled]="submitting()"
-          (click)="cancelConfirmDialog()">
+          (click)="cancelConfirmDialog()" autofocus>
           Cancel
         </button>
+        <!-- eslint-enable @angular-eslint/template/no-autofocus -->
         <button type="button" class="btn btn--danger" data-testid="offboard-confirm-btn" [disabled]="submitting()"
           (click)="confirmOffboard()">
           @if (submitting()) {

--- a/src/app/features/people/pages/person-location-assignments/person-location-assignments-page.component.html
+++ b/src/app/features/people/pages/person-location-assignments/person-location-assignments-page.component.html
@@ -146,10 +146,15 @@
         This will end the selected assignment for this person.
       </p>
       <footer class="form-footer">
+        <!-- autofocus moves focus into this non-native role="alertdialog" on open (Cancel is the
+             safe default for a destructive confirm); no JS focus-trap exists, so this is the only
+             mechanism placing keyboard/SR users inside the modal. ADR-0029 keyboard-flow. -->
+        <!-- eslint-disable @angular-eslint/template/no-autofocus -->
         <button type="button" class="btn btn--ghost" data-testid="cancel-end-btn" [disabled]="submitting()"
-          (click)="closeEndDialog()">
+          (click)="closeEndDialog()" autofocus>
           Cancel
         </button>
+        <!-- eslint-enable @angular-eslint/template/no-autofocus -->
         <button type="button" class="btn btn--danger" data-testid="confirm-end-btn" [disabled]="submitting()"
           (click)="confirmEnd()">
           @if (submitting()) {

--- a/src/app/features/people/pages/person-location-assignments/person-location-assignments-page.component.html
+++ b/src/app/features/people/pages/person-location-assignments/person-location-assignments-page.component.html
@@ -147,7 +147,7 @@
       </p>
       <footer class="form-footer">
         <button type="button" class="btn btn--ghost" data-testid="cancel-end-btn" [disabled]="submitting()"
-          (click)="closeEndDialog()" autofocus>
+          (click)="closeEndDialog()">
           Cancel
         </button>
         <button type="button" class="btn btn--danger" data-testid="confirm-end-btn" [disabled]="submitting()"

--- a/src/app/features/people/pages/time-approval/time-approval-page.component.html
+++ b/src/app/features/people/pages/time-approval/time-approval-page.component.html
@@ -173,7 +173,7 @@
           rows="4"></textarea>
       </div>
       <div class="actions-row">
-        <button type="button" (click)="closeRejectDialog()" data-testid="cancel-reject-btn" autofocus>
+        <button type="button" (click)="closeRejectDialog()" data-testid="cancel-reject-btn">
           Cancel
         </button>
         <button type="button" (click)="submitReject()" data-testid="submit-reject-btn" [disabled]="actionInFlight()">

--- a/src/app/features/people/pages/time-approval/time-approval-page.component.html
+++ b/src/app/features/people/pages/time-approval/time-approval-page.component.html
@@ -173,9 +173,14 @@
           rows="4"></textarea>
       </div>
       <div class="actions-row">
-        <button type="button" (click)="closeRejectDialog()" data-testid="cancel-reject-btn">
+        <!-- autofocus moves focus into this non-native role="alertdialog" on open (Cancel is the
+             safe default for a destructive confirm); no JS focus-trap exists, so this is the only
+             mechanism placing keyboard/SR users inside the modal. ADR-0029 keyboard-flow. -->
+        <!-- eslint-disable @angular-eslint/template/no-autofocus -->
+        <button type="button" (click)="closeRejectDialog()" data-testid="cancel-reject-btn" autofocus>
           Cancel
         </button>
+        <!-- eslint-enable @angular-eslint/template/no-autofocus -->
         <button type="button" (click)="submitReject()" data-testid="submit-reject-btn" [disabled]="actionInFlight()">
           Submit Reject
         </button>

--- a/src/app/features/product/pages/inventory/availability/availability.component.ts
+++ b/src/app/features/product/pages/inventory/availability/availability.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -13,7 +13,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-availability',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './availability.component.html',
   styleUrl: './availability.component.css',
 })

--- a/src/app/features/security/pages/audit-logs/audit-logs.component.ts
+++ b/src/app/features/security/pages/audit-logs/audit-logs.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -15,7 +15,7 @@ type PageState = 'idle' | 'loading' | 'empty' | 'ready' | 'error';
 @Component({
   selector: 'app-audit-logs',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './audit-logs.component.html',
   styleUrl: './audit-logs.component.css',
 })

--- a/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
+++ b/src/app/features/security/pages/audit/security-audit-list/security-audit-list-page.component.html
@@ -11,16 +11,26 @@
     <button type="submit">{{ 'SECURITY.AUDIT_LIST.LOAD' | translate }}</button>
   </form>
 
-  <p class="error-banner" *ngIf="error()">{{ error()! | translate }}</p>
+  @if (error()) {
+    <p class="error-banner">{{ error()! | translate }}</p>
+  }
 
-  <div class="audit-list" *ngIf="!loading() && auditEntries().length > 0">
-    <div class="audit-entry" *ngFor="let entry of auditEntries()">
-      <button type="button" (click)="viewEntry(entry)">{{ 'SECURITY.AUDIT_LIST.VIEW_ENTRY' | translate }}</button>
-      <span>{{ entry | json }}</span>
+  @if (!loading() && auditEntries().length > 0) {
+    <div class="audit-list">
+      @for (entry of auditEntries(); track entry) {
+        <div class="audit-entry">
+          <button type="button" (click)="viewEntry(entry)">{{ 'SECURITY.AUDIT_LIST.VIEW_ENTRY' | translate }}</button>
+          <span>{{ entry | json }}</span>
+        </div>
+      }
     </div>
-  </div>
+  }
 
-  <div class="audit-detail" *ngIf="selectedEntry()">{{ selectedEntry() | json }}</div>
+  @if (selectedEntry()) {
+    <div class="audit-detail">{{ selectedEntry() | json }}</div>
+  }
 
-  <p class="empty-state" *ngIf="!loading() && !error() && auditEntries().length === 0">{{ 'SECURITY.AUDIT_LIST.EMPTY' | translate }}</p>
+  @if (!loading() && !error() && auditEntries().length === 0) {
+    <p class="empty-state">{{ 'SECURITY.AUDIT_LIST.EMPTY' | translate }}</p>
+  }
 </section>

--- a/src/app/features/shell/components/chat-panel/chat-panel.component.ts
+++ b/src/app/features/shell/components/chat-panel/chat-panel.component.ts
@@ -1,7 +1,6 @@
 import {
   Component,
   computed,
-  DestroyRef,
   inject,
   output,
   signal,
@@ -10,13 +9,10 @@ import {
   AfterViewChecked,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { finalize } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslatePipe } from '@ngx-translate/core';
 import { ChatStateService } from '../../services/chat-state.service';
-import { ChatApiService } from '../../services/chat-api.service';
+import { ChatSendService } from '../../services/chat-send.service';
 import { AuthService } from '../../../../core/services/auth.service';
 import { RagIngestDialogComponent } from '../rag-ingest-dialog/rag-ingest-dialog.component';
 import { MaterialSymbolPipe } from '../../../../shared/material-symbol.pipe';
@@ -29,12 +25,8 @@ import { MaterialSymbolPipe } from '../../../../shared/material-symbol.pipe';
   styleUrl: './chat-panel.component.css',
 })
 export class ChatPanelComponent implements AfterViewChecked {
-  private static readonly CORRELATION_ID_HEADER = 'X-Correlation-Id';
-
-  private readonly destroyRef = inject(DestroyRef);
   private readonly chatState = inject(ChatStateService);
-  private readonly chatApi = inject(ChatApiService);
-  private readonly translateService = inject(TranslateService);
+  private readonly chatSend = inject(ChatSendService);
   private readonly authService = inject(AuthService);
 
   /** Emitted when the user collapses the panel via its close button. */
@@ -56,26 +48,16 @@ export class ChatPanelComponent implements AfterViewChecked {
     const text = this.inputValue().trim();
     if (!text || this.sending()) return;
 
-    this.chatState.addUserMessage(text);
     this.inputValue.set('');
     this.sending.set(true);
     this.scrollPending = true;
 
-    this.chatApi
-      .sendMessage({ message: text })
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => this.sending.set(false)),
-      )
-      .subscribe({
-        next: resp => {
-          this.chatState.addSystemMessage(resp.response);
-          this.scrollPending = true;
-        },
-        error: error => {
-          this.handleSendFailure(error);
-        },
-      });
+    this.chatSend.send(text, {
+      onSettled: () => {
+        this.sending.set(false);
+        this.scrollPending = true;
+      },
+    });
   }
 
   onKeyDown(event: KeyboardEvent): void {
@@ -91,81 +73,5 @@ export class ChatPanelComponent implements AfterViewChecked {
       el.scrollTop = el.scrollHeight;
       this.scrollPending = false;
     }
-  }
-
-  private handleSendFailure(error: unknown): void {
-    this.logChatFailure(error);
-    this.chatState.addSystemMessage(this.translateService.instant('SHELL.CHAT.ERROR_BACKEND'));
-
-    const troubleshootingMessage = this.buildTroubleshootingMessage(error);
-    if (troubleshootingMessage) {
-      this.chatState.addSystemMessage(troubleshootingMessage);
-    }
-
-    this.scrollPending = true;
-  }
-
-  private buildTroubleshootingMessage(error: unknown): string {
-    if (!(error instanceof HttpErrorResponse)) {
-      return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING_GENERIC');
-    }
-
-    const details = [
-      this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_STATUS', { status: error.status }),
-      this.buildBackendCodeDetail(error),
-      this.buildCorrelationIdDetail(error),
-    ].filter((detail): detail is string => typeof detail === 'string' && detail.trim().length > 0);
-
-    if (details.length === 0) {
-      return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING_GENERIC');
-    }
-
-    return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING', {
-      details: details.join(' '),
-    });
-  }
-
-  private buildBackendCodeDetail(error: HttpErrorResponse): string | null {
-    const backendCode = this.extractBackendCode(error.error);
-    if (!backendCode) {
-      return null;
-    }
-
-    return this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_CODE', { code: backendCode });
-  }
-
-  private buildCorrelationIdDetail(error: HttpErrorResponse): string | null {
-    const correlationId = error.headers.get(ChatPanelComponent.CORRELATION_ID_HEADER);
-    if (!correlationId) {
-      return null;
-    }
-
-    return this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_CORRELATION_ID', {
-      correlationId,
-    });
-  }
-
-  private extractBackendCode(errorBody: unknown): string | null {
-    if (!errorBody || typeof errorBody !== 'object') {
-      return null;
-    }
-
-    const code = (errorBody as { code?: unknown }).code;
-    return typeof code === 'string' && code.trim().length > 0 ? code.trim() : null;
-  }
-
-  private logChatFailure(error: unknown): void {
-    if (error instanceof HttpErrorResponse) {
-      console.error('Chat backend request failed', {
-        status: error.status,
-        url: error.url,
-        correlationId: error.headers.get(ChatPanelComponent.CORRELATION_ID_HEADER),
-        backendCode: this.extractBackendCode(error.error),
-        errorBody: error.error,
-      });
-      return;
-    }
-
-    console.error('Chat backend request failed', { error });
   }
 }

--- a/src/app/features/shell/dashboard/dashboard.component.ts
+++ b/src/app/features/shell/dashboard/dashboard.component.ts
@@ -1,12 +1,10 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { finalize } from 'rxjs';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslatePipe } from '@ngx-translate/core';
 import { AuthService } from '../../../core/services/auth.service';
 import { MaterialSymbolPipe } from '../../../shared/material-symbol.pipe';
-import { ChatStateService } from '../services/chat-state.service';
-import { ChatApiService } from '../services/chat-api.service';
+import { ChatSendService } from '../services/chat-send.service';
 import { ChatUiService } from '../services/chat-ui.service';
 
 /** Visual tone for a quick-action tile; maps to a CSS class. */
@@ -52,10 +50,8 @@ interface FavoriteArea {
 })
 export class DashboardComponent {
   private readonly auth = inject(AuthService);
-  private readonly chatState = inject(ChatStateService);
-  private readonly chatApi = inject(ChatApiService);
+  private readonly chatSend = inject(ChatSendService);
   private readonly chatUi = inject(ChatUiService);
-  private readonly translate = inject(TranslateService);
 
   /** First name derived from the JWT `sub` claim, or null when unresolved.
    *  Uses the FIRST token of an email/dotted id (e.g. `jane.doe@durion.com` → `Jane`). */
@@ -100,18 +96,13 @@ export class DashboardComponent {
     const text = this.assistantInput().trim();
     if (!text || this.assistantSending()) return;
 
-    this.chatState.addUserMessage(text);
     this.assistantInput.set('');
     this.assistantSending.set(true);
     this.chatUi.open(); // surface the conversation in the shell chat panel
 
-    this.chatApi
-      .sendMessage({ message: text })
-      .pipe(finalize(() => this.assistantSending.set(false)))
-      .subscribe({
-        next: resp => this.chatState.addSystemMessage(resp.response),
-        error: () => this.chatState.addSystemMessage(this.translate.instant('SHELL.CHAT.ERROR_BACKEND')),
-      });
+    this.chatSend.send(text, {
+      onSettled: () => this.assistantSending.set(false),
+    });
   }
 
   onAssistantKeydown(event: KeyboardEvent): void {

--- a/src/app/features/shell/services/chat-send.service.spec.ts
+++ b/src/app/features/shell/services/chat-send.service.spec.ts
@@ -1,0 +1,138 @@
+import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { JwtClaims } from '../../../core/models/auth.models';
+import { AuthService } from '../../../core/services/auth.service';
+import { ChatApiService, ChatResponse } from './chat-api.service';
+import { ChatStateService } from './chat-state.service';
+import { ChatSendService } from './chat-send.service';
+
+const chatTranslations = {
+  SHELL: {
+    CHAT: {
+      ERROR_BACKEND: 'Chat service is not available. Your message was received locally.',
+      ERROR_TROUBLESHOOTING:
+        'Troubleshooting: {{ details }} Check your browser Network tab and the gateway logs for /mcp-server/v1/mcp/chat.',
+      ERROR_TROUBLESHOOTING_GENERIC:
+        'Troubleshooting: Check your browser Network tab and the gateway logs for /mcp-server/v1/mcp/chat.',
+      ERROR_DETAIL_STATUS: 'HTTP {{ status }}.',
+      ERROR_DETAIL_CODE: 'Backend code {{ code }}.',
+      ERROR_DETAIL_CORRELATION_ID: 'Correlation ID {{ correlationId }}.',
+    },
+  },
+};
+
+describe('ChatSendService', () => {
+  let service: ChatSendService;
+  let chatState: ChatStateService;
+
+  const chatApiStub: Pick<ChatApiService, 'sendMessage'> = {
+    sendMessage: vi.fn(),
+  };
+
+  const authServiceStub: Pick<AuthService, 'currentUserClaims'> = {
+    currentUserClaims: signal<JwtClaims | null>(null),
+  };
+
+  beforeEach(() => {
+    vi.mocked(chatApiStub.sendMessage).mockReset();
+
+    TestBed.configureTestingModule({
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        { provide: ChatApiService, useValue: chatApiStub },
+        { provide: AuthService, useValue: authServiceStub },
+      ],
+    });
+
+    const translate = TestBed.inject(TranslateService);
+    translate.setTranslation('en-US', chatTranslations);
+    translate.use('en-US');
+
+    service = TestBed.inject(ChatSendService);
+    chatState = TestBed.inject(ChatStateService);
+    chatState.clear();
+  });
+
+  afterEach(() => {
+    chatState.clear();
+    vi.clearAllMocks();
+  });
+
+  it('records the user message, sends it, and stores the reply as a system message', () => {
+    const response: ChatResponse = { response: 'How can I help?' };
+    vi.mocked(chatApiStub.sendMessage).mockReturnValueOnce(of(response));
+
+    const onSettled = vi.fn();
+    service.send('Hello', { onSettled });
+
+    const messages = chatState.messages();
+    expect(chatApiStub.sendMessage).toHaveBeenCalledWith({ message: 'Hello' });
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({ content: 'Hello', sender: 'user' });
+    expect(messages[1]).toMatchObject({ content: 'How can I help?', sender: 'system' });
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the failure and surfaces fallback + troubleshooting detail on an HTTP error', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const httpError = new HttpErrorResponse({
+      status: 502,
+      statusText: 'Bad Gateway',
+      url: 'https://durionpos.org/mcp-server/v1/mcp/chat',
+      headers: new HttpHeaders({ 'X-Correlation-Id': 'corr-123' }),
+      error: { code: 'UPSTREAM_FAILURE' },
+    });
+    vi.mocked(chatApiStub.sendMessage).mockReturnValueOnce(throwError(() => httpError));
+
+    const onSettled = vi.fn();
+    service.send('Hello', { onSettled });
+
+    const systemMessages = chatState
+      .messages()
+      .filter(message => message.sender === 'system')
+      .map(message => message.content);
+
+    expect(systemMessages).toEqual([
+      'Chat service is not available. Your message was received locally.',
+      'Troubleshooting: HTTP 502. Backend code UPSTREAM_FAILURE. Correlation ID corr-123. Check your browser Network tab and the gateway logs for /mcp-server/v1/mcp/chat.',
+    ]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Chat backend request failed',
+      expect.objectContaining({
+        status: 502,
+        url: 'https://durionpos.org/mcp-server/v1/mcp/chat',
+        correlationId: 'corr-123',
+        backendCode: 'UPSTREAM_FAILURE',
+        errorBody: { code: 'UPSTREAM_FAILURE' },
+      }),
+    );
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a generic troubleshooting message for a non-HTTP error', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(chatApiStub.sendMessage).mockReturnValueOnce(throwError(() => new Error('boom')));
+
+    service.send('Hello');
+
+    const systemMessages = chatState
+      .messages()
+      .filter(message => message.sender === 'system')
+      .map(message => message.content);
+
+    expect(systemMessages).toEqual([
+      'Chat service is not available. Your message was received locally.',
+      'Troubleshooting: Check your browser Network tab and the gateway logs for /mcp-server/v1/mcp/chat.',
+    ]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Chat backend request failed', { error: expect.any(Error) });
+  });
+
+  it('runs onSettled even when no callbacks object is passed', () => {
+    vi.mocked(chatApiStub.sendMessage).mockReturnValueOnce(of<ChatResponse>({ response: 'ok' }));
+    expect(() => service.send('Hello')).not.toThrow();
+    expect(chatState.messages().some(m => m.sender === 'system' && m.content === 'ok')).toBe(true);
+  });
+});

--- a/src/app/features/shell/services/chat-send.service.spec.ts
+++ b/src/app/features/shell/services/chat-send.service.spec.ts
@@ -90,6 +90,9 @@ describe('ChatSendService', () => {
     const onSettled = vi.fn();
     service.send('Hello', { onSettled });
 
+    // The user's own message must still be recorded even when the send fails.
+    expect(chatState.messages().some(m => m.sender === 'user' && m.content === 'Hello')).toBe(true);
+
     const systemMessages = chatState
       .messages()
       .filter(message => message.sender === 'system')

--- a/src/app/features/shell/services/chat-send.service.ts
+++ b/src/app/features/shell/services/chat-send.service.ts
@@ -1,0 +1,128 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TranslateService } from '@ngx-translate/core';
+import { finalize } from 'rxjs';
+import { ChatStateService } from './chat-state.service';
+import { ChatApiService } from './chat-api.service';
+
+/** Optional lifecycle hooks for a chat send. */
+export interface ChatSendCallbacks {
+  /** Invoked once the request settles (success OR error) — e.g. to clear a
+   *  component `sending` flag and trigger a scroll. */
+  onSettled?: () => void;
+}
+
+/**
+ * ChatSendService
+ * ---------------
+ * Single, canonical chat-send flow shared by the shell {@link ChatPanelComponent}
+ * and the dashboard assistant strip. Records the user message, dispatches to the
+ * backend, and writes the reply — or a logged troubleshooting message on failure —
+ * to the root {@link ChatStateService}.
+ *
+ * Root scoped on purpose: the request is NOT tied to any component's `DestroyRef`,
+ * so the reply still lands in the always-visible shell chat panel even if the
+ * originating component is destroyed mid-request (e.g. a dashboard quick-action
+ * navigates away). Both call sites therefore behave identically — including
+ * console logging and the correlation-id/backend-code troubleshooting message.
+ */
+@Injectable({ providedIn: 'root' })
+export class ChatSendService {
+  private static readonly CORRELATION_ID_HEADER = 'X-Correlation-Id';
+
+  private readonly chatState = inject(ChatStateService);
+  private readonly chatApi = inject(ChatApiService);
+  private readonly translateService = inject(TranslateService);
+
+  /**
+   * Send a chat message through the canonical flow.
+   *
+   * @param text      already-trimmed, non-empty message text
+   * @param callbacks optional lifecycle hooks (see {@link ChatSendCallbacks})
+   */
+  send(text: string, callbacks?: ChatSendCallbacks): void {
+    this.chatState.addUserMessage(text);
+
+    this.chatApi
+      .sendMessage({ message: text })
+      .pipe(finalize(() => callbacks?.onSettled?.()))
+      .subscribe({
+        next: resp => this.chatState.addSystemMessage(resp.response),
+        error: error => this.handleSendFailure(error),
+      });
+  }
+
+  private handleSendFailure(error: unknown): void {
+    this.logChatFailure(error);
+    this.chatState.addSystemMessage(this.translateService.instant('SHELL.CHAT.ERROR_BACKEND'));
+
+    const troubleshootingMessage = this.buildTroubleshootingMessage(error);
+    if (troubleshootingMessage) {
+      this.chatState.addSystemMessage(troubleshootingMessage);
+    }
+  }
+
+  private buildTroubleshootingMessage(error: unknown): string {
+    if (!(error instanceof HttpErrorResponse)) {
+      return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING_GENERIC');
+    }
+
+    const details = [
+      this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_STATUS', { status: error.status }),
+      this.buildBackendCodeDetail(error),
+      this.buildCorrelationIdDetail(error),
+    ].filter((detail): detail is string => typeof detail === 'string' && detail.trim().length > 0);
+
+    if (details.length === 0) {
+      return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING_GENERIC');
+    }
+
+    return this.translateService.instant('SHELL.CHAT.ERROR_TROUBLESHOOTING', {
+      details: details.join(' '),
+    });
+  }
+
+  private buildBackendCodeDetail(error: HttpErrorResponse): string | null {
+    const backendCode = this.extractBackendCode(error.error);
+    if (!backendCode) {
+      return null;
+    }
+
+    return this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_CODE', { code: backendCode });
+  }
+
+  private buildCorrelationIdDetail(error: HttpErrorResponse): string | null {
+    const correlationId = error.headers.get(ChatSendService.CORRELATION_ID_HEADER);
+    if (!correlationId) {
+      return null;
+    }
+
+    return this.translateService.instant('SHELL.CHAT.ERROR_DETAIL_CORRELATION_ID', {
+      correlationId,
+    });
+  }
+
+  private extractBackendCode(errorBody: unknown): string | null {
+    if (!errorBody || typeof errorBody !== 'object') {
+      return null;
+    }
+
+    const code = (errorBody as { code?: unknown }).code;
+    return typeof code === 'string' && code.trim().length > 0 ? code.trim() : null;
+  }
+
+  private logChatFailure(error: unknown): void {
+    if (error instanceof HttpErrorResponse) {
+      console.error('Chat backend request failed', {
+        status: error.status,
+        url: error.url,
+        correlationId: error.headers.get(ChatSendService.CORRELATION_ID_HEADER),
+        backendCode: this.extractBackendCode(error.error),
+        errorBody: error.error,
+      });
+      return;
+    }
+
+    console.error('Chat backend request failed', { error });
+  }
+}

--- a/src/app/features/shopmgmt/pages/appointment-assignment/appointment-assignment-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-assignment/appointment-assignment-page.component.html
@@ -2,43 +2,48 @@
   <h2>{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.TITLE' | translate }}</h2>
 </div>
 
-<ng-container *ngIf="loading()">
+@if (loading()) {
   <div class="loading-state">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.LOADING' | translate }}</div>
-</ng-container>
+}
 
-<ng-container *ngIf="!loading()">
-  <div *ngIf="error()" class="error-banner">{{ error()! | translate }}</div>
-  <div *ngIf="sseError()" class="sse-error-banner">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.LIVE_UPDATES_UNAVAILABLE' | translate }}</div>
-  <div *ngIf="showUpdateNotification()" class="update-notification">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.UPDATED' | translate }}</div>
-
-  <ng-container *ngIf="assignment(); else emptyTpl">
+@if (!loading()) {
+  @if (error()) {
+    <div class="error-banner">{{ error()! | translate }}</div>
+  }
+  @if (sseError()) {
+    <div class="sse-error-banner">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.LIVE_UPDATES_UNAVAILABLE' | translate }}</div>
+  }
+  @if (showUpdateNotification()) {
+    <div class="update-notification">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.UPDATED' | translate }}</div>
+  }
+  @if (assignment()) {
     <div class="assignment-section">
       <div class="assignment-type-label">{{ assignment()!.assignmentType }}</div>
-
-      <ng-container *ngIf="assignment()!.assignmentType === 'BAY'">
+      @if (assignment()!.assignmentType === 'BAY') {
         <div class="bay-details">
           <span>{{ assignment()!.bayIdentifier }}</span>
-          <span *ngIf="assignment()!.bayName">&nbsp;— {{ assignment()!.bayName }}</span>
+          @if (assignment()!.bayName) {
+            <span>&nbsp;— {{ assignment()!.bayName }}</span>
+          }
         </div>
-      </ng-container>
-
-      <ng-container *ngIf="assignment()!.assignmentType === 'MOBILE_UNIT'">
+      }
+      @if (assignment()!.assignmentType === 'MOBILE_UNIT') {
         <div class="mobile-unit-details">
           <span>{{ assignment()!.mobileUnitId }}</span>
         </div>
-      </ng-container>
-
-      <div *ngIf="assignment()!.mechanic" class="mechanic-display">
-        {{ mechanicDisplay }}
-      </div>
-
-      <div *ngIf="assignment()!.notes" class="assignment-notes">
-        {{ assignment()!.notes }}
-      </div>
+      }
+      @if (assignment()!.mechanic) {
+        <div class="mechanic-display">
+          {{ mechanicDisplay }}
+        </div>
+      }
+      @if (assignment()!.notes) {
+        <div class="assignment-notes">
+          {{ assignment()!.notes }}
+        </div>
+      }
     </div>
-  </ng-container>
-
-  <ng-template #emptyTpl>
+  } @else {
     <div class="empty-state empty-assignment">{{ 'SHOPMGMT.APPOINTMENT_ASSIGNMENT.EMPTY' | translate }}</div>
-  </ng-template>
-</ng-container>
+  }
+}

--- a/src/app/features/shopmgmt/pages/appointment-assignment/appointment-assignment-page.component.ts
+++ b/src/app/features/shopmgmt/pages/appointment-assignment/appointment-assignment-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, signal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
 import { forkJoin } from 'rxjs';
@@ -9,7 +9,7 @@ import type { AppointmentDetail, AssignmentDetail } from '../../models/appointme
 @Component({
   selector: 'app-appointment-assignment-page',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './appointment-assignment-page.component.html',
   styleUrl: './appointment-assignment-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/appointment-conflict-override/appointment-conflict-override-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-conflict-override/appointment-conflict-override-page.component.html
@@ -2,16 +2,26 @@
   <h2>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.TITLE' | translate }}</h2>
 </section>
 
-<div *ngIf="rescheduleSuccess()" class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.SUCCESS.RESCHEDULE' | translate }}</div>
-<div *ngIf="overrideSuccess()" class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.SUCCESS.OVERRIDE' | translate }}</div>
-<div *ngIf="rescheduleError()" class="error-banner">{{ rescheduleError()! | translate }}</div>
-<div *ngIf="overrideError()" class="error-banner">{{ overrideError()! | translate }}</div>
+@if (rescheduleSuccess()) {
+  <div class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.SUCCESS.RESCHEDULE' | translate }}</div>
+}
+@if (overrideSuccess()) {
+  <div class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.SUCCESS.OVERRIDE' | translate }}</div>
+}
+@if (rescheduleError()) {
+  <div class="error-banner">{{ rescheduleError()! | translate }}</div>
+}
+@if (overrideError()) {
+  <div class="error-banner">{{ overrideError()! | translate }}</div>
+}
 
-<section *ngIf="appointment() as appt" class="appointment-summary">
-  <h3>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.APPOINTMENT' | translate: { id: appt.appointmentId } }}</h3>
-  <p>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.STATUS' | translate }}: {{ appt.status }}</p>
-  <p>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.FACILITY' | translate }}: {{ appt.facilityId }}</p>
-</section>
+@if (appointment(); as appt) {
+  <section class="appointment-summary">
+    <h3>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.APPOINTMENT' | translate: { id: appt.appointmentId } }}</h3>
+    <p>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.STATUS' | translate }}: {{ appt.status }}</p>
+    <p>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.FACILITY' | translate }}: {{ appt.facilityId }}</p>
+  </section>
+}
 
 <form [formGroup]="rescheduleForm" class="reschedule-form" (ngSubmit)="submitReschedule()">
   <div class="form-group">
@@ -30,30 +40,33 @@
   </div>
 
   <button type="submit" class="btn-primary submit-reschedule-btn"
-    [disabled]="rescheduleLoading()">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.RESCHEDULE' | translate }}</button>
+  [disabled]="rescheduleLoading()">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.RESCHEDULE' | translate }}</button>
 </form>
 
-<section *ngIf="showConflictPanel() && hasConflicts()" class="conflict-panel">
-  <h3>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.CONFLICTS' | translate }}</h3>
-
-  <article *ngFor="let conflict of conflicts()" class="conflict-item"
-    [ngClass]="conflict.type === 'HARD' ? 'hard-conflict' : 'soft-conflict'">
-    <strong>{{ conflict.type }}</strong>
-    <p>{{ conflict.message }}</p>
-  </article>
-
-  <button type="button" class="btn-danger enable-override-btn"
+@if (showConflictPanel() && hasConflicts()) {
+  <section class="conflict-panel">
+    <h3>{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.CONFLICTS' | translate }}</h3>
+    @for (conflict of conflicts(); track conflict) {
+      <article class="conflict-item"
+        [ngClass]="conflict.type === 'HARD' ? 'hard-conflict' : 'soft-conflict'">
+        <strong>{{ conflict.type }}</strong>
+        <p>{{ conflict.message }}</p>
+      </article>
+    }
+    <button type="button" class="btn-danger enable-override-btn"
     (click)="enableOverrideMode()">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.ENABLE_OVERRIDE' | translate }}</button>
-</section>
+  </section>
+}
 
-<section *ngIf="overrideMode()" class="override-panel">
-  <form [formGroup]="overrideForm" (ngSubmit)="submitOverride()">
-    <div class="form-group override-reason-field">
-      <label for="override-reason">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.OVERRIDE_REASON' | translate }}</label>
-      <textarea id="override-reason" formControlName="overrideReason" rows="4"></textarea>
-    </div>
-
-    <button type="submit" class="btn-secondary submit-override-btn"
+@if (overrideMode()) {
+  <section class="override-panel">
+    <form [formGroup]="overrideForm" (ngSubmit)="submitOverride()">
+      <div class="form-group override-reason-field">
+        <label for="override-reason">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.OVERRIDE_REASON' | translate }}</label>
+        <textarea id="override-reason" formControlName="overrideReason" rows="4"></textarea>
+      </div>
+      <button type="submit" class="btn-secondary submit-override-btn"
       [disabled]="overrideLoading()">{{ 'SHOPMGMT.APPOINTMENT_CONFLICT_OVERRIDE.SUBMIT_OVERRIDE' | translate }}</button>
-  </form>
-</section>
+    </form>
+  </section>
+}

--- a/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.html
@@ -50,20 +50,24 @@
     <legend class="section-legend">{{ 'SHOPMGMT.APPOINTMENT_CREATE_CRM.SECTION_SERVICE_REQUESTS' | translate }}</legend>
 
     <div formArrayName="serviceRequests">
-      <div *ngFor="let ctrl of serviceRequestsArray.controls; let i = index" class="service-request-row">
-        <input [formControlName]="i" type="text" class="service-request-input"
-          [attr.placeholder]="'SHOPMGMT.APPOINTMENT_CREATE_CRM.SERVICE_REQUEST_PLACEHOLDER' | translate"
-          [name]="'serviceRequest-' + i" />
-        <button type="button" class="btn-remove" (click)="removeServiceRequest(i)"
+      @for (ctrl of serviceRequestsArray.controls; track ctrl; let i = $index) {
+        <div class="service-request-row">
+          <input [formControlName]="i" type="text" class="service-request-input"
+            [attr.placeholder]="'SHOPMGMT.APPOINTMENT_CREATE_CRM.SERVICE_REQUEST_PLACEHOLDER' | translate"
+            [name]="'serviceRequest-' + i" />
+          <button type="button" class="btn-remove" (click)="removeServiceRequest(i)"
           [attr.aria-label]="'SHOPMGMT.APPOINTMENT_CREATE_CRM.REMOVE_SERVICE_ARIA' | translate">&#x2715;</button>
-      </div>
+        </div>
+      }
     </div>
 
     <button type="button" class="btn-add-service"
-      (click)="addServiceRequest()">{{ 'SHOPMGMT.APPOINTMENT_CREATE_CRM.ADD_SERVICE' | translate }}</button>
+    (click)="addServiceRequest()">{{ 'SHOPMGMT.APPOINTMENT_CREATE_CRM.ADD_SERVICE' | translate }}</button>
   </fieldset>
 
-  <div *ngIf="error()" class="error-banner">{{ error()! | translate }}</div>
+  @if (error()) {
+    <div class="error-banner">{{ error()! | translate }}</div>
+  }
 
   <div class="form-actions">
     <button type="submit" class="btn-primary" [disabled]="createForm.invalid || loading()">

--- a/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.ts
+++ b/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, signal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ReactiveFormsModule, FormGroup, FormControl, Validators, FormArray } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -10,7 +10,7 @@ import type { CreateAppointmentPayload } from '../../models/appointment.models';
 @Component({
   selector: 'app-appointment-create-crm-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './appointment-create-crm-page.component.html',
   styleUrl: './appointment-create-crm-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/appointment-create/appointment-create-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-create/appointment-create-page.component.html
@@ -12,16 +12,24 @@
   <span>{{ facilityTimeZoneId() }}</span>
 </div>
 
-<div *ngIf="errorMessage()" class="error-banner">
-  {{ errorMessage()! | translate }}
-  <span *ngIf="correlationId()" class="correlation-id">{{ correlationId() }}</span>
-  <a *ngIf="showBackToSource()" class="back-to-source" href="#">{{ 'SHOPMGMT.APPOINTMENT_CREATE.BACK_TO_SOURCE' | translate }}</a>
-</div>
+@if (errorMessage()) {
+  <div class="error-banner">
+    {{ errorMessage()! | translate }}
+    @if (correlationId()) {
+      <span class="correlation-id">{{ correlationId() }}</span>
+    }
+    @if (showBackToSource()) {
+      <a class="back-to-source" href="#">{{ 'SHOPMGMT.APPOINTMENT_CREATE.BACK_TO_SOURCE' | translate }}</a>
+    }
+  </div>
+}
 
-<div *ngIf="showEligibilityError()" class="eligibility-error">
-  {{ 'SHOPMGMT.APPOINTMENT_CREATE.ELIGIBILITY_ERROR' | translate }}
-  <a class="back-to-source" href="#">{{ 'SHOPMGMT.APPOINTMENT_CREATE.BACK_TO_SOURCE' | translate }}</a>
-</div>
+@if (showEligibilityError()) {
+  <div class="eligibility-error">
+    {{ 'SHOPMGMT.APPOINTMENT_CREATE.ELIGIBILITY_ERROR' | translate }}
+    <a class="back-to-source" href="#">{{ 'SHOPMGMT.APPOINTMENT_CREATE.BACK_TO_SOURCE' | translate }}</a>
+  </div>
+}
 
 <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
   <div class="form-group">
@@ -36,29 +44,39 @@
       formControlName="scheduledEndDateTime" />
   </div>
 
-  <ng-container *ngIf="conflicts().length > 0">
+  @if (conflicts().length > 0) {
     <div class="conflict-panel">
-      <div *ngFor="let c of conflicts()">
-        <div *ngIf="c.type === 'HARD'" class="hard-conflict">
-          <span class="severity-badge">{{ 'SHOPMGMT.APPOINTMENT_CREATE.HARD' | translate }}</span> {{ c.message }}
+      @for (c of conflicts(); track c) {
+        <div>
+          @if (c.type === 'HARD') {
+            <div class="hard-conflict">
+              <span class="severity-badge">{{ 'SHOPMGMT.APPOINTMENT_CREATE.HARD' | translate }}</span> {{ c.message }}
+            </div>
+          }
+          @if (c.type === 'SOFT') {
+            <div class="soft-conflict">
+              <span class="severity-badge">{{ 'SHOPMGMT.APPOINTMENT_CREATE.SOFT' | translate }}</span> {{ c.message }}
+            </div>
+          }
         </div>
-        <div *ngIf="c.type === 'SOFT'" class="soft-conflict">
-          <span class="severity-badge">{{ 'SHOPMGMT.APPOINTMENT_CREATE.SOFT' | translate }}</span> {{ c.message }}
-        </div>
-      </div>
+      }
     </div>
-  </ng-container>
+  }
 
-  <div *ngIf="hasSoftOnly()" class="override-section">
-    <label>
-      <input type="checkbox" (change)="overrideEnabled.set($any($event.target).checked)" />
-      {{ 'SHOPMGMT.APPOINTMENT_CREATE.OVERRIDE_SOFT' | translate }}
-    </label>
-    <div *ngIf="overrideEnabled()" class="override-reason form-group">
-      <label for="overrideReason">{{ 'SHOPMGMT.APPOINTMENT_CREATE.OVERRIDE_REASON' | translate }}</label>
-      <textarea id="overrideReason" name="overrideReason" formControlName="overrideReason" rows="2"></textarea>
+  @if (hasSoftOnly()) {
+    <div class="override-section">
+      <label>
+        <input type="checkbox" (change)="overrideEnabled.set($any($event.target).checked)" />
+        {{ 'SHOPMGMT.APPOINTMENT_CREATE.OVERRIDE_SOFT' | translate }}
+      </label>
+      @if (overrideEnabled()) {
+        <div class="override-reason form-group">
+          <label for="overrideReason">{{ 'SHOPMGMT.APPOINTMENT_CREATE.OVERRIDE_REASON' | translate }}</label>
+          <textarea id="overrideReason" name="overrideReason" formControlName="overrideReason" rows="2"></textarea>
+        </div>
+      }
     </div>
-  </div>
+  }
 
   <div class="action-row">
     <button type="submit" [disabled]="isSubmitDisabled">{{ 'SHOPMGMT.APPOINTMENT_CREATE.CREATE' | translate }}</button>

--- a/src/app/features/shopmgmt/pages/appointment-create/appointment-create-page.component.ts
+++ b/src/app/features/shopmgmt/pages/appointment-create/appointment-create-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, signal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -10,7 +10,7 @@ import type { Conflict } from '../../models/appointment.models';
 @Component({
   selector: 'app-appointment-create-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './appointment-create-page.component.html',
   styleUrl: './appointment-create-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/appointment-dispatch-assign/appointment-dispatch-assign-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-dispatch-assign/appointment-dispatch-assign-page.component.html
@@ -2,21 +2,29 @@
   <h2>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.TITLE' | translate }}</h2>
 </section>
 
-<div *ngIf="submitSuccess()" class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.SUCCESS' | translate }}</div>
-<div *ngIf="submitError()" class="error-banner">{{ submitError()! | translate }}</div>
+@if (submitSuccess()) {
+  <div class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.SUCCESS' | translate }}</div>
+}
+@if (submitError()) {
+  <div class="error-banner">{{ submitError()! | translate }}</div>
+}
 
-<section *ngIf="appointment() as appt" class="appointment-header">
-  <h3>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.APPOINTMENT' | translate: { id: appt.appointmentId } }}</h3>
-  <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.STATUS' | translate }}: {{ appt.status }}</p>
-  <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.FACILITY' | translate }}: {{ appt.facilityId }}</p>
-</section>
+@if (appointment(); as appt) {
+  <section class="appointment-header">
+    <h3>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.APPOINTMENT' | translate: { id: appt.appointmentId } }}</h3>
+    <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.STATUS' | translate }}: {{ appt.status }}</p>
+    <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.FACILITY' | translate }}: {{ appt.facilityId }}</p>
+  </section>
+}
 
 <section class="assignment-history">
   <h3>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.ASSIGNMENT_HISTORY' | translate }}</h3>
-  <article *ngFor="let assignment of assignments()" class="assignment-item">
-    <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.ROLE' | translate }}: {{ getAssignmentRole(assignment) }}</p>
-    <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.MECHANIC' | translate }}: {{ assignment.mechanic?.displayName ?? assignment.mechanic?.mechanicId }}</p>
-  </article>
+  @for (assignment of assignments(); track assignment) {
+    <article class="assignment-item">
+      <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.ROLE' | translate }}: {{ getAssignmentRole(assignment) }}</p>
+      <p>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.MECHANIC' | translate }}: {{ assignment.mechanic?.displayName ?? assignment.mechanic?.mechanicId }}</p>
+    </article>
+  }
 </section>
 
 <form [formGroup]="assignForm" class="create-form" (ngSubmit)="submitAssignment()">
@@ -39,15 +47,18 @@
   </div>
 
   <button type="submit" class="btn-primary submit-assignment-btn"
-    [disabled]="submitLoading()">{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.CREATE' | translate }}</button>
+  [disabled]="submitLoading()">{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.CREATE' | translate }}</button>
 </form>
 
-<section *ngIf="conflicts().length > 0" class="conflict-panel">
-  <h3>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.CONFLICTS' | translate }}</h3>
-
-  <article *ngFor="let conflict of conflicts()" class="conflict-item"
-    [ngClass]="conflict.type === 'HARD' ? 'hard-conflict' : 'soft-conflict'">
-    <strong>{{ conflict.type }}</strong>
-    <p>{{ conflict.message }}</p>
-  </article>
-</section>
+@if (conflicts().length > 0) {
+  <section class="conflict-panel">
+    <h3>{{ 'SHOPMGMT.APPOINTMENT_DISPATCH_ASSIGN.CONFLICTS' | translate }}</h3>
+    @for (conflict of conflicts(); track conflict) {
+      <article class="conflict-item"
+        [ngClass]="conflict.type === 'HARD' ? 'hard-conflict' : 'soft-conflict'">
+        <strong>{{ conflict.type }}</strong>
+        <p>{{ conflict.message }}</p>
+      </article>
+    }
+  </section>
+}

--- a/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.html
@@ -1,136 +1,163 @@
 <div class="page-header">
   <h2>{{ 'SHOPMGMT.APPOINTMENT_EDIT.TITLE' | translate }}</h2>
-  <span *ngIf="appointment()" class="appt-id">{{ appointment()!.appointmentId }}</span>
+  @if (appointment()) {
+    <span class="appt-id">{{ appointment()!.appointmentId }}</span>
+  }
 </div>
 
-<ng-container *ngIf="loading()">
+@if (loading()) {
   <div class="loading-state">{{ 'SHOPMGMT.APPOINTMENT_EDIT.LOADING' | translate }}</div>
-</ng-container>
+}
 
-<ng-container *ngIf="!loading()">
-  <div *ngIf="rescheduleSuccess()" class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE_SUCCESS' | translate }}</div>
-  <div *ngIf="cancelSuccess()" class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_SUCCESS' | translate }}</div>
-
-  <div *ngIf="appointment()" class="appointment-summary">
-    <div class="summary-row">
-      <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.STATUS' | translate }}</span>
-      <span class="value status-badge">{{ appointment()!.status }}</span>
+@if (!loading()) {
+  @if (rescheduleSuccess()) {
+    <div class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE_SUCCESS' | translate }}</div>
+  }
+  @if (cancelSuccess()) {
+    <div class="success-banner">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_SUCCESS' | translate }}</div>
+  }
+  @if (appointment()) {
+    <div class="appointment-summary">
+      <div class="summary-row">
+        <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.STATUS' | translate }}</span>
+        <span class="value status-badge">{{ appointment()!.status }}</span>
+      </div>
+      @if (appointment()!.scheduledStart) {
+        <div class="summary-row">
+          <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.SCHEDULED_START' | translate }}</span>
+          <span class="value">{{ appointment()!.scheduledStart }}</span>
+        </div>
+      }
+      @if (appointment()!.scheduledEnd) {
+        <div class="summary-row">
+          <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.SCHEDULED_END' | translate }}</span>
+          <span class="value">{{ appointment()!.scheduledEnd }}</span>
+        </div>
+      }
+      <div class="summary-row">
+        <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.FACILITY' | translate }}</span>
+        <span class="value">{{ appointment()!.facilityId }}</span>
+      </div>
     </div>
-    <div class="summary-row" *ngIf="appointment()!.scheduledStart">
-      <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.SCHEDULED_START' | translate }}</span>
-      <span class="value">{{ appointment()!.scheduledStart }}</span>
-    </div>
-    <div class="summary-row" *ngIf="appointment()!.scheduledEnd">
-      <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.SCHEDULED_END' | translate }}</span>
-      <span class="value">{{ appointment()!.scheduledEnd }}</span>
-    </div>
-    <div class="summary-row">
-      <span class="label">{{ 'SHOPMGMT.APPOINTMENT_EDIT.FACILITY' | translate }}</span>
-      <span class="value">{{ appointment()!.facilityId }}</span>
-    </div>
-  </div>
-
+  }
   <div class="actions-row">
-    <ng-container *ngIf="canModify; else disabledActions">
+    @if (canModify) {
       <button class="btn-primary" (click)="openReschedule()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE' | translate }}</button>
       <button class="btn-danger" (click)="openCancel()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_APPOINTMENT' | translate }}</button>
-    </ng-container>
-    <ng-template #disabledActions>
+    } @else {
       <button class="btn-primary" disabled>{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE' | translate }}</button>
       <button class="btn-danger" disabled>{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_APPOINTMENT' | translate }}</button>
       <span class="actions-helper-text">
         {{ 'SHOPMGMT.APPOINTMENT_EDIT.CANNOT_MODIFY' | translate: { status: appointment()?.status } }}
       </span>
-    </ng-template>
+    }
   </div>
-
   <div class="audit-section">
     <h3>{{ 'SHOPMGMT.APPOINTMENT_EDIT.AUDIT_HISTORY' | translate }}</h3>
-    <div *ngIf="auditUnavailable()" class="audit-unavailable">
-      {{ 'SHOPMGMT.APPOINTMENT_EDIT.AUDIT_UNAVAILABLE' | translate }}
-    </div>
-    <div *ngIf="!auditUnavailable()">
-      <div *ngIf="auditEntries().length === 0" class="audit-empty">{{ 'SHOPMGMT.APPOINTMENT_EDIT.AUDIT_EMPTY' | translate }}</div>
-      <div *ngFor="let entry of auditEntries()" class="audit-entry">
-        <span class="audit-timestamp">{{ entry.timestamp }}</span>
-        <span class="audit-actor">{{ entry.actor }}</span>
-        <span class="audit-action">{{ entry.action }}</span>
-        <span class="audit-details">{{ entry.details }}</span>
+    @if (auditUnavailable()) {
+      <div class="audit-unavailable">
+        {{ 'SHOPMGMT.APPOINTMENT_EDIT.AUDIT_UNAVAILABLE' | translate }}
       </div>
-    </div>
+    }
+    @if (!auditUnavailable()) {
+      <div>
+        @if (auditEntries().length === 0) {
+          <div class="audit-empty">{{ 'SHOPMGMT.APPOINTMENT_EDIT.AUDIT_EMPTY' | translate }}</div>
+        }
+        @for (entry of auditEntries(); track entry) {
+          <div class="audit-entry">
+            <span class="audit-timestamp">{{ entry.timestamp }}</span>
+            <span class="audit-actor">{{ entry.actor }}</span>
+            <span class="audit-action">{{ entry.action }}</span>
+            <span class="audit-details">{{ entry.details }}</span>
+          </div>
+        }
+      </div>
+    }
   </div>
-</ng-container>
+}
 
-<div *ngIf="showRescheduleModal()" class="modal-overlay">
-  <div class="modal reschedule-modal" role="dialog" aria-modal="true">
-    <div class="modal-header">
-      <h3>{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE_APPOINTMENT' | translate }}</h3>
-      <button class="modal-close" (click)="closeReschedule()" [attr.aria-label]="'SHOPMGMT.APPOINTMENT_EDIT.CLOSE' | translate">&#x2715;</button>
-    </div>
-    <form [formGroup]="rescheduleForm" (ngSubmit)="submitReschedule()" novalidate>
-      <div class="form-group">
-        <label for="rsStart">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NEW_START' | translate }}</label>
-        <input id="rsStart" name="scheduledStartDateTime" type="datetime-local"
-          formControlName="scheduledStartDateTime" />
+@if (showRescheduleModal()) {
+  <div class="modal-overlay">
+    <div class="modal reschedule-modal" role="dialog" aria-modal="true">
+      <div class="modal-header">
+        <h3>{{ 'SHOPMGMT.APPOINTMENT_EDIT.RESCHEDULE_APPOINTMENT' | translate }}</h3>
+        <button class="modal-close" (click)="closeReschedule()" [attr.aria-label]="'SHOPMGMT.APPOINTMENT_EDIT.CLOSE' | translate">&#x2715;</button>
       </div>
-      <div class="form-group">
-        <label for="rsEnd">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NEW_END' | translate }}</label>
-        <input id="rsEnd" name="scheduledEndDateTime" type="datetime-local" formControlName="scheduledEndDateTime" />
-      </div>
-      <div class="form-group">
-        <label for="rsReason">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASON' | translate }}</label>
-        <input id="rsReason" name="reason" type="text" formControlName="reason" />
-      </div>
-
-      <div *ngIf="rescheduleError()" class="error-banner">{{ rescheduleError()! | translate }}</div>
-
-      <div *ngIf="rescheduleConflicts().length > 0" class="conflict-panel">
-        <div *ngFor="let c of rescheduleConflicts()">
-          <div *ngIf="c.type === 'HARD'" class="hard-conflict">{{ c.message }}</div>
-          <div *ngIf="c.type === 'SOFT'" class="soft-conflict">{{ c.message }}</div>
+      <form [formGroup]="rescheduleForm" (ngSubmit)="submitReschedule()" novalidate>
+        <div class="form-group">
+          <label for="rsStart">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NEW_START' | translate }}</label>
+          <input id="rsStart" name="scheduledStartDateTime" type="datetime-local"
+            formControlName="scheduledStartDateTime" />
         </div>
-      </div>
-
-      <div class="modal-actions">
-        <button type="button" class="btn-secondary" (click)="closeReschedule()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL' | translate }}</button>
-        <button type="submit" class="btn-primary" [disabled]="rescheduleForm.invalid || rescheduleLoading()">
-          {{ 'SHOPMGMT.APPOINTMENT_EDIT.SAVE' | translate }}
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<div *ngIf="showCancelModal()" class="modal-overlay">
-  <div class="modal cancel-modal" role="dialog" aria-modal="true">
-    <div class="modal-header">
-      <h3>{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_APPOINTMENT' | translate }}</h3>
-      <button class="modal-close" (click)="closeCancel()" [attr.aria-label]="'SHOPMGMT.APPOINTMENT_EDIT.CLOSE' | translate">&#x2715;</button>
+        <div class="form-group">
+          <label for="rsEnd">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NEW_END' | translate }}</label>
+          <input id="rsEnd" name="scheduledEndDateTime" type="datetime-local" formControlName="scheduledEndDateTime" />
+        </div>
+        <div class="form-group">
+          <label for="rsReason">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASON' | translate }}</label>
+          <input id="rsReason" name="reason" type="text" formControlName="reason" />
+        </div>
+        @if (rescheduleError()) {
+          <div class="error-banner">{{ rescheduleError()! | translate }}</div>
+        }
+        @if (rescheduleConflicts().length > 0) {
+          <div class="conflict-panel">
+            @for (c of rescheduleConflicts(); track c) {
+              <div>
+                @if (c.type === 'HARD') {
+                  <div class="hard-conflict">{{ c.message }}</div>
+                }
+                @if (c.type === 'SOFT') {
+                  <div class="soft-conflict">{{ c.message }}</div>
+                }
+              </div>
+            }
+          </div>
+        }
+        <div class="modal-actions">
+          <button type="button" class="btn-secondary" (click)="closeReschedule()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL' | translate }}</button>
+          <button type="submit" class="btn-primary" [disabled]="rescheduleForm.invalid || rescheduleLoading()">
+            {{ 'SHOPMGMT.APPOINTMENT_EDIT.SAVE' | translate }}
+          </button>
+        </div>
+      </form>
     </div>
-    <form [formGroup]="cancelForm" (ngSubmit)="submitCancel()" novalidate>
-      <div class="form-group">
-        <label for="cancelReason">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCELLATION_REASON' | translate }}</label>
-        <select id="cancelReason" name="cancellationReason" formControlName="cancellationReason">
-          <option value="CUSTOMER_REQUEST">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.CUSTOMER_REQUEST' | translate }}</option>
-          <option value="TECHNICIAN_UNAVAILABLE">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.TECHNICIAN_UNAVAILABLE' | translate }}</option>
-          <option value="WEATHER">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.WEATHER' | translate }}</option>
-          <option value="VEHICLE_NOT_READY">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.VEHICLE_NOT_READY' | translate }}</option>
-          <option value="OTHER">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.OTHER' | translate }}</option>
-        </select>
-      </div>
-      <div class="form-group">
-        <label for="cancelNotes">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NOTES_OPTIONAL' | translate }}</label>
-        <textarea id="cancelNotes" name="notes" formControlName="notes" rows="3"></textarea>
-      </div>
-
-      <div *ngIf="cancelError()" class="error-banner">{{ cancelError()! | translate }}</div>
-
-      <div class="modal-actions">
-        <button type="button" class="btn-secondary" (click)="closeCancel()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.BACK' | translate }}</button>
-        <button type="submit" class="btn-danger" [disabled]="cancelForm.invalid || cancelLoading()">
-          {{ 'SHOPMGMT.APPOINTMENT_EDIT.CONFIRM_CANCEL' | translate }}
-        </button>
-      </div>
-    </form>
   </div>
-</div>
+}
+
+@if (showCancelModal()) {
+  <div class="modal-overlay">
+    <div class="modal cancel-modal" role="dialog" aria-modal="true">
+      <div class="modal-header">
+        <h3>{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCEL_APPOINTMENT' | translate }}</h3>
+        <button class="modal-close" (click)="closeCancel()" [attr.aria-label]="'SHOPMGMT.APPOINTMENT_EDIT.CLOSE' | translate">&#x2715;</button>
+      </div>
+      <form [formGroup]="cancelForm" (ngSubmit)="submitCancel()" novalidate>
+        <div class="form-group">
+          <label for="cancelReason">{{ 'SHOPMGMT.APPOINTMENT_EDIT.CANCELLATION_REASON' | translate }}</label>
+          <select id="cancelReason" name="cancellationReason" formControlName="cancellationReason">
+            <option value="CUSTOMER_REQUEST">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.CUSTOMER_REQUEST' | translate }}</option>
+            <option value="TECHNICIAN_UNAVAILABLE">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.TECHNICIAN_UNAVAILABLE' | translate }}</option>
+            <option value="WEATHER">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.WEATHER' | translate }}</option>
+            <option value="VEHICLE_NOT_READY">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.VEHICLE_NOT_READY' | translate }}</option>
+            <option value="OTHER">{{ 'SHOPMGMT.APPOINTMENT_EDIT.REASONS.OTHER' | translate }}</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="cancelNotes">{{ 'SHOPMGMT.APPOINTMENT_EDIT.NOTES_OPTIONAL' | translate }}</label>
+          <textarea id="cancelNotes" name="notes" formControlName="notes" rows="3"></textarea>
+        </div>
+        @if (cancelError()) {
+          <div class="error-banner">{{ cancelError()! | translate }}</div>
+        }
+        <div class="modal-actions">
+          <button type="button" class="btn-secondary" (click)="closeCancel()">{{ 'SHOPMGMT.APPOINTMENT_EDIT.BACK' | translate }}</button>
+          <button type="submit" class="btn-danger" [disabled]="cancelForm.invalid || cancelLoading()">
+            {{ 'SHOPMGMT.APPOINTMENT_EDIT.CONFIRM_CANCEL' | translate }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+}

--- a/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.ts
+++ b/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, signal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
@@ -18,7 +18,7 @@ export interface AuditEntry {
 @Component({
   selector: 'app-appointment-edit-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './appointment-edit-page.component.html',
   styleUrl: './appointment-edit-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/appointment-reschedule/appointment-reschedule-page.component.html
+++ b/src/app/features/shopmgmt/pages/appointment-reschedule/appointment-reschedule-page.component.html
@@ -2,32 +2,32 @@
   <h2>{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.TITLE' | translate }}</h2>
 </div>
 
-<ng-container *ngIf="loading()">
+@if (loading()) {
   <div class="loading-state">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.LOADING' | translate }}</div>
-</ng-container>
+}
 
-<ng-container *ngIf="!loading()">
-  <div *ngIf="successMessage()" class="success-banner">
-    {{ successMessage()! | translate }}
-  </div>
-
-  <div *ngIf="versionMismatch()" class="version-mismatch-prompt">
-    {{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.VERSION_MISMATCH' | translate }}
-  </div>
-
+@if (!loading()) {
+  @if (successMessage()) {
+    <div class="success-banner">
+      {{ successMessage()! | translate }}
+    </div>
+  }
+  @if (versionMismatch()) {
+    <div class="version-mismatch-prompt">
+      {{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.VERSION_MISMATCH' | translate }}
+    </div>
+  }
   <form [formGroup]="form" (ngSubmit)="submit()" novalidate>
     <div class="form-group">
       <label for="scheduledStartDateTime">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.NEW_START' | translate }}</label>
       <input id="scheduledStartDateTime" name="scheduledStartDateTime" type="datetime-local"
         formControlName="scheduledStartDateTime" />
     </div>
-
     <div class="form-group">
       <label for="scheduledEndDateTime">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.NEW_END' | translate }}</label>
       <input id="scheduledEndDateTime" name="scheduledEndDateTime" type="datetime-local"
         formControlName="scheduledEndDateTime" />
     </div>
-
     <div class="form-group">
       <label for="reason">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.RESCHEDULE_REASON' | translate }}</label>
       <select id="reason" name="reason" formControlName="reason">
@@ -38,45 +38,54 @@
         <option value="OTHER">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.REASONS.OTHER' | translate }}</option>
       </select>
     </div>
-
     <div class="form-group">
       <label for="notes">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.NOTES' | translate }}</label>
       <textarea id="notes" name="notes" formControlName="notes" rows="3"></textarea>
     </div>
-
-    <ng-container *ngIf="fieldErrors().length > 0">
-      <div *ngFor="let fe of fieldErrors()" class="field-error">
-        {{ fe.message | translate }}
-      </div>
-    </ng-container>
-
-    <ng-container *ngIf="conflicts().length > 0">
+    @if (fieldErrors().length > 0) {
+      @for (fe of fieldErrors(); track fe) {
+        <div class="field-error">
+          {{ fe.message | translate }}
+        </div>
+      }
+    }
+    @if (conflicts().length > 0) {
       <div class="conflict-panel">
-        <div *ngFor="let c of conflicts()">
-          <div *ngIf="c.type === 'HARD'" class="hard-conflict">{{ c.message }}</div>
-          <div *ngIf="c.type === 'SOFT'" class="soft-conflict">{{ c.message }}</div>
-        </div>
-
-        <div *ngIf="suggestedAlternatives().length > 0" class="suggested-slots">
-          <div *ngFor="let slot of suggestedAlternatives()" class="suggested-slot">
-            {{ slot.scheduledStartDateTime }} &ndash; {{ slot.scheduledEndDateTime }}
+        @for (c of conflicts(); track c) {
+          <div>
+            @if (c.type === 'HARD') {
+              <div class="hard-conflict">{{ c.message }}</div>
+            }
+            @if (c.type === 'SOFT') {
+              <div class="soft-conflict">{{ c.message }}</div>
+            }
           </div>
-        </div>
+        }
+        @if (suggestedAlternatives().length > 0) {
+          <div class="suggested-slots">
+            @for (slot of suggestedAlternatives(); track slot) {
+              <div class="suggested-slot">
+                {{ slot.scheduledStartDateTime }} &ndash; {{ slot.scheduledEndDateTime }}
+              </div>
+            }
+          </div>
+        }
       </div>
-    </ng-container>
-
-    <div *ngIf="showOverrideReason()" class="override-reason-field form-group">
-      <label for="overrideReason">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.OVERRIDE_REASON' | translate }}</label>
-      <textarea id="overrideReason" name="overrideReason" formControlName="overrideReason" rows="2"></textarea>
-    </div>
-
-    <div *ngIf="showApprovalReason()" class="approval-reason-field form-group">
-      <label for="approvalReason">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.APPROVAL_REASON' | translate }}</label>
-      <textarea id="approvalReason" name="approvalReason" formControlName="approvalReason" rows="2"></textarea>
-    </div>
-
+    }
+    @if (showOverrideReason()) {
+      <div class="override-reason-field form-group">
+        <label for="overrideReason">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.OVERRIDE_REASON' | translate }}</label>
+        <textarea id="overrideReason" name="overrideReason" formControlName="overrideReason" rows="2"></textarea>
+      </div>
+    }
+    @if (showApprovalReason()) {
+      <div class="approval-reason-field form-group">
+        <label for="approvalReason">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.APPROVAL_REASON' | translate }}</label>
+        <textarea id="approvalReason" name="approvalReason" formControlName="approvalReason" rows="2"></textarea>
+      </div>
+    }
     <div class="action-row">
       <button type="submit" [disabled]="isSubmitDisabled">{{ 'SHOPMGMT.APPOINTMENT_RESCHEDULE.RESCHEDULE' | translate }}</button>
     </div>
   </form>
-</ng-container>
+}

--- a/src/app/features/shopmgmt/pages/appointment-reschedule/appointment-reschedule-page.component.ts
+++ b/src/app/features/shopmgmt/pages/appointment-reschedule/appointment-reschedule-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, signal, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
@@ -10,7 +10,7 @@ import type { AppointmentDetail, Conflict, TimeSlot } from '../../models/appoint
 @Component({
   selector: 'app-appointment-reschedule-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './appointment-reschedule-page.component.html',
   styleUrl: './appointment-reschedule-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/dispatch-board/dispatch-board-page.component.html
+++ b/src/app/features/shopmgmt/pages/dispatch-board/dispatch-board-page.component.html
@@ -26,7 +26,7 @@
             [attr.aria-expanded]="showSuggestions() && locationSuggestions().length > 0"
             aria-autocomplete="list"
             aria-haspopup="listbox"
-          />
+            />
           @if (showSuggestions() && locationSuggestions().length > 0) {
             <ul class="location-suggestions" role="listbox">
               @for (loc of locationSuggestions(); track loc.id) {
@@ -34,7 +34,7 @@
                   class="location-suggestion"
                   role="option"
                   (mousedown)="selectLocation(loc)"
-                >
+                  >
                   <span class="suggestion-name">{{ loc.name }}</span>
                   @if (loc.code) {
                     <span class="suggestion-code">{{ loc.code }}</span>
@@ -60,51 +60,68 @@
       </button>
     </div>
 
-    <div class="last-updated" *ngIf="lastRefreshed()" aria-live="polite">
-      {{ 'SHOPMGMT.DISPATCH_BOARD.LAST_UPDATED' | translate }}: {{ lastRefreshed() | date: 'short' }}
-    </div>
+    @if (lastRefreshed()) {
+      <div class="last-updated" aria-live="polite">
+        {{ 'SHOPMGMT.DISPATCH_BOARD.LAST_UPDATED' | translate }}: {{ lastRefreshed() | date: 'short' }}
+      </div>
+    }
 
-    <div class="banners-row" *ngIf="dataQualityWarning() || isStale()">
-      <output class="data-quality-warning alert alert-warning" *ngIf="dataQualityWarning()" aria-live="polite">
-        {{ 'SHOPMGMT.DISPATCH_BOARD.DATA_QUALITY_WARNING' | translate }}
-      </output>
+    @if (dataQualityWarning() || isStale()) {
+      <div class="banners-row">
+        @if (dataQualityWarning()) {
+          <output class="data-quality-warning alert alert-warning" aria-live="polite">
+            {{ 'SHOPMGMT.DISPATCH_BOARD.DATA_QUALITY_WARNING' | translate }}
+          </output>
+        }
+        @if (isStale()) {
+          <output class="stale-data-banner alert alert-warning" aria-live="polite">
+            {{ 'SHOPMGMT.DISPATCH_BOARD.STALE_DATA' | translate }}
+          </output>
+        }
+      </div>
+    }
 
-      <output class="stale-data-banner alert alert-warning" *ngIf="isStale()" aria-live="polite">
-        {{ 'SHOPMGMT.DISPATCH_BOARD.STALE_DATA' | translate }}
-      </output>
-    </div>
+    @if (loading()) {
+      <div class="loading-state" aria-live="polite">
+        {{ 'SHOPMGMT.DISPATCH_BOARD.LOADING' | translate }}
+      </div>
+    }
 
-    <div class="loading-state" *ngIf="loading()" aria-live="polite">
-      {{ 'SHOPMGMT.DISPATCH_BOARD.LOADING' | translate }}
-    </div>
+    @if (error(); as errorMessage) {
+      <div class="state-panel" role="alert" aria-live="polite">
+        <p>{{ errorMessage | translate }}</p>
+        <button type="button" class="btn-text" (click)="refresh()"
+          [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.RETRY_ARIA' | translate">
+          {{ 'SHOPMGMT.DISPATCH_BOARD.RETRY' | translate }}
+        </button>
+      </div>
+    }
 
-    <div class="state-panel" *ngIf="error() as errorMessage" role="alert" aria-live="polite">
-      <p>{{ errorMessage | translate }}</p>
-      <button type="button" class="btn-text" (click)="refresh()"
-        [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.RETRY_ARIA' | translate">
-        {{ 'SHOPMGMT.DISPATCH_BOARD.RETRY' | translate }}
-      </button>
-    </div>
+    @if (!loading() && !error() && workorders().length === 0) {
+      <div class="empty-state" aria-live="polite">
+        <h2>{{ 'SHOPMGMT.DISPATCH_BOARD.EMPTY_TITLE' | translate }}</h2>
+        <p>{{ 'SHOPMGMT.DISPATCH_BOARD.EMPTY_DESC' | translate }}</p>
+      </div>
+    }
 
-    <div class="empty-state" *ngIf="!loading() && !error() && workorders().length === 0" aria-live="polite">
-      <h2>{{ 'SHOPMGMT.DISPATCH_BOARD.EMPTY_TITLE' | translate }}</h2>
-      <p>{{ 'SHOPMGMT.DISPATCH_BOARD.EMPTY_DESC' | translate }}</p>
-    </div>
-
-    <div class="workorders" *ngIf="!loading() && workorders().length > 0" aria-live="polite">
-      <article class="workorder-row" *ngFor="let workorder of workorders()"
-        [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.WORKORDER_ARIA' | translate">
-        <div class="workorder-id">
-          <span class="row-label">{{ 'SHOPMGMT.DISPATCH_BOARD.WORKORDER' | translate }}</span>
-          <span>{{ workorder.workorderId }}</span>
-        </div>
-        <div class="workorder-status">
-          <span class="row-label">{{ 'SHOPMGMT.DISPATCH_BOARD.STATUS' | translate }}</span>
-          <span class="status-chip" [class.exception-badge]="workorder.status.toLowerCase().includes('exception')">
-            {{ workorder.status }}
-          </span>
-        </div>
-      </article>
-    </div>
+    @if (!loading() && workorders().length > 0) {
+      <div class="workorders" aria-live="polite">
+        @for (workorder of workorders(); track workorder) {
+          <article class="workorder-row"
+            [attr.aria-label]="'SHOPMGMT.DISPATCH_BOARD.WORKORDER_ARIA' | translate">
+            <div class="workorder-id">
+              <span class="row-label">{{ 'SHOPMGMT.DISPATCH_BOARD.WORKORDER' | translate }}</span>
+              <span>{{ workorder.workorderId }}</span>
+            </div>
+            <div class="workorder-status">
+              <span class="row-label">{{ 'SHOPMGMT.DISPATCH_BOARD.STATUS' | translate }}</span>
+              <span class="status-chip" [class.exception-badge]="workorder.status.toLowerCase().includes('exception')">
+                {{ workorder.status }}
+              </span>
+            </div>
+          </article>
+        }
+      </div>
+    }
   </section>
 </section>

--- a/src/app/features/shopmgmt/pages/mechanic-availability/mechanic-availability-page.component.html
+++ b/src/app/features/shopmgmt/pages/mechanic-availability/mechanic-availability-page.component.html
@@ -15,17 +15,25 @@
     <button type="submit">{{ 'SHOPMGMT.MECHANIC_AVAILABILITY.LOAD' | translate }}</button>
   </form>
 
-  <p class="error-banner" *ngIf="error()">{{ error()! | translate }}</p>
+  @if (error()) {
+    <p class="error-banner">{{ error()! | translate }}</p>
+  }
 
-  <div class="availability-grid" *ngIf="!loading() && availabilityData().length > 0">
-    <div class="mechanic-row" *ngFor="let row of availabilityData()">
-      <span class="mechanic-name">{{ getMechanicName(row) }}</span>
-      <span class="availability-cell" [ngClass]="isAvailable(row) ? 'available-slot' : 'unavailable-slot'">
-        {{ isAvailable(row) ? ('SHOPMGMT.MECHANIC_AVAILABILITY.AVAILABLE' | translate) : ('SHOPMGMT.MECHANIC_AVAILABILITY.UNAVAILABLE' | translate) }}
-      </span>
+  @if (!loading() && availabilityData().length > 0) {
+    <div class="availability-grid">
+      @for (row of availabilityData(); track row) {
+        <div class="mechanic-row">
+          <span class="mechanic-name">{{ getMechanicName(row) }}</span>
+          <span class="availability-cell" [ngClass]="isAvailable(row) ? 'available-slot' : 'unavailable-slot'">
+            {{ isAvailable(row) ? ('SHOPMGMT.MECHANIC_AVAILABILITY.AVAILABLE' | translate) : ('SHOPMGMT.MECHANIC_AVAILABILITY.UNAVAILABLE' | translate) }}
+          </span>
+        </div>
+      }
     </div>
-  </div>
+  }
 
-  <p class="empty-state" *ngIf="!loading() && !error() && availabilityData().length === 0">{{ 'SHOPMGMT.MECHANIC_AVAILABILITY.EMPTY' | translate }}
-  </p>
+  @if (!loading() && !error() && availabilityData().length === 0) {
+    <p class="empty-state">{{ 'SHOPMGMT.MECHANIC_AVAILABILITY.EMPTY' | translate }}
+    </p>
+  }
 </section>

--- a/src/app/features/shopmgmt/pages/mechanic-roster/mechanic-roster-page.component.html
+++ b/src/app/features/shopmgmt/pages/mechanic-roster/mechanic-roster-page.component.html
@@ -7,32 +7,43 @@
     <button class="open-create-btn" type="button" (click)="openCreateModal()">{{ 'SHOPMGMT.MECHANIC_ROSTER.CREATE_EMPLOYEE' | translate }}</button>
   </div>
 
-  <p class="success-banner" *ngIf="createSuccess()">{{ 'SHOPMGMT.MECHANIC_ROSTER.EMPLOYEE_CREATED' | translate }}</p>
-  <p class="error-banner" *ngIf="error() || createError()">{{ (error() || createError())! | translate }}</p>
+  @if (createSuccess()) {
+    <p class="success-banner">{{ 'SHOPMGMT.MECHANIC_ROSTER.EMPLOYEE_CREATED' | translate }}</p>
+  }
+  @if (error() || createError()) {
+    <p class="error-banner">{{ (error() || createError())! | translate }}</p>
+  }
 
-  <div class="roster-table" *ngIf="!loading() && people().length > 0">
-    <div class="roster-row" *ngFor="let person of people()">{{ getDisplayName(person) }}</div>
-  </div>
+  @if (!loading() && people().length > 0) {
+    <div class="roster-table">
+      @for (person of people(); track person) {
+        <div class="roster-row">{{ getDisplayName(person) }}</div>
+      }
+    </div>
+  }
 
-  <p class="empty-state" *ngIf="!loading() && !error() && people().length === 0">{{ 'SHOPMGMT.MECHANIC_ROSTER.EMPTY' | translate }}</p>
+  @if (!loading() && !error() && people().length === 0) {
+    <p class="empty-state">{{ 'SHOPMGMT.MECHANIC_ROSTER.EMPTY' | translate }}</p>
+  }
 
-  <div class="create-modal-overlay" *ngIf="showCreateModal()">
-    <form [formGroup]="createForm" (ngSubmit)="submitCreateEmployee()">
-      <div class="form-group">
-        <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.FIRST_NAME' | translate }} <input type="text" formControlName="firstName" /></label>
-      </div>
-      <div class="form-group">
-        <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.LAST_NAME' | translate }} <input type="text" formControlName="lastName" /></label>
-      </div>
-      <div class="form-group">
-        <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.EMAIL' | translate }} <input type="email" formControlName="email" /></label>
-      </div>
-      <div class="form-group">
-        <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.ROLE' | translate }} <input type="text" formControlName="role" /></label>
-      </div>
-
-      <button class="submit-create-btn" type="submit">{{ 'SHOPMGMT.MECHANIC_ROSTER.SAVE' | translate }}</button>
-      <button type="button" (click)="closeCreateModal()">{{ 'SHOPMGMT.MECHANIC_ROSTER.CLOSE' | translate }}</button>
-    </form>
-  </div>
+  @if (showCreateModal()) {
+    <div class="create-modal-overlay">
+      <form [formGroup]="createForm" (ngSubmit)="submitCreateEmployee()">
+        <div class="form-group">
+          <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.FIRST_NAME' | translate }} <input type="text" formControlName="firstName" /></label>
+        </div>
+        <div class="form-group">
+          <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.LAST_NAME' | translate }} <input type="text" formControlName="lastName" /></label>
+        </div>
+        <div class="form-group">
+          <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.EMAIL' | translate }} <input type="email" formControlName="email" /></label>
+        </div>
+        <div class="form-group">
+          <label>{{ 'SHOPMGMT.MECHANIC_ROSTER.ROLE' | translate }} <input type="text" formControlName="role" /></label>
+        </div>
+        <button class="submit-create-btn" type="submit">{{ 'SHOPMGMT.MECHANIC_ROSTER.SAVE' | translate }}</button>
+        <button type="button" (click)="closeCreateModal()">{{ 'SHOPMGMT.MECHANIC_ROSTER.CLOSE' | translate }}</button>
+      </form>
+    </div>
+  }
 </section>

--- a/src/app/features/shopmgmt/pages/mechanic-roster/mechanic-roster-page.component.ts
+++ b/src/app/features/shopmgmt/pages/mechanic-roster/mechanic-roster-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -8,7 +8,7 @@ import { ShopmgmtRosterService } from '../../services/shopmgmt-roster.service';
 @Component({
   selector: 'app-mechanic-roster-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './mechanic-roster-page.component.html',
   styleUrl: './mechanic-roster-page.component.css',
 })

--- a/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.html
+++ b/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.html
@@ -20,7 +20,7 @@
           aria-autocomplete="list"
           aria-haspopup="listbox"
           [placeholder]="'SHOPMGMT.SCHEDULE_VIEW.LOCATION_ID' | translate"
-        />
+          />
         @if (showSuggestions() && locationSuggestions().length > 0) {
           <ul class="location-suggestions" role="listbox">
             @for (loc of locationSuggestions(); track loc.id) {
@@ -28,7 +28,7 @@
                 class="location-suggestion"
                 role="option"
                 (mousedown)="selectLocation(loc)"
-              >
+                >
                 <span class="suggestion-name">{{ loc.name }}</span>
                 @if (loc.code) {
                   <span class="suggestion-code">{{ loc.code }}</span>
@@ -58,52 +58,67 @@
   </form>
 </div>
 
-<div *ngIf="availabilityError()" class="availability-warning">
-  {{ 'SHOPMGMT.SCHEDULE_VIEW.ERROR_LOAD' | translate }}
-</div>
-
-<div *ngIf="loading()" class="loading-state">{{ 'SHOPMGMT.SCHEDULE_VIEW.LOADING' | translate }}</div>
-
-<ng-container *ngIf="!loading()">
-  <div *ngIf="scheduleData().length === 0 && !availabilityError()" class="empty-board">
-    {{ 'SHOPMGMT.SCHEDULE_VIEW.EMPTY' | translate }}
+@if (availabilityError()) {
+  <div class="availability-warning">
+    {{ 'SHOPMGMT.SCHEDULE_VIEW.ERROR_LOAD' | translate }}
   </div>
+}
 
-  <div *ngIf="scheduleData().length > 0" class="board-region">
-    <div *ngFor="let resource of scheduleData()" class="resource-lane">
-      <div class="lane-header">
-        <span class="resource-type">{{ resource.resourceType }}</span>
-        <span class="resource-name">{{ resource.resourceName ?? resource.resourceId }}</span>
-      </div>
-      <div class="lane-items">
-        <div *ngFor="let appt of resource.appointments" class="work-item-card" (click)="selectItem(appt)">
-          <span class="item-id">{{ appt.appointmentId }}</span>
-          <span class="item-time">{{ appt.scheduledStart }}</span>
-          <span class="item-status">{{ appt.status }}</span>
-          <span *ngIf="appt.rescheduleCount && appt.rescheduleCount > 0" class="conflict-badge">
-            {{ 'SHOPMGMT.SCHEDULE_VIEW.RESCHEDULED_X' | translate: { count: appt.rescheduleCount } }}
-          </span>
+@if (loading()) {
+  <div class="loading-state">{{ 'SHOPMGMT.SCHEDULE_VIEW.LOADING' | translate }}</div>
+}
+
+@if (!loading()) {
+  @if (scheduleData().length === 0 && !availabilityError()) {
+    <div class="empty-board">
+      {{ 'SHOPMGMT.SCHEDULE_VIEW.EMPTY' | translate }}
+    </div>
+  }
+  @if (scheduleData().length > 0) {
+    <div class="board-region">
+      @for (resource of scheduleData(); track resource) {
+        <div class="resource-lane">
+          <div class="lane-header">
+            <span class="resource-type">{{ resource.resourceType }}</span>
+            <span class="resource-name">{{ resource.resourceName ?? resource.resourceId }}</span>
+          </div>
+          <div class="lane-items">
+            @for (appt of resource.appointments; track appt) {
+              <div class="work-item-card" (click)="selectItem(appt)">
+                <span class="item-id">{{ appt.appointmentId }}</span>
+                <span class="item-time">{{ appt.scheduledStart }}</span>
+                <span class="item-status">{{ appt.status }}</span>
+                @if (appt.rescheduleCount && appt.rescheduleCount > 0) {
+                  <span class="conflict-badge">
+                    {{ 'SHOPMGMT.SCHEDULE_VIEW.RESCHEDULED_X' | translate: { count: appt.rescheduleCount } }}
+                  </span>
+                }
+              </div>
+            }
+          </div>
         </div>
-      </div>
+      }
+    </div>
+  }
+}
+
+@if (selectedItem()) {
+  <div class="details-panel">
+    <div class="details-header">
+      <h3>{{ 'SHOPMGMT.SCHEDULE_VIEW.APPOINTMENT' | translate: { id: selectedItem()!.appointmentId } }}</h3>
+      <button class="details-close" (click)="closeDetails()" [attr.aria-label]="'SHOPMGMT.SCHEDULE_VIEW.CLOSE_DETAILS' | translate">&#x2715;</button>
+    </div>
+    <div class="details-row">
+      <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.STATUS' | translate }}</span>
+      <span class="value">{{ selectedItem()!.status }}</span>
+    </div>
+    <div class="details-row">
+      <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.START' | translate }}</span>
+      <span class="value">{{ selectedItem()!.scheduledStart }}</span>
+    </div>
+    <div class="details-row">
+      <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.END' | translate }}</span>
+      <span class="value">{{ selectedItem()!.scheduledEnd }}</span>
     </div>
   </div>
-</ng-container>
-
-<div *ngIf="selectedItem()" class="details-panel">
-  <div class="details-header">
-    <h3>{{ 'SHOPMGMT.SCHEDULE_VIEW.APPOINTMENT' | translate: { id: selectedItem()!.appointmentId } }}</h3>
-    <button class="details-close" (click)="closeDetails()" [attr.aria-label]="'SHOPMGMT.SCHEDULE_VIEW.CLOSE_DETAILS' | translate">&#x2715;</button>
-  </div>
-  <div class="details-row">
-    <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.STATUS' | translate }}</span>
-    <span class="value">{{ selectedItem()!.status }}</span>
-  </div>
-  <div class="details-row">
-    <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.START' | translate }}</span>
-    <span class="value">{{ selectedItem()!.scheduledStart }}</span>
-  </div>
-  <div class="details-row">
-    <span class="label">{{ 'SHOPMGMT.SCHEDULE_VIEW.END' | translate }}</span>
-    <span class="value">{{ selectedItem()!.scheduledEnd }}</span>
-  </div>
-</div>
+}

--- a/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.ts
+++ b/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, DestroyRef, OnInit, signal, computed, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { CommonModule } from '@angular/common';
+
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute } from '@angular/router';
@@ -20,7 +20,7 @@ const MAX_SUGGESTIONS = 8;
 @Component({
   selector: 'app-schedule-view-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './schedule-view-page.component.html',
   styleUrl: './schedule-view-page.component.css',
 })

--- a/src/app/features/workexec/components/operational-cost/operational-cost.component.ts
+++ b/src/app/features/workexec/components/operational-cost/operational-cost.component.ts
@@ -1,5 +1,5 @@
 import { CurrencyPipe } from '@angular/common';
-import { Component, DestroyRef, Input, computed, inject, signal } from '@angular/core';
+import { Component, DestroyRef, Input, computed, inject, signal, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslatePipe } from '@ngx-translate/core';
 import { WorkexecService } from '../../services/workexec.service';
@@ -11,7 +11,7 @@ import { WorkexecService } from '../../services/workexec.service';
   templateUrl: './operational-cost.component.html',
   styleUrl: './operational-cost.component.css',
 })
-export class OperationalCostComponent {
+export class OperationalCostComponent implements OnInit {
   private readonly workexecService = inject(WorkexecService);
   private readonly destroyRef = inject(DestroyRef);
 

--- a/src/app/features/workexec/components/search-typeahead/workexec-search-typeahead.component.ts
+++ b/src/app/features/workexec/components/search-typeahead/workexec-search-typeahead.component.ts
@@ -8,7 +8,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable, Subject, of } from 'rxjs';
@@ -31,7 +31,7 @@ type TypeaheadState = 'idle' | 'loading' | 'loaded' | 'empty' | 'error';
 @Component({
   selector: 'app-workexec-search-typeahead',
   standalone: true,
-  imports: [CommonModule, TranslatePipe],
+  imports: [TranslatePipe],
   templateUrl: './workexec-search-typeahead.component.html',
   styleUrl: './workexec-search-typeahead.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-create/estimate-create-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, signal, OnInit, DestroyRef } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -24,7 +24,7 @@ const ADD_VEHICLE_OPTION = '__add__';
 @Component({
   selector: 'app-estimate-create-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './estimate-create-page.component.html',
   styleUrl: './estimate-create-page.component.css',
 })

--- a/src/app/features/workexec/pages/estimate-from-appointment/estimate-from-appointment-page.component.html
+++ b/src/app/features/workexec/pages/estimate-from-appointment/estimate-from-appointment-page.component.html
@@ -15,9 +15,13 @@
     </div>
 
     <button class="submit-btn" type="submit"
-      [disabled]="estimateForm.controls.appointmentId.value.trim().length === 0 || loading()">{{ 'WORKEXEC.ESTIMATE_FROM_APPT.CREATE' | translate }}</button>
+    [disabled]="estimateForm.controls.appointmentId.value.trim().length === 0 || loading()">{{ 'WORKEXEC.ESTIMATE_FROM_APPT.CREATE' | translate }}</button>
   </form>
 
-  <p class="success-banner" *ngIf="createSuccess()">{{ 'WORKEXEC.ESTIMATE_FROM_APPT.SUCCESS' | translate }}</p>
-  <p class="error-banner" *ngIf="createError()">{{ createError() }}</p>
+  @if (createSuccess()) {
+    <p class="success-banner">{{ 'WORKEXEC.ESTIMATE_FROM_APPT.SUCCESS' | translate }}</p>
+  }
+  @if (createError()) {
+    <p class="error-banner">{{ createError() }}</p>
+  }
 </section>

--- a/src/app/features/workexec/pages/estimate-from-appointment/estimate-from-appointment-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-from-appointment/estimate-from-appointment-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { Component, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -9,7 +9,7 @@ import { EstimateResponse } from '../../models/workexec.models';
 @Component({
   selector: 'app-estimate-from-appointment-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './estimate-from-appointment-page.component.html',
   styleUrl: './estimate-from-appointment-page.component.css',
 })

--- a/src/app/features/workexec/pages/estimate-revise/estimate-revise-page.component.ts
+++ b/src/app/features/workexec/pages/estimate-revise/estimate-revise-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, signal, OnInit, DestroyRef } from '@angular/core';
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -19,7 +19,7 @@ import { ModalDialogDirective } from '../../../../shared/modal-dialog.directive'
 @Component({
   selector: 'app-estimate-revise-page',
   standalone: true,
-  imports: [CommonModule, RouterLink, TranslatePipe, ModalDialogDirective],
+  imports: [RouterLink, TranslatePipe, ModalDialogDirective],
   templateUrl: './estimate-revise-page.component.html',
   styleUrl: './estimate-revise-page.component.css',
 })

--- a/src/app/features/workexec/pages/operational-context/operational-context-page.component.html
+++ b/src/app/features/workexec/pages/operational-context/operational-context-page.component.html
@@ -3,35 +3,44 @@
     <h1>{{ 'WORKEXEC.OPS_CONTEXT.TITLE' | translate }}</h1>
   </header>
 
-  <div class="context-panel" *ngIf="context(); else emptyState">
-    <div class="context-item" *ngFor="let item of contextEntries()">
-      <span class="context-key">{{ item.key }}</span>
-      <span class="context-value">{{ item.value }}</span>
+  @if (context()) {
+    <div class="context-panel">
+      @for (item of contextEntries(); track item.key) {
+        <div class="context-item">
+          <span class="context-key">{{ item.key }}</span>
+          <span class="context-value">{{ item.value }}</span>
+        </div>
+      }
     </div>
-  </div>
-
-  <ng-template #emptyState>
+  } @else {
     <div class="context-panel">{{ 'WORKEXEC.OPS_CONTEXT.EMPTY' | translate }}</div>
-  </ng-template>
+  }
+
 
   <button type="button" (click)="openOverrideForm()">{{ 'WORKEXEC.OPS_CONTEXT.OVERRIDE' | translate }}</button>
 
-  <div class="override-panel" *ngIf="showOverrideForm()">
-    <form class="override-form" [formGroup]="overrideForm" (ngSubmit)="submitOverride()">
-      <div class="form-group">
-        <label>{{ 'WORKEXEC.OPS_CONTEXT.CONTEXT_KEY' | translate }} <input type="text" formControlName="contextKey" /></label>
-      </div>
-      <div class="form-group">
-        <label>{{ 'WORKEXEC.OPS_CONTEXT.CONTEXT_VALUE' | translate }} <input type="text" formControlName="contextValue" /></label>
-      </div>
-      <div class="form-group">
-        <label>{{ 'WORKEXEC.OPS_CONTEXT.REASON' | translate }} <input type="text" formControlName="overrideReason" /></label>
-      </div>
-      <button type="submit">{{ 'WORKEXEC.OPS_CONTEXT.SUBMIT' | translate }}</button>
-      <button type="button" (click)="closeOverrideForm()">{{ 'WORKEXEC.OPS_CONTEXT.CLOSE' | translate }}</button>
-    </form>
-  </div>
+  @if (showOverrideForm()) {
+    <div class="override-panel">
+      <form class="override-form" [formGroup]="overrideForm" (ngSubmit)="submitOverride()">
+        <div class="form-group">
+          <label>{{ 'WORKEXEC.OPS_CONTEXT.CONTEXT_KEY' | translate }} <input type="text" formControlName="contextKey" /></label>
+        </div>
+        <div class="form-group">
+          <label>{{ 'WORKEXEC.OPS_CONTEXT.CONTEXT_VALUE' | translate }} <input type="text" formControlName="contextValue" /></label>
+        </div>
+        <div class="form-group">
+          <label>{{ 'WORKEXEC.OPS_CONTEXT.REASON' | translate }} <input type="text" formControlName="overrideReason" /></label>
+        </div>
+        <button type="submit">{{ 'WORKEXEC.OPS_CONTEXT.SUBMIT' | translate }}</button>
+        <button type="button" (click)="closeOverrideForm()">{{ 'WORKEXEC.OPS_CONTEXT.CLOSE' | translate }}</button>
+      </form>
+    </div>
+  }
 
-  <p class="success-banner" *ngIf="overrideSuccess()">{{ 'WORKEXEC.OPS_CONTEXT.SAVED' | translate }}</p>
-  <p class="error-banner" *ngIf="overrideError()">{{ overrideError() }}</p>
+  @if (overrideSuccess()) {
+    <p class="success-banner">{{ 'WORKEXEC.OPS_CONTEXT.SAVED' | translate }}</p>
+  }
+  @if (overrideError()) {
+    <p class="error-banner">{{ overrideError() }}</p>
+  }
 </section>

--- a/src/app/features/workexec/pages/operational-context/operational-context-page.component.ts
+++ b/src/app/features/workexec/pages/operational-context/operational-context-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -9,7 +9,7 @@ import { OperationalContextResponse } from '../../models/workexec.models';
 @Component({
   selector: 'app-operational-context-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './operational-context-page.component.html',
   styleUrl: './operational-context-page.component.css',
 })

--- a/src/app/features/workexec/pages/travel-time/travel-time-page.component.html
+++ b/src/app/features/workexec/pages/travel-time/travel-time-page.component.html
@@ -11,20 +11,25 @@
     <button type="submit">{{ 'WORKEXEC.TRAVEL.START' | translate }}</button>
   </form>
 
-  <div class="active-segment" *ngIf="activeSegment(); else inactiveState">
-    {{ 'WORKEXEC.TRAVEL.ACTIVE_SEGMENT' | translate }}
-    <button class="stop-btn" type="button" (click)="stopTravel(getSegmentId())"
+  @if (activeSegment()) {
+    <div class="active-segment">
+      {{ 'WORKEXEC.TRAVEL.ACTIVE_SEGMENT' | translate }}
+      <button class="stop-btn" type="button" (click)="stopTravel(getSegmentId())"
       [disabled]="!getSegmentId()">{{ 'WORKEXEC.TRAVEL.STOP' | translate }}</button>
-  </div>
-
-  <ng-template #inactiveState>
+    </div>
+  } @else {
     <div class="travel-inactive">{{ 'WORKEXEC.TRAVEL.INACTIVE' | translate }}</div>
-  </ng-template>
+  }
+
 
   <button class="submit-all-btn" type="button" (click)="submitAll(mobileWorkAssignmentId())"
-    [disabled]="!mobileWorkAssignmentId()">{{ 'WORKEXEC.TRAVEL.SUBMIT_ALL' | translate }}</button>
+  [disabled]="!mobileWorkAssignmentId()">{{ 'WORKEXEC.TRAVEL.SUBMIT_ALL' | translate }}</button>
 
-  <p class="success-banner" *ngIf="submitSuccess()">{{ 'WORKEXEC.TRAVEL.SUBMITTED' | translate }}</p>
-  <p class="error-banner" *ngIf="startError() || stopError() || submitError()">{{ startError() || stopError() ||
+  @if (submitSuccess()) {
+    <p class="success-banner">{{ 'WORKEXEC.TRAVEL.SUBMITTED' | translate }}</p>
+  }
+  @if (startError() || stopError() || submitError()) {
+    <p class="error-banner">{{ startError() || stopError() ||
     submitError() }}</p>
+  }
 </section>

--- a/src/app/features/workexec/pages/travel-time/travel-time-page.component.ts
+++ b/src/app/features/workexec/pages/travel-time/travel-time-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+
 import { TranslatePipe } from '@ngx-translate/core';
 import { Component, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -7,7 +7,7 @@ import { WorkexecService } from '../../services/workexec.service';
 @Component({
   selector: 'app-travel-time-page',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TranslatePipe],
+  imports: [ReactiveFormsModule, TranslatePipe],
   templateUrl: './travel-time-page.component.html',
   styleUrl: './travel-time-page.component.css',
 })

--- a/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
+++ b/src/app/features/workexec/pages/workorder-detail/workorder-detail-page.component.spec.ts
@@ -240,7 +240,8 @@ describe('WorkorderDetailPageComponent [Stories 213–215]', () => {
       drainWithTechnician(() =>
         http.expectOne(`${BASE}/v1/people/employees/${TECH_ID}`).flush({
           id: TECH_ID,
-          legalName: 'Jane Smith',
+          firstName: 'Jane',
+          lastName: 'Smith',
           employeeNumber: 'EMP-007',
           status: 'ACTIVE',
           hireDate: '2024-01-01',


### PR DESCRIPTION
Closes #110.

Started as the #110 chat-send extraction; grew to include the lint tooling it surfaced and a repo-wide control-flow migration, plus the review fixes for both.

## 1. Shared chat-send flow (#110)
`DashboardComponent.submitAssistant()` re-implemented `ChatPanelComponent.sendMessage()` and had **diverged**: its error handler dropped `logChatFailure()` + `buildTroubleshootingMessage()`, so assistant-strip failures showed only the generic `ERROR_BACKEND` text — no logging, no correlation-id/backend-code diagnostics.

- New root-scoped `ChatSendService` owns the single canonical flow: `addUserMessage` → `chatApi.sendMessage` → `finalize(onSettled)` → `addSystemMessage`, plus `logChatFailure` + troubleshooting message on failure.
- Both components call `chatSend.send(text, { onSettled })`; each keeps only its own UI concerns (trim guard, input clear, `sending` flag, scroll / `chatUi.open`).
- Error handling now identical on both surfaces.
- Request stays untied to any component `DestroyRef` (root service) — the reply still lands in the always-visible shell chat panel if the originating component is destroyed mid-request (preserves the b02aca6 lifecycle).

## 2. Lint target
The repo shipped `@angular-eslint` plugins but no config, builder, or `lint` target (`ng lint` → "Cannot find lint target").
- Add flat `eslint.config.js` (`@eslint/js` + `typescript-eslint` + `@angular-eslint`; template a11y rules; `app` selector prefix; `^_` unused-var ignore; ignores `dist`/`coverage`/`.angular`/`src/index.html`).
- Add `lint` architect target (`@angular-eslint/builder:lint`) + `lint`/`lint:fix` npm scripts.
- devDeps: `@angular-eslint/builder`, `angular-eslint`, `typescript-eslint`, `@eslint/js`.

## 3. Control-flow migration
`ng generate @angular/core:control-flow` converted all `*ngIf`/`*ngFor`/`*ngSwitch` → `@if`/`@for`/`@switch` (~60 templates), clearing the 115 `prefer-control-flow` lint errors and dropping now-unused `NgIf`/`NgFor`/`CommonModule` imports. One manual fix: `operational-context` identity-track (`track item` over a fresh-object getter → NG0956) changed to `track item.key`.

## 4. Review fixes (PR self-review)
- **a11y:** `ng lint --fix` had stripped `autofocus` from three non-native confirm dialogs (`role="alertdialog"`, no focus-trap), leaving keyboard/SR users outside the modal on open. Restored `autofocus` on the Cancel control (safe destructive default) with a scoped `eslint-disable` + rationale (ADR-0029 keyboard-flow).
- **test:** chat-send error spec now asserts the user message persists on a failed send.
- **lint config:** bumped `@eslint/js` ^9 → ^10 to track the engine major; ignore `src/index.html`.

## Pre-existing fix pulled in
`workorder-detail` technician-name spec flushed a legacy `legalName` employee body while the resolver was switched to first/last name in #131 — updated the spec to `firstName`/`lastName`.

## Tests
Full suite: **1764 passing**, 1 skipped, 0 failing. Accessibility Gate: green.

## Lint debt (follow-up, not in scope)
`ng lint` still reports ~147 pre-existing violations (`no-explicit-any`, `no-unused-vars`, remaining a11y) untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
