### PR TITLE
Audit cleanup (round 2): persistent h1 landmarks + PO-form hint contrast

### DIFF
--- a/src/app/features/inventory/pages/counts/count-execute/count-execute.component.css
+++ b/src/app/features/inventory/pages/counts/count-execute/count-execute.component.css
@@ -6,6 +6,16 @@
   margin-bottom: 1rem;
 }
 
+.page-header {
+  margin-bottom: var(--space-6);
+}
+
+.page-header h1 {
+  margin: 0;
+  font-family: var(--font-primary);
+  color: var(--currentTextColor);
+}
+
 .detail-grid {
   display: grid;
   grid-template-columns: auto 1fr;

--- a/src/app/features/inventory/pages/counts/count-execute/count-execute.component.html
+++ b/src/app/features/inventory/pages/counts/count-execute/count-execute.component.html
@@ -6,6 +6,10 @@
     </button>
   </div>
 
+  <header class="page-header">
+    <h1 id="count-execute-title">{{ 'INVENTORY.COUNTS.EXECUTE.TITLE' | translate }}</h1>
+  </header>
+
   @if (state() === 'loading') {
   <section class="card" aria-busy="true" aria-live="polite">
     <p class="sr-only">{{ 'COMMON.LOADING' | translate }}</p>
@@ -32,7 +36,6 @@
   @if (state() === 'ready' && task()) {
   <!-- Task context -->
   <section class="card">
-    <h1 id="count-execute-title">{{ 'INVENTORY.COUNTS.EXECUTE.TITLE' | translate }}</h1>
     <dl class="detail-grid">
       <dt>{{ 'INVENTORY.COUNTS.EXECUTE.FIELD.LOCATION' | translate }}</dt>
       <dd>{{ task()!.locationId }}</dd>

--- a/src/app/features/inventory/pages/purchase-orders/po-form/po-form.component.css
+++ b/src/app/features/inventory/pages/purchase-orders/po-form/po-form.component.css
@@ -60,8 +60,9 @@
 }
 
 .no-lines-hint {
-  color: var(--brand-secondary, var(--currentTextColor));
-  opacity: 0.7;
+  /* --text-muted (graphite-600) is AA on the card surface; opacity dimming
+     dropped this below the WCAG AA threshold (ADR-0039). */
+  color: var(--text-muted);
   font-size: 0.9rem;
   margin: 0.5rem 0;
 }

--- a/src/app/features/location/pages/bays/bays-page.component.html
+++ b/src/app/features/location/pages/bays/bays-page.component.html
@@ -1,3 +1,10 @@
+<section class="page-header">
+  <h1>{{ 'LOCATION.BAYS.TITLE' | translate }}</h1>
+  @if (locationId()) {
+    <button type="button" class="btn-primary open-create-btn" (click)="openCreate()">{{ 'LOCATION.BAYS.CREATE_BAY' | translate }}</button>
+  }
+</section>
+
 <app-location-picker
   [label]="'LOCATION.BAYS.LABEL' | translate"
   [selectedId]="locationId()"
@@ -20,11 +27,6 @@
 }
 
 @if (locationId()) {
-  <section class="page-header">
-    <h1>{{ 'LOCATION.BAYS.TITLE' | translate }}</h1>
-    <button type="button" class="btn-primary open-create-btn" (click)="openCreate()">{{ 'LOCATION.BAYS.CREATE_BAY' | translate }}</button>
-  </section>
-
   @if (loading()) {
     <section class="bays-grid">
       <p>{{ 'LOCATION.BAYS.LOADING' | translate }}</p>

--- a/src/app/features/location/pages/mobile-units/mobile-units-page.component.html
+++ b/src/app/features/location/pages/mobile-units/mobile-units-page.component.html
@@ -1,3 +1,10 @@
+<section class="page-header">
+  <h1>{{ 'LOCATION.MOBILE_UNITS.TITLE' | translate }}</h1>
+  @if (locationId()) {
+    <button type="button" class="btn-primary open-create-btn" (click)="openCreate()">{{ 'LOCATION.MOBILE_UNITS.CREATE_MOBILE_UNIT' | translate }}</button>
+  }
+</section>
+
 <app-location-picker
   [label]="'LOCATION.MOBILE_UNITS.LABEL' | translate"
   [selectedId]="locationId()"
@@ -16,11 +23,6 @@
 }
 
 @if (locationId()) {
-  <section class="page-header">
-    <h1>{{ 'LOCATION.MOBILE_UNITS.TITLE' | translate }}</h1>
-    <button type="button" class="btn-primary open-create-btn" (click)="openCreate()">{{ 'LOCATION.MOBILE_UNITS.CREATE_MOBILE_UNIT' | translate }}</button>
-  </section>
-
   @if (error()) {
     <div class="error-banner">{{ error()! | translate }}</div>
   }


### PR DESCRIPTION
## Summary

Clears the frontend-fixable findings left after the post-deploy audit re-run (64 → 23).

- **`missing-h1` (bays, mobile-units, count-execute):** the page `<h1>` was nested inside a state gate (`@if (locationId())` / `@if (state()==='ready')`), so the audit crawler — which hits these pages with no location selected / mid-load — saw no `<h1>`. Hoisted a persistent page-header `<h1>` that always renders; the "Create" button stays gated on `locationId()`, and count-execute's `<main aria-labelledby>` target now always resolves (ADR-0029).
- **`a11y/color-contrast` (purchase-orders/po-form):** the "no lines yet" hint (`<p class="no-lines-hint">`, shown on a new/empty PO) used `--brand-secondary` at `opacity: 0.7`, failing WCAG AA. Switched to the AA-safe `--text-muted` token and dropped the opacity dimming (ADR-0039).

## Validation

- [x] `npm run build` — passes (only the pre-existing `invoice-detail` CSS-budget warning).
- [x] `npm run test` (targeted) — bays / mobile-units / count-execute / po-form specs pass (29). `npm run lint:css` clean.

## Accessibility Verification (Required for Changed UI)

Changes are landmark structure (an always-present `<h1>`) and a token/contrast fix — no interaction change. Not manually smoke-tested in CI (no NVDA/VoiceOver here); the `<h1>` hoist specifically improves the no-selection/loading state a screen reader lands on.

- [ ] Keyboard smoke verified on each changed feature page
- [ ] Screen-reader smoke verified (NVDA or VoiceOver)

## Notes / Follow-ups

- The last remaining `uuid-on-screen` item — the vendor-payment "Vendor ID" free-text field — is **backend-blocked** (no vendor search/directory endpoint exists; only vendor-bills). Filed as durion-positivity-backend#816; the frontend typeahead will follow once that ships.
- Still-open audit findings after this are backend-owned (posting-rules 500, people 404s, inventory `sync-logs`/`cycleCountPlans` list) or deferred heuristics (`raw-i18n-key` permission code, `search-possibly-id-keyed`) and the timekeeping checkbox `value` UUIDs (form values, not visible text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhnZH4hct5e1PUrgU4hUJK)_