### PR TITLE
[CAP:CAP-007] Show tax as separate line on invoice detail

### DIFF
--- a/src/app/features/billing/models/billing.models.ts
+++ b/src/app/features/billing/models/billing.models.ts
@@ -110,7 +110,6 @@ export interface InvoiceDetail {
   poNumber?: string;
   status: InvoiceStatus;
   subtotal?: number;
-  taxTotal?: number;
   taxAmount?: number;
   feeTotal?: number;
   discountAmount?: number;

--- a/src/app/features/billing/services/billing-transport.service.spec.ts
+++ b/src/app/features/billing/services/billing-transport.service.spec.ts
@@ -120,7 +120,7 @@ describe('BillingTransportService', () => {
       invoiceId: 'inv-001',
       workOrderId: 'wo-001',
       status: 'FINALIZED',
-      taxTotal: 8,
+      taxAmount: 8,
       adjustmentTotal: 5,
       grandTotal: 113,
     }));

--- a/src/app/features/billing/services/billing-transport.service.ts
+++ b/src/app/features/billing/services/billing-transport.service.ts
@@ -299,7 +299,7 @@ export class BillingTransportService {
       workOrderId: source.workorderId,
       status,
       subtotal: source.subtotal,
-      taxTotal: source.tax,
+      taxAmount: source.tax,
       adjustmentTotal: source.adjustments,
       grandTotal: source.total,
       createdAt: source.createdAt,


### PR DESCRIPTION
## Summary
Invoice detail totals breakdown now renders the **tax** amount on its own line instead of silently folding it into the grand total.

## Root cause
The totals breakdown template binds `invoice.taxAmount`, but `BillingTransportService.toInvoiceDetail()` mapped the backend `tax` value into `taxTotal`. `taxAmount` stayed `undefined`, so the `(taxAmount ?? 0) > 0` guard was always false and the tax row never rendered.

## Changes
- `billing-transport.service.ts` — map `source.tax` → `taxAmount`
- `billing.models.ts` — remove dead `taxTotal` field
- `billing-transport.service.spec.ts` — update assertion to `taxAmount`

## Tests
- `billing-transport.service.spec.ts` — 14 passed
- `invoice-detail-page.component.spec.ts` — 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)