### PR TITLE
fix(inventory): reconcile divergent API routes with backend #813 canonical paths

### DIFF
--- a/src/app/features/inventory/pages/fulfillment/shortage-resolution/shortage-resolution-page.component.ts
+++ b/src/app/features/inventory/pages/fulfillment/shortage-resolution/shortage-resolution-page.component.ts
@@ -94,7 +94,7 @@ export class ShortageResolutionPageComponent {
     this.errorKey.set(null);
 
     this.inventoryService
-      .getShortageOptions(workorderId, allocationLineId)
+      .getShortageOptions(allocationLineId)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: options => {

--- a/src/app/features/inventory/services/inventory.service.spec.ts
+++ b/src/app/features/inventory/services/inventory.service.spec.ts
@@ -179,7 +179,7 @@ describe('InventoryDomainService', () => {
       nextPageToken: null,
     };
 
-    it('calls GET /inventory/v1/ledger with filter params', () => {
+    it('calls GET /inventory/v1/inventory/ledger with filter params', () => {
       apiStub.get.mockReturnValueOnce(of(mockPage));
 
       const filter: LedgerFilter = { locationId: 'loc-01', productSku: 'SKU-001' };
@@ -187,7 +187,7 @@ describe('InventoryDomainService', () => {
 
       expect(apiStub.get).toHaveBeenCalledOnce();
       const [path, params] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/ledger');
+      expect(path).toBe('/inventory/v1/inventory/ledger');
       expect((params as HttpParams).get('locationId')).toBe('loc-01');
       expect((params as HttpParams).get('productSku')).toBe('SKU-001');
     });
@@ -234,14 +234,14 @@ describe('InventoryDomainService', () => {
       uom: 'EA',
     };
 
-    it('calls GET /inventory/v1/ledger/{ledgerEntryId}', () => {
+    it('calls GET /inventory/v1/inventory/ledger/{ledgerEntryId}', () => {
       apiStub.get.mockReturnValueOnce(of(mockEntry));
 
       service.getLedgerEntry('entry-001').subscribe();
 
       expect(apiStub.get).toHaveBeenCalledOnce();
       const [path] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/ledger/entry-001');
+      expect(path).toBe('/inventory/v1/inventory/ledger/entry-001');
     });
 
     it('URL-encodes the ledgerEntryId', () => {
@@ -250,7 +250,7 @@ describe('InventoryDomainService', () => {
       service.getLedgerEntry('entry/001').subscribe();
 
       const [path] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/ledger/entry%2F001');
+      expect(path).toBe('/inventory/v1/inventory/ledger/entry%2F001');
     });
 
     it('returns the InventoryLedgerEntry emitted by the API', () => {
@@ -438,23 +438,15 @@ describe('InventoryDomainService', () => {
       },
     ];
 
-    it('calls GET /inventory/v1/workorders/{workorderId}/returnable-items', () => {
+    it('calls GET /inventory/v1/inventory/returns/returnable-items with workorderId param', () => {
       apiStub.get.mockReturnValueOnce(of(mockItems));
 
       service.getReturnableItems('wo-001').subscribe();
 
       expect(apiStub.get).toHaveBeenCalledOnce();
-      const [path] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/workorders/wo-001/returnable-items');
-    });
-
-    it('URL-encodes the workorderId', () => {
-      apiStub.get.mockReturnValueOnce(of(mockItems));
-
-      service.getReturnableItems('wo/001').subscribe();
-
-      const [path] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/workorders/wo%2F001/returnable-items');
+      const [path, params] = apiStub.get.mock.calls[0];
+      expect(path).toBe('/inventory/v1/inventory/returns/returnable-items');
+      expect((params as HttpParams).get('workorderId')).toBe('wo-001');
     });
 
     it('returns the ReturnableItem array emitted by the API', () => {
@@ -475,14 +467,14 @@ describe('InventoryDomainService', () => {
       { code: 'UNUSED', label: 'Unused part' },
     ];
 
-    it('calls GET /inventory/v1/reasons with type param', () => {
+    it('calls GET /inventory/v1/inventory/returns/reason-codes with type param', () => {
       apiStub.get.mockReturnValueOnce(of(mockCodes));
 
       service.getReasonCodes('RETURN').subscribe();
 
       expect(apiStub.get).toHaveBeenCalledOnce();
       const [path, params] = apiStub.get.mock.calls[0];
-      expect(path).toBe('/inventory/v1/reasons');
+      expect(path).toBe('/inventory/v1/inventory/returns/reason-codes');
       expect((params as HttpParams).get('type')).toBe('RETURN');
     });
 
@@ -512,14 +504,14 @@ describe('InventoryDomainService', () => {
       totalItemsReturned: 2,
     };
 
-    it('calls POST /inventory/v1/movements/return-to-stock with request body', () => {
+    it('calls POST /inventory/v1/inventory/returns/submit-to-stock with request body', () => {
       apiStub.post.mockReturnValueOnce(of(mockResult));
 
       service.submitReturnToStock(mockRequest).subscribe();
 
       expect(apiStub.post).toHaveBeenCalledOnce();
       const [path, body] = apiStub.post.mock.calls[0];
-      expect(path).toBe('/inventory/v1/movements/return-to-stock');
+      expect(path).toBe('/inventory/v1/inventory/returns/submit-to-stock');
       expect(body).toEqual(mockRequest);
     });
 
@@ -541,32 +533,22 @@ describe('InventoryDomainService', () => {
       { optionId: 'opt-02', decisionType: 'BACKORDER', label: 'Backorder part', leadTimeDays: 3 },
     ];
 
-    it('calls GET /inventory/v1/workorders/{workorderId}/allocations/{allocationLineId}/shortage-options', () => {
+    it('calls GET /inventory/v1/inventory/shortage/options with allocationId param', () => {
       apiStub.get.mockReturnValueOnce(of(mockOptions));
 
-      service.getShortageOptions('wo-001', 'alloc-001').subscribe();
+      service.getShortageOptions('alloc-001').subscribe();
 
       expect(apiStub.get).toHaveBeenCalledOnce();
-      const [path] = apiStub.get.mock.calls[0];
-      expect(path).toBe(
-        '/inventory/v1/workorders/wo-001/allocations/alloc-001/shortage-options',
-      );
-    });
-
-    it('URL-encodes workorderId and allocationLineId', () => {
-      apiStub.get.mockReturnValueOnce(of(mockOptions));
-
-      service.getShortageOptions('wo/001', 'alloc/001').subscribe();
-
-      const [path] = apiStub.get.mock.calls[0];
-      expect(path).toContain('wo%2F001/allocations/alloc%2F001');
+      const [path, params] = apiStub.get.mock.calls[0];
+      expect(path).toBe('/inventory/v1/inventory/shortage/options');
+      expect((params as HttpParams).get('allocationId')).toBe('alloc-001');
     });
 
     it('returns the ShortageOption array emitted by the API', () => {
       apiStub.get.mockReturnValueOnce(of(mockOptions));
 
       let result: ShortageOption[] | undefined;
-      service.getShortageOptions('wo-001', 'alloc-001').subscribe(r => (result = r));
+      service.getShortageOptions('alloc-001').subscribe(r => (result = r));
 
       expect(result).toEqual(mockOptions);
     });
@@ -588,16 +570,14 @@ describe('InventoryDomainService', () => {
       resolvedDecisionType: 'SUBSTITUTE',
     };
 
-    it('calls POST /inventory/v1/workorders/{workorderId}/allocations/{allocationLineId}/resolve-shortage', () => {
+    it('calls POST /inventory/v1/inventory/shortage/resolve', () => {
       apiStub.post.mockReturnValueOnce(of(mockResult));
 
       service.resolveShortage(mockRequest).subscribe();
 
       expect(apiStub.post).toHaveBeenCalledOnce();
       const [path] = apiStub.post.mock.calls[0];
-      expect(path).toBe(
-        '/inventory/v1/workorders/wo-001/allocations/alloc-001/resolve-shortage',
-      );
+      expect(path).toBe('/inventory/v1/inventory/shortage/resolve');
     });
 
     it('posts the full ShortageResolutionRequest as body', () => {

--- a/src/app/features/inventory/services/inventory.service.ts
+++ b/src/app/features/inventory/services/inventory.service.ts
@@ -116,12 +116,12 @@ export class InventoryDomainService {
     if (filter.movementTypes != null && filter.movementTypes.length > 0) {
       filter.movementTypes.forEach(t => { params = params.append('movementTypes', t); });
     }
-    return this.api.get<LedgerPageResponse>('/inventory/v1/ledger', params);
+    return this.api.get<LedgerPageResponse>('/inventory/v1/inventory/ledger', params);
   }
 
   getLedgerEntry(ledgerEntryId: string): Observable<InventoryLedgerEntry> {
     return this.api.get<InventoryLedgerEntry>(
-      `/inventory/v1/ledger/${encodeURIComponent(ledgerEntryId)}`,
+      `/inventory/v1/inventory/ledger/${encodeURIComponent(ledgerEntryId)}`,
     );
   }
 
@@ -149,35 +149,36 @@ export class InventoryDomainService {
   }
 
   getReturnableItems(workorderId: string): Observable<ReturnableItem[]> {
+    const params = new HttpParams().set('workorderId', workorderId);
     return this.api.get<ReturnableItem[]>(
-      `/inventory/v1/workorders/${encodeURIComponent(workorderId)}/returnable-items`,
+      '/inventory/v1/inventory/returns/returnable-items',
+      params,
     );
   }
 
   getReasonCodes(type: string): Observable<ReturnReasonCode[]> {
     const params = new HttpParams().set('type', type);
-    return this.api.get<ReturnReasonCode[]>('/inventory/v1/reasons', params);
+    return this.api.get<ReturnReasonCode[]>('/inventory/v1/inventory/returns/reason-codes', params);
   }
 
   submitReturnToStock(request: ReturnToStockRequest): Observable<ReturnToStockResult> {
     return this.api.post<ReturnToStockResult>(
-      '/inventory/v1/movements/return-to-stock',
+      '/inventory/v1/inventory/returns/submit-to-stock',
       request,
     );
   }
 
-  getShortageOptions(
-    workorderId: string,
-    allocationLineId: string,
-  ): Observable<ShortageOption[]> {
+  getShortageOptions(allocationLineId: string): Observable<ShortageOption[]> {
+    const params = new HttpParams().set('allocationId', allocationLineId);
     return this.api.get<ShortageOption[]>(
-      `/inventory/v1/workorders/${encodeURIComponent(workorderId)}/allocations/${encodeURIComponent(allocationLineId)}/shortage-options`,
+      '/inventory/v1/inventory/shortage/options',
+      params,
     );
   }
 
   resolveShortage(request: ShortageResolutionRequest): Observable<ShortageResolutionResult> {
     return this.api.post<ShortageResolutionResult>(
-      `/inventory/v1/workorders/${encodeURIComponent(request.workorderId)}/allocations/${encodeURIComponent(request.allocationLineId)}/resolve-shortage`,
+      '/inventory/v1/inventory/shortage/resolve',
       request,
     );
   }

--- a/src/app/features/location/pages/location-sync/location-sync-page.component.spec.ts
+++ b/src/app/features/location/pages/location-sync/location-sync-page.component.spec.ts
@@ -70,6 +70,29 @@ describe('LocationSyncPageComponent [CAP-214 #104]', () => {
     expect(rows[0].nativeElement.textContent).toContain('Main');
   });
 
+  it('should unwrap a Spring Page (content) for the locations table', async () => {
+    vi.clearAllMocks();
+    stubInventoryService.listInventoryLocations.mockReturnValue(of({ content: INVENTORY_LOCATIONS }));
+    stubInventoryService.listSyncLogs.mockReturnValue(of(SYNC_LOGS));
+
+    await TestBed.configureTestingModule({
+      imports: [LocationSyncPageComponent],
+      providers: [
+        provideRouter([]),
+        { provide: InventoryService, useValue: stubInventoryService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LocationSyncPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.inventoryLocations()).toHaveLength(1);
+    expect((component.inventoryLocations()[0] as Record<string, unknown>)['locationId']).toBe('L-1');
+    const rows = fixture.debugElement.queryAll(By.css('[data-testid^="inventory-location-row-"]'));
+    expect(rows.length).toBe(1);
+  });
+
   it('should load sync logs on init', async () => {
     await setup();
     expect(stubInventoryService.listSyncLogs).toHaveBeenCalledWith({ pageSize: 20 });

--- a/src/app/features/location/pages/location-sync/location-sync-page.component.ts
+++ b/src/app/features/location/pages/location-sync/location-sync-page.component.ts
@@ -109,6 +109,12 @@ export class LocationSyncPageComponent {
       return response;
     }
     const payload = this.toRecord(response);
+    // /locations returns a Spring `Page` (rows under `content`); the paged
+    // sync-logs response uses `items`. Accept either wrapper.
+    const content = payload?.['content'];
+    if (Array.isArray(content)) {
+      return content;
+    }
     const items = payload?.['items'];
     return Array.isArray(items) ? items : [];
   }


### PR DESCRIPTION
## Summary

Backend [durion-positivity-backend#813](https://github.com/louisburroughs/durion-positivity-backend/issues/813) finalized the canonical inventory route paths (`docs/frontend-audit-route-reconciliation.md`). This aligns the frontend to them and fixes a related data-unwrapping bug surfaced during the reconciliation.

**Route corrections** (`features/inventory/services/inventory.service.ts`):

| Method | Old path | Canonical path |
|---|---|---|
| `queryLedger` / `getLedgerEntry` | `/inventory/v1/ledger` | `/inventory/v1/inventory/ledger` |
| `getReturnableItems` | `/workorders/{id}/returnable-items` | `/inventory/returns/returnable-items?workorderId={id}` |
| `getReasonCodes` | `/reasons` | `/inventory/returns/reason-codes` |
| `submitReturnToStock` | `/movements/return-to-stock` | `/inventory/returns/submit-to-stock` |
| `getShortageOptions` | `/workorders/{id}/allocations/{id}/shortage-options` | `/inventory/shortage/options?allocationId={id}` |
| `resolveShortage` | `/workorders/{id}/allocations/{id}/resolve-shortage` | `/inventory/shortage/resolve` |

`getShortageOptions` no longer needs `workorderId` (the allocation id identifies the allocation); dropped the unused parameter and updated its sole caller.

**Data-unwrapping fix** (`features/location/pages/location-sync/`): `normalizeItems` only unwrapped `items`, but `/inventory/v1/inventory/locations` returns a Spring `Page` with rows under `content`, so the "Synced Locations" table stayed empty even though the endpoint works. It now accepts `content` (Spring Page) in addition to `items` (paged sync-logs response).

**Not in scope (already correct or backend-owned):** posting-rules 500 (backend `SortParamParser`), people 404s (semantic no-assignment outcomes), cycleCountPlans/putaway/replenishment/locations paths (already fixed in #144).

## Validation

- [x] `npm run build` (succeeds; only a pre-existing CSS-budget warning on unrelated `invoice-detail-page.component.css`)
- [x] `npm run test` (targeted): 297/297 inventory-domain tests + 10/10 location-sync tests pass

## Accessibility Verification (Required for Changed UI)

No UI structure, markup, or focus behavior changed. The route corrections are service-layer only; the location-sync fix only changes which array the existing table binds to (no template change). Keyboard/screen-reader smoke items are therefore N/A for this diff.

## Notes / Follow-ups

- The location-sync page's **Sync Logs** panel and **Trigger Sync** button depend on endpoints that don't yet exist in the backend; they are the deliverables of backend story [durion-positivity-backend#40](https://github.com/louisburroughs/durion-positivity-backend/issues/40). Tracked frontend-side by #150 — recheck #40 status and verify/wire (or remove) that functionality when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhnZH4hct5e1PUrgU4hUJK)_