### PR TITLE
Audit follow-up: human-readable IDs on detail pages + post-deploy API re-triage

### DIFF
--- a/docs/testing/frontend-audit-api-error-triage.md
+++ b/docs/testing/frontend-audit-api-error-triage.md
@@ -10,7 +10,7 @@ Everything below the line was re-probed after backend PR 817 deployed:
 
 | Endpoint | Was | Now |
 |---|---|---|
-| `/api/people/v1/people/me/primary-location` | 404 | **200** ✅ |
+| `/api/people/v1/people/me/primary-location` | 404 | **UNSTABLE** ⚠️ — 200 at 12:58Z, 404×5 by 13:05Z (see #160) |
 | `/api/people/v1/people/availability?locationId=<real>&date=…` | 404 | **200** ✅ |
 | `/api/inventory/v1/inventory/sync-logs` | 404 | **200** ✅ |
 | `/api/accounting/v1/accounting/posting-rules` | 500 | **200** ✅ |
@@ -19,6 +19,7 @@ Everything below the line was re-probed after backend PR 817 deployed:
 | `/api/inventory/v1/inventory/replenishment/tasks` | 404 | **200** ✅ |
 | `/api/inventory/v1/inventory/cycleCountPlans` | 404 | **200** ✅ |
 | CRM party detail cluster (below) | 404 | **404 — still broken** ❌ |
+| `/api/location/v1/locations/{id}` (+`/defaults`) | n/a | 404 during the 12:59Z crawl, **200** on direct probes minutes later — mid-rollout transient, not a defect |
 
 **Remaining defect — CRM list/detail inconsistency (customer module).**
 `GET /api/customer/v1/crm/accounts/parties` returns 20 parties, but for those

--- a/docs/testing/frontend-audit-api-error-triage.md
+++ b/docs/testing/frontend-audit-api-error-triage.md
@@ -4,6 +4,46 @@ Triage of the `failed-api-request` / `console-error` findings from the
 durionpos.org site audit (see `frontend-audit-test-plan.md`,
 `artifacts/audit/error-pages.md`).
 
+## Post-backend-PR-817 re-triage (2026-07-06, authenticated probes)
+
+Everything below the line was re-probed after backend PR 817 deployed:
+
+| Endpoint | Was | Now |
+|---|---|---|
+| `/api/people/v1/people/me/primary-location` | 404 | **200** ✅ |
+| `/api/people/v1/people/availability?locationId=<real>&date=…` | 404 | **200** ✅ |
+| `/api/inventory/v1/inventory/sync-logs` | 404 | **200** ✅ |
+| `/api/accounting/v1/accounting/posting-rules` | 500 | **200** ✅ |
+| `/api/inventory/v1/inventory/locations` | 404 | **200** ✅ (empty dataset) |
+| `/api/inventory/v1/inventory/putaway/tasks` | 404 | **200** ✅ |
+| `/api/inventory/v1/inventory/replenishment/tasks` | 404 | **200** ✅ |
+| `/api/inventory/v1/inventory/cycleCountPlans` | 404 | **200** ✅ |
+| CRM party detail cluster (below) | 404 | **404 — still broken** ❌ |
+
+**Remaining defect — CRM list/detail inconsistency (customer module).**
+`GET /api/customer/v1/crm/accounts/parties` returns 20 parties, but for those
+exact `partyId`s — ACTIVE and INACTIVE alike, PERSON type — every detail
+endpoint 404s:
+
+- `/v1/crm/accounts/parties/{partyId}` — Spring error body, `"path"` echoed
+- `/v1/crm/parties/{partyId}/communicationPreferences` — Spring error body
+- `/v1/crm/commercial-accounts/{partyId}/contacts` — Spring error body
+- `/v1/crm/snapshot/party/{partyId}` (+`/billing-rules`) — bodyless 404
+
+All paths are SDK-canonical (`@durion-sdk/customer`). The JSON error bodies
+show the customer service itself answering (not the gateway), so either the
+detail handlers query a store the list projection doesn't share, or the
+handlers aren't registered. Impact: the party-detail, contacts, billing-rules
+and CRM-snapshot pages render error/empty states for every real customer.
+Tracked as [#158](https://github.com/louisburroughs/durion-positivity-frontend/issues/158)
+(backend-owned; frontend already shows handled ADR-0031 error states).
+
+Related finding from the same day's investigation: stale pre-deploy tabs
+dead-click lazy-module nav links after a deploy —
+[#159](https://github.com/louisburroughs/durion-positivity-frontend/issues/159).
+
+---
+
 Ground truth for endpoint paths is the **`@durion-sdk/*`** packages (the
 generated gateway client) plus the per-module `AccountingConfiguration`-style
 basePaths wired in `src/app/app.config.ts`. Where the SDK does not model an

--- a/docs/testing/frontend-audit-api-error-triage.md
+++ b/docs/testing/frontend-audit-api-error-triage.md
@@ -4,43 +4,52 @@ Triage of the `failed-api-request` / `console-error` findings from the
 durionpos.org site audit (see `frontend-audit-test-plan.md`,
 `artifacts/audit/error-pages.md`).
 
-## Post-backend-PR-817 re-triage (2026-07-06, authenticated probes)
+## Post-backend re-triage (2026-07-07, authenticated probes)
 
-Everything below the line was re-probed after backend PR 817 deployed:
+Re-probed after the second backend deploy, with a **fresh** audit token.
 
-| Endpoint | Was | Now |
+> ⚠️ **Gateway auth gotcha that misled the first pass.** An expired or
+> bad-signature bearer token makes the gateway return **`200` with an empty
+> body** (not `401`). During the 2026-07-06 pass the audit token had aged out,
+> so the CRM endpoints looked like empty-200s. With a freshly minted token
+> (re-run `playwright test --project=setup`), the picture below is the real
+> one. Missing token / structurally-invalid token → `401`; valid-structure
+> bad-signature token → `200` empty. (Worth a separate gateway hardening note.)
+
+| Endpoint | Now | Verdict |
 |---|---|---|
-| `/api/people/v1/people/me/primary-location` | 404 | **UNSTABLE** ⚠️ — 200 at 12:58Z, 404×5 by 13:05Z (see #160) |
-| `/api/people/v1/people/availability?locationId=<real>&date=…` | 404 | **200** ✅ |
-| `/api/inventory/v1/inventory/sync-logs` | 404 | **200** ✅ |
-| `/api/accounting/v1/accounting/posting-rules` | 500 | **200** ✅ |
-| `/api/inventory/v1/inventory/locations` | 404 | **200** ✅ (empty dataset) |
-| `/api/inventory/v1/inventory/putaway/tasks` | 404 | **200** ✅ |
-| `/api/inventory/v1/inventory/replenishment/tasks` | 404 | **200** ✅ |
-| `/api/inventory/v1/inventory/cycleCountPlans` | 404 | **200** ✅ |
-| CRM party detail cluster (below) | 404 | **404 — still broken** ❌ |
-| `/api/location/v1/locations/{id}` (+`/defaults`) | n/a | 404 during the 12:59Z crawl, **200** on direct probes minutes later — mid-rollout transient, not a defect |
+| CRM party detail cluster (parties/{id}, communicationPreferences, commercial-accounts/{id}/contacts, snapshot/party/{id}, .../billing-rules) | **200 with real bodies** | ✅ **FIXED** — transferred to backend as durion-positivity-backend#818, closed |
+| `/api/people/v1/people/me/primary-location` | **404** `"No primary location assignment exists for requester on <date>"` | ✅ **working as intended** — admin.alpha has no primary location; frontend handles it (post-#157). #160 closed. |
+| `/api/people/v1/people/availability?locationId=<real>&date=…` | 200 | ✅ |
+| `/api/inventory/...` (sync-logs, locations, putaway, replenishment, cycleCountPlans) | 200 | ✅ |
+| `/api/accounting/v1/accounting/posting-rules` | 200 | ✅ |
+| `/api/location/v1/locations/{id}` (+`/defaults`) | 200 | ✅ (12:59Z crawl 404s were a mid-rollout transient) |
+| **people staffing / location-assignment query path** (below) | **500** | ❌ **new defect — #162** |
 
-**Remaining defect — CRM list/detail inconsistency (customer module).**
-`GET /api/customer/v1/crm/accounts/parties` returns 20 parties, but for those
-exact `partyId`s — ACTIVE and INACTIVE alike, PERSON type — every detail
-endpoint 404s:
+**New defect — people staffing/location endpoints throw 500.** Uncovered while
+confirming #160. With a valid admin token, these all `500 Internal Server
+Error` (Spring problem+json), while sibling people endpoints are fine:
 
-- `/v1/crm/accounts/parties/{partyId}` — Spring error body, `"path"` echoed
-- `/v1/crm/parties/{partyId}/communicationPreferences` — Spring error body
-- `/v1/crm/commercial-accounts/{partyId}/contacts` — Spring error body
-- `/v1/crm/snapshot/party/{partyId}` (+`/billing-rules`) — bodyless 404
+| Endpoint | Status |
+|---|---|
+| `GET /v1/people/me` | **500** |
+| `GET /v1/people/me/locations` | **500** |
+| `GET /v1/people/{id}/locations` | **500** |
+| `GET /v1/people/{id}/primary-location` | **500** (note: `me/primary-location` correctly 404s — inconsistent) |
+| `GET /v1/people/staffing/assignments?personId={id}` | **500** |
+| `GET /v1/people/{id}/staffing/assignments` | **500** |
+| `GET /v1/people/{id}` | 200 ✅ |
+| `GET /v1/people/{id}/access/assignments` | 200 ✅ |
+| `GET /v1/people` (list) | 200 ✅ |
 
-All paths are SDK-canonical (`@durion-sdk/customer`). The JSON error bodies
-show the customer service itself answering (not the gateway), so either the
-detail handlers query a store the list projection doesn't share, or the
-handlers aren't registered. Impact: the party-detail, contacts, billing-rules
-and CRM-snapshot pages render error/empty states for every real customer.
-Tracked as [#158](https://github.com/louisburroughs/durion-positivity-frontend/issues/158)
-(backend-owned; frontend already shows handled ADR-0031 error states).
+Frontend impact: `/app/people/person/{personId}/locations`
+(person-location-assignments) calls `getAssignments1(personId)` →
+`/v1/people/staffing/assignments?personId=…`, which 500s, so the page shows its
+error state for every person. Tracked as
+[#162](https://github.com/louisburroughs/durion-positivity-frontend/issues/162).
 
-Related finding from the same day's investigation: stale pre-deploy tabs
-dead-click lazy-module nav links after a deploy —
+Related finding from the same investigation: stale pre-deploy tabs dead-click
+lazy-module nav links after a deploy —
 [#159](https://github.com/louisburroughs/durion-positivity-frontend/issues/159).
 
 ---

--- a/docs/testing/frontend-audit-api-error-triage.md
+++ b/docs/testing/frontend-audit-api-error-triage.md
@@ -52,6 +52,25 @@ Related finding from the same investigation: stale pre-deploy tabs dead-click
 lazy-module nav links after a deploy —
 [#159](https://github.com/louisburroughs/durion-positivity-frontend/issues/159).
 
+### Post-deploy audit run (2026-07-07, fresh token): 12 High / 4 problem pages (was 33 / 12)
+
+The CRM cluster clearing dropped the count sharply. Remaining findings:
+
+- **uuid-on-screen ×4** — party-detail showed "Party ID: \<uuid\>",
+  location-defaults showed "Location ID: \<uuid\>". These only appeared *because*
+  the backend fix made the pages load real data. **Fixed on this branch**:
+  party-detail now shows the account/customer number (best-effort snapshot
+  fetch), location-defaults shows the location name·code.
+- **shopmgmt dispatch-board + mechanics/availability** — `me/primary-location`
+  404 (= #160, working as intended; admin.alpha has no primary location). The
+  `console-error` is the browser's automatic "Failed to load resource 404" log,
+  not app code — unavoidable while the user has no assignment. Not a defect.
+- **location detail 404** (`/app/location/locations/01960001-…/{,defaults}`) —
+  the crawler harvested locationId `01960001-…` from some record, but the real
+  locations are all `01960003-…`, so it's a **dangling location reference** in
+  seed data (some entity points at a location that doesn't exist). Backend/data
+  hygiene, low priority; the page shows its error state correctly. Not filed.
+
 ---
 
 Ground truth for endpoint paths is the **`@durion-sdk/*`** packages (the

--- a/src/app/core/services/locale.service.spec.ts
+++ b/src/app/core/services/locale.service.spec.ts
@@ -1,5 +1,6 @@
 import '@angular/compiler';
-import { createEnvironmentInjector, PLATFORM_ID, runInInjectionContext } from '@angular/core';
+import { createEnvironmentInjector, EnvironmentInjector, PLATFORM_ID, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { TranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -49,7 +50,7 @@ describe('LocaleService', () => {
     const injector = createEnvironmentInjector([
       { provide: PLATFORM_ID, useValue: 'browser' },
       { provide: TranslateService, useValue: translateService },
-    ], null);
+    ], TestBed.inject(EnvironmentInjector));
 
     service = runInInjectionContext(injector, () => new LocaleService());
   });

--- a/src/app/features/crm/pages/customer-list/customer-list.component.html
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.html
@@ -96,9 +96,9 @@
             @for (party of parties(); track party.partyId) {
               <tr class="party-row"
                   tabindex="0"
-                  (click)="openParty(party.partyId)"
-                  (keydown.enter)="openParty(party.partyId)"
-                  (keydown.space)="$event.preventDefault(); openParty(party.partyId)"
+                  (click)="openParty(party.partyId, party.customerNumber)"
+                  (keydown.enter)="openParty(party.partyId, party.customerNumber)"
+                  (keydown.space)="$event.preventDefault(); openParty(party.partyId, party.customerNumber)"
                   [attr.aria-label]="'Open party record for ' + party.legalName">
                 <td>
                   <span class="party-row__name">{{ party.legalName }}</span>

--- a/src/app/features/crm/pages/customer-list/customer-list.component.ts
+++ b/src/app/features/crm/pages/customer-list/customer-list.component.ts
@@ -134,8 +134,11 @@ export class CustomerListComponent implements OnInit {
     return party.primaryContact?.name ? party.primaryContact : undefined;
   }
 
-  openParty(partyId: string): void {
-    this.router.navigate(['/app/crm/party', partyId]);
+  openParty(partyId: string, customerNumber?: string): void {
+    // Carry the human-readable customer number so the detail page can show it
+    // without re-fetching (the party detail endpoint omits it). Falls back to a
+    // snapshot fetch on direct navigation / refresh where no state is passed.
+    this.router.navigate(['/app/crm/party', partyId], { state: { customerNumber } });
   }
 
   createCommercial(): void {

--- a/src/app/features/crm/pages/party-detail/party-detail.component.html
+++ b/src/app/features/crm/pages/party-detail/party-detail.component.html
@@ -33,8 +33,10 @@
         <p class="party-dba">DBA: {{ party()!.dba }}</p>
       }
       <dl class="party-meta">
-        <dt>Party ID</dt>
-        <dd><code>{{ party()!.partyId }}</code></dd>
+        @if (customerNumber(); as customerNo) {
+          <dt>Customer #</dt>
+          <dd data-testid="customer-number">{{ customerNo }}</dd>
+        }
         @if (party()!.taxId) {
           <dt>Tax ID</dt>
           <dd>{{ party()!.taxId }}</dd>

--- a/src/app/features/crm/pages/party-detail/party-detail.component.spec.ts
+++ b/src/app/features/crm/pages/party-detail/party-detail.component.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { convertToParamMap, ActivatedRoute, Router } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+import { PartyDetailComponent } from './party-detail.component';
+import { CrmService } from '../../services/crm.service';
+
+const PARTY_ID = '01960020-0000-7000-8000-00000000002b';
+
+const crmServiceStub = {
+  getParty: vi.fn(),
+  getContactsWithRoles: vi.fn(),
+  getCommunicationPreferences: vi.fn(),
+  fetchByParty: vi.fn(),
+};
+
+const routerStub = {
+  // Nav state captured at construction; overridden per test.
+  getCurrentNavigation: vi.fn().mockReturnValue(null),
+  navigate: vi.fn(),
+};
+
+describe('PartyDetailComponent', () => {
+  let fixture: ComponentFixture<PartyDetailComponent>;
+
+  const setup = async () => {
+    crmServiceStub.getParty.mockReturnValue(of({ partyId: PARTY_ID, legalName: 'Albert Rogers' }));
+    crmServiceStub.getContactsWithRoles.mockReturnValue(of([]));
+    crmServiceStub.getCommunicationPreferences.mockReturnValue(of(null));
+
+    await TestBed.configureTestingModule({
+      imports: [PartyDetailComponent, TranslateModule.forRoot()],
+      providers: [
+        { provide: CrmService, useValue: crmServiceStub },
+        { provide: Router, useValue: routerStub },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: convertToParamMap({ partyId: PARTY_ID }) } } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PartyDetailComponent);
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    routerStub.getCurrentNavigation.mockReturnValue(null);
+    TestBed.resetTestingModule();
+  });
+
+  it('shows the customer number carried via router state without fetching the snapshot', async () => {
+    routerStub.getCurrentNavigation.mockReturnValue({ extras: { state: { customerNumber: 'CUST-PP-043' } } });
+    await setup();
+
+    expect(crmServiceStub.fetchByParty).not.toHaveBeenCalled();
+    const cell = fixture.debugElement.query(By.css('[data-testid="customer-number"]'));
+    expect(cell.nativeElement.textContent.trim()).toBe('CUST-PP-043');
+  });
+
+  it('falls back to the snapshot account number on direct navigation', async () => {
+    crmServiceStub.fetchByParty.mockReturnValue(of({ account: { accountNumber: 'CUST-PP-099' } }));
+    await setup();
+
+    expect(crmServiceStub.fetchByParty).toHaveBeenCalledWith(PARTY_ID);
+    const cell = fixture.debugElement.query(By.css('[data-testid="customer-number"]'));
+    expect(cell.nativeElement.textContent.trim()).toBe('CUST-PP-099');
+  });
+
+  it('never renders the raw partyId UUID, and hides the row when no number resolves', async () => {
+    crmServiceStub.fetchByParty.mockReturnValue(throwError(() => new Error('no snapshot')));
+    await setup();
+
+    expect(fixture.debugElement.query(By.css('[data-testid="customer-number"]'))).toBeNull();
+    expect(fixture.nativeElement.textContent).not.toContain(PARTY_ID);
+  });
+});

--- a/src/app/features/crm/pages/party-detail/party-detail.component.ts
+++ b/src/app/features/crm/pages/party-detail/party-detail.component.ts
@@ -56,6 +56,11 @@ export class PartyDetailComponent implements OnInit {
     return this.route.snapshot.paramMap.get('partyId') ?? '';
   }
 
+  // Customer number passed via router state when navigating from the customer
+  // list (captured at construction, before the navigation settles).
+  private readonly passedCustomerNumber =
+    this.router.getCurrentNavigation()?.extras.state?.['customerNumber'];
+
   ngOnInit(): void {
     this.loadParty();
     this.loadContacts();
@@ -63,11 +68,19 @@ export class PartyDetailComponent implements OnInit {
     this.loadCustomerNumber();
   }
 
-  // Best-effort human-readable account number for the header (UI rule: no raw
-  // UUID on screen). Silent on failure — the h1 name still identifies the party.
+  // Human-readable account number for the header (UI rule: no raw UUID on
+  // screen). Prefer the value carried from the browse row; only on direct
+  // navigation / refresh do we fall back to a best-effort snapshot fetch. The
+  // h1 name still identifies the party if neither is available.
   private loadCustomerNumber(): void {
+    if (typeof this.passedCustomerNumber === 'string' && this.passedCustomerNumber) {
+      this.customerNumber.set(this.passedCustomerNumber);
+      return;
+    }
     this.crm.fetchByParty(this.partyId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: snapshot => {
+        // The snapshot's account block is AccountSummary at runtime
+        // (`accountNumber`), though the local model still types it as PartyDetail.
         const account = (snapshot?.account ?? {}) as Record<string, unknown>;
         const number = account['accountNumber'] ?? account['customerNumber'];
         this.customerNumber.set(typeof number === 'string' ? number : '');

--- a/src/app/features/crm/pages/party-detail/party-detail.component.ts
+++ b/src/app/features/crm/pages/party-detail/party-detail.component.ts
@@ -32,6 +32,10 @@ export class PartyDetailComponent implements OnInit {
   // ── Party ───────────────────────────────────────────────────────────────
   readonly partyState  = signal<SectionState>('loading');
   readonly party       = signal<PartyDetail | null>(null);
+  // Human-readable account number so we never publish the raw partyId UUID on
+  // screen (UI rule). The party detail endpoint omits it; the snapshot's
+  // account block carries it, so we fetch it best-effort.
+  readonly customerNumber = signal('');
 
   // ── Contacts ─────────────────────────────────────────────────────────
   readonly contactsState = signal<SectionState>('loading');
@@ -56,6 +60,20 @@ export class PartyDetailComponent implements OnInit {
     this.loadParty();
     this.loadContacts();
     this.loadPrefs();
+    this.loadCustomerNumber();
+  }
+
+  // Best-effort human-readable account number for the header (UI rule: no raw
+  // UUID on screen). Silent on failure — the h1 name still identifies the party.
+  private loadCustomerNumber(): void {
+    this.crm.fetchByParty(this.partyId).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: snapshot => {
+        const account = (snapshot?.account ?? {}) as Record<string, unknown>;
+        const number = account['accountNumber'] ?? account['customerNumber'];
+        this.customerNumber.set(typeof number === 'string' ? number : '');
+      },
+      error: () => this.customerNumber.set(''),
+    });
   }
 
   // ── Load party ─────────────────────────────────────────────────────────

--- a/src/app/features/location/pages/location-defaults/location-defaults-page.component.html
+++ b/src/app/features/location/pages/location-defaults/location-defaults-page.component.html
@@ -1,7 +1,9 @@
 <main>
   <header class="page-header">
     <h1>Site Default Locations</h1>
-    <p>Location ID: <code data-testid="location-id">{{ locationId() }}</code></p>
+    @if (locationLabel(); as label) {
+    <p data-testid="location-label">{{ label }}</p>
+    }
   </header>
 
   @if (loading()) {

--- a/src/app/features/location/pages/location-defaults/location-defaults-page.component.spec.ts
+++ b/src/app/features/location/pages/location-defaults/location-defaults-page.component.spec.ts
@@ -18,6 +18,7 @@ const STORAGE_LOCATIONS = [
 ];
 
 const stubLocationService = {
+  getLocationById: vi.fn(),
   getLocationDefaults: vi.fn(),
   listStorageLocations: vi.fn(),
   configureLocationDefaults: vi.fn(),
@@ -34,6 +35,9 @@ describe('LocationDefaultsPageComponent [CAP-214 #102]', () => {
 
   const setup = async (options: SetupOptions = {}) => {
     vi.clearAllMocks();
+    stubLocationService.getLocationById.mockReturnValue(
+      of({ id: 'LOC-001', name: 'Charlotte Hub', code: 'CLT-01' }),
+    );
     stubLocationService.getLocationDefaults.mockReturnValue(
       options.defaultsResult ?? of(DEFAULTS),
     );
@@ -66,11 +70,14 @@ describe('LocationDefaultsPageComponent [CAP-214 #102]', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display location ID from route param', async () => {
+  it('resolves the location from the route param and shows a human-readable label', async () => {
     await setup();
     expect(component.locationId()).toBe('LOC-001');
-    const el = fixture.debugElement.query(By.css('[data-testid="location-id"]'));
-    expect(el.nativeElement.textContent.trim()).toBe('LOC-001');
+    expect(stubLocationService.getLocationById).toHaveBeenCalledWith('LOC-001');
+    const el = fixture.debugElement.query(By.css('[data-testid="location-label"]'));
+    expect(el.nativeElement.textContent.trim()).toBe('Charlotte Hub · CLT-01');
+    // The raw location UUID must not be published on screen (UI rule).
+    expect(fixture.nativeElement.textContent).not.toContain('LOC-001');
   });
 
   it('should load defaults and storage locations on init', async () => {

--- a/src/app/features/location/pages/location-defaults/location-defaults-page.component.ts
+++ b/src/app/features/location/pages/location-defaults/location-defaults-page.component.ts
@@ -91,7 +91,9 @@ export class LocationDefaultsPageComponent {
   }
 
   // Human-readable label for the location so the page never publishes the raw
-  // UUID on screen (UI rule). Falls back silently to the id if the lookup fails.
+  // UUID on screen (UI rule). If the lookup fails (e.g. a dangling id) the label
+  // stays empty and the header simply omits the identifier — the raw id is never
+  // shown as a fallback. Guarded against out-of-order responses on rapid nav.
   private loadLocationLabel(): void {
     const locationId = this.locationId();
     if (!locationId) {
@@ -101,13 +103,20 @@ export class LocationDefaultsPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (location) => {
+          if (this.locationId() !== locationId) {
+            return; // route changed while this request was in flight
+          }
           const rec = this.toRecord(location);
           const name = rec?.['name'];
           const code = rec?.['code'];
           const label = [name, code].filter(v => typeof v === 'string' && v.trim()).join(' · ');
           this.locationLabel.set(label);
         },
-        error: () => this.locationLabel.set(''),
+        error: () => {
+          if (this.locationId() === locationId) {
+            this.locationLabel.set('');
+          }
+        },
       });
   }
 

--- a/src/app/features/location/pages/location-defaults/location-defaults-page.component.ts
+++ b/src/app/features/location/pages/location-defaults/location-defaults-page.component.ts
@@ -27,6 +27,7 @@ export class LocationDefaultsPageComponent {
   private readonly formStateTick = signal(0);
 
   readonly locationId = signal('');
+  readonly locationLabel = signal('');
   readonly siteDefaults = signal<Record<string, unknown> | null>(null);
   readonly storageLocations = signal<unknown[]>([]);
   readonly loading = signal(false);
@@ -65,11 +66,13 @@ export class LocationDefaultsPageComponent {
       .subscribe(params => {
         const routeLocationId = String(params['locationId'] ?? '');
         this.locationId.set(routeLocationId);
+        this.locationLabel.set('');
         if (!routeLocationId) {
           this.siteDefaults.set(null);
           this.storageLocations.set([]);
           return;
         }
+        this.loadLocationLabel();
         this.loadDefaults();
         this.loadStorageLocations();
       });
@@ -84,6 +87,27 @@ export class LocationDefaultsPageComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
         this.formStateTick.update(v => v + 1);
+      });
+  }
+
+  // Human-readable label for the location so the page never publishes the raw
+  // UUID on screen (UI rule). Falls back silently to the id if the lookup fails.
+  private loadLocationLabel(): void {
+    const locationId = this.locationId();
+    if (!locationId) {
+      return;
+    }
+    this.locationService.getLocationById(locationId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (location) => {
+          const rec = this.toRecord(location);
+          const name = rec?.['name'];
+          const code = rec?.['code'];
+          const label = [name, code].filter(v => typeof v === 'string' && v.trim()).join(' · ');
+          this.locationLabel.set(label);
+        },
+        error: () => this.locationLabel.set(''),
       });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to the site audit (PR louisburroughs/durion-positivity-frontend#157) after the backend deploys. Fixes the two `uuid-on-screen` findings that surfaced once the backend fix let CRM/location detail pages load real data, and records the post-deploy API re-triage.

- **party-detail** (`/app/crm/party/{partyId}`): the header meta rendered `Party ID: <uuid>`. The party detail endpoint omits the customer number, so we fetch it best-effort from the CRM snapshot's `account` block and show `Customer #: CUST-…` instead. Silent on failure — the `<h1>` name still identifies the party.
- **location-defaults** (`/app/location/locations/{id}/defaults`): the subtitle rendered `Location ID: <uuid>`. We now resolve the location via `getLocationById` and show `name · code`. Silent on failure. Spec updated to assert the human-readable label renders and the raw id no longer appears.
- **Triage doc** (`docs/testing/frontend-audit-api-error-triage.md`): post-deploy re-triage. CRM detail cluster fixed (backend #818, closed); `me/primary-location` 404 confirmed working-as-intended (#160 closed); new people-staffing 500 cluster filed (#162). Audit dropped from 33 High / 12 problem pages to 12 / 4.

Neither raw UUID is rendered anymore (UI rule: no UUIDs published on screen).

## Validation

- [x] `npm run build` (clean; pre-existing invoice-detail CSS-budget warning unrelated)
- [x] Targeted suites: CRM + location — 232 tests pass
- [x] `npm run lint:css`, `npm run i18n:check` (4 locales aligned)
- [x] Live probes against durionpos.org confirmed the endpoint statuses recorded in the triage doc

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

UI delta is minimal: two header/subtitle text fields swap a raw UUID for a human-readable identifier; no interactive controls added or moved. Manual keyboard/SR smoke not performed in this environment.

## Notes / Follow-ups

- Backend items tracked in the triage doc: louisburroughs/durion-positivity-backend#820 (people staffing 500 cluster) is the open one; #818 (CRM detail) and louisburroughs/durion-positivity-frontend#160 (primary-location) are resolved.
- A dangling location reference in seed data (`locationId 01960001-…` with no matching location) is noted in the doc but not filed — low-priority data hygiene; the page shows its error state correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJFQPVWHnzg5YFL82jMLkT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJFQPVWHnzg5YFL82jMLkT)_