### PR TITLE
Recover stale-tab lazy-chunk failures after a deploy (#159)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,7 @@
 import { provideAppInitializer, ApplicationConfig, provideBrowserGlobalErrorListeners, importProvidersFrom, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { provideRouter, withComponentInputBinding, withNavigationErrorHandler } from '@angular/router';
+import { NavigationEnd, provideRouter, Router, withComponentInputBinding, withNavigationErrorHandler } from '@angular/router';
+import { filter, take } from 'rxjs/operators';
 import { HttpClient, provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { firstValueFrom, Observable, of } from 'rxjs';
@@ -22,7 +23,7 @@ import { Configuration as ShopManagerConfiguration } from '@durion-sdk/shop-mana
 import { Configuration as WorkorderConfiguration } from '@durion-sdk/workorder';
 
 import { routes } from './app.routes';
-import { recoverFromChunkError } from './core/router/chunk-error-recovery';
+import { clearChunkReloadGuard, recoverFromChunkError } from './core/router/chunk-error-recovery';
 import { AuthService } from './core/services/auth.service';
 import { LocaleService } from './core/services/locale.service';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
@@ -73,6 +74,15 @@ export const appConfig: ApplicationConfig = {
         }
       }),
     ),
+    // Reset the chunk-reload budget once the app completes a navigation: a
+    // successful nav proves the tab is healthy, so the next stale-chunk click
+    // gets a fresh recovery attempt (see chunk-error-recovery.ts).
+    provideAppInitializer(() => {
+      if (!isPlatformBrowser(inject(PLATFORM_ID))) return;
+      inject(Router).events
+        .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd), take(1))
+        .subscribe(() => clearChunkReloadGuard());
+    }),
     provideHttpClient(
       withFetch(),
       withInterceptors([authInterceptor]),

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { provideAppInitializer, ApplicationConfig, provideBrowserGlobalErrorListeners, importProvidersFrom, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideRouter, withComponentInputBinding, withNavigationErrorHandler } from '@angular/router';
 import { HttpClient, provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { firstValueFrom, Observable, of } from 'rxjs';
@@ -22,6 +22,7 @@ import { Configuration as ShopManagerConfiguration } from '@durion-sdk/shop-mana
 import { Configuration as WorkorderConfiguration } from '@durion-sdk/workorder';
 
 import { routes } from './app.routes';
+import { recoverFromChunkError } from './core/router/chunk-error-recovery';
 import { AuthService } from './core/services/auth.service';
 import { LocaleService } from './core/services/locale.service';
 import { authInterceptor } from './core/interceptors/auth.interceptor';
@@ -61,7 +62,17 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideAppInitializer(() => firstValueFrom(inject(AuthService).validateSessionOnResume())),
     provideBrowserGlobalErrorListeners(),
-    provideRouter(routes, withComponentInputBinding()),
+    provideRouter(
+      routes,
+      withComponentInputBinding(),
+      // Recover stale-tab lazy-chunk failures after a deploy by reloading the
+      // attempted URL (browser only; a no-op during SSR).
+      withNavigationErrorHandler(event => {
+        if (isPlatformBrowser(inject(PLATFORM_ID))) {
+          recoverFromChunkError(event);
+        }
+      }),
+    ),
     provideHttpClient(
       withFetch(),
       withInterceptors([authInterceptor]),

--- a/src/app/core/router/chunk-error-recovery.spec.ts
+++ b/src/app/core/router/chunk-error-recovery.spec.ts
@@ -1,19 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NavigationError } from '@angular/router';
-import { isChunkLoadError, recoverFromChunkError } from './chunk-error-recovery';
+import { isChunkLoadError, recoverFromChunkError, clearChunkReloadGuard } from './chunk-error-recovery';
 
 const navError = (error: unknown, url = '/app/billing'): NavigationError =>
   new NavigationError(1, url, error);
 
-function fakeWindow() {
+function fakeWindow(opts: { throwStorage?: boolean } = {}) {
   const store = new Map<string, string>();
+  const throwing = { getItem: () => { throw new Error('blocked'); }, setItem: () => { throw new Error('blocked'); }, removeItem: () => { throw new Error('blocked'); } };
+  const working = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
   return {
     location: { pathname: '/app', assign: vi.fn() },
-    sessionStorage: {
-      getItem: (k: string) => store.get(k) ?? null,
-      setItem: (k: string, v: string) => void store.set(k, v),
-      removeItem: (k: string) => void store.delete(k),
-    },
+    sessionStorage: opts.throwStorage ? throwing : working,
   } as unknown as Window;
 }
 
@@ -26,10 +28,19 @@ describe('isChunkLoadError', () => {
     expect(isChunkLoadError(new Error('Loading chunk 42 failed'))).toBe(true);
   });
 
-  it('ignores unrelated navigation errors and nullish input', () => {
+  it('walks a wrapped error.cause', () => {
+    const wrapped = new Error('Unable to load route', {
+      cause: new Error('Failed to fetch dynamically imported module: /chunk-ABC.js'),
+    });
+    expect(isChunkLoadError(wrapped)).toBe(true);
+  });
+
+  it('ignores unrelated errors, nullish input, and deep non-matching cause chains', () => {
     expect(isChunkLoadError(new Error('Cannot match any routes'))).toBe(false);
     expect(isChunkLoadError(null)).toBe(false);
     expect(isChunkLoadError(undefined)).toBe(false);
+    const deep = new Error('a', { cause: new Error('b', { cause: new Error('c') }) });
+    expect(isChunkLoadError(deep)).toBe(false);
   });
 });
 
@@ -39,37 +50,58 @@ describe('recoverFromChunkError', () => {
 
   it('reloads the attempted URL on a stale-chunk failure', () => {
     const handled = recoverFromChunkError(
-      navError(new Error('Failed to fetch dynamically imported module'), '/app/people'),
-      win, 1000,
+      navError(new Error('Failed to fetch dynamically imported module'), '/app/people'), win,
     );
     expect(handled).toBe(true);
     expect(win.location.assign).toHaveBeenCalledWith('/app/people');
   });
 
   it('does not reload for a non-chunk navigation error', () => {
-    const handled = recoverFromChunkError(navError(new Error('Cannot match any routes')), win, 1000);
+    const handled = recoverFromChunkError(navError(new Error('Cannot match any routes')), win);
     expect(handled).toBe(false);
     expect(win.location.assign).not.toHaveBeenCalled();
   });
 
-  it('suppresses a second reload for the same URL within the guard window', () => {
+  it('never reloads the same URL twice (broken-deploy loop protection)', () => {
     const err = navError(new Error('ChunkLoadError'), '/app/location');
-    expect(recoverFromChunkError(err, win, 1000)).toBe(true);
-    // Same URL failing again 3s later → broken deploy, do not loop.
-    expect(recoverFromChunkError(err, win, 4000)).toBe(false);
+    expect(recoverFromChunkError(err, win)).toBe(true);
+    // Simulates the post-reload re-bootstrap failing on the same URL — must stop
+    // regardless of how long the reload took (count-based, not time-based).
+    expect(recoverFromChunkError(err, win)).toBe(false);
     expect(win.location.assign).toHaveBeenCalledTimes(1);
   });
 
-  it('recovers again for the same URL after the guard window elapses (later deploy)', () => {
+  it('caps total reloads across distinct URLs (systemic shared-chunk break)', () => {
+    for (const path of ['/a', '/b', '/c', '/d', '/e']) {
+      recoverFromChunkError(navError(new Error('ChunkLoadError'), path), win);
+    }
+    expect(win.location.assign).toHaveBeenCalledTimes(3); // MAX_RELOADS
+  });
+
+  it('fails safe (no reload) when sessionStorage is unavailable — cannot guard a loop', () => {
+    const blocked = fakeWindow({ throwStorage: true });
+    const handled = recoverFromChunkError(navError(new Error('ChunkLoadError')), blocked);
+    expect(handled).toBe(false);
+    expect(blocked.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('allows a fresh recovery after the guard is cleared (healthy navigation)', () => {
     const err = navError(new Error('ChunkLoadError'), '/app/location');
-    expect(recoverFromChunkError(err, win, 1000)).toBe(true);
-    expect(recoverFromChunkError(err, win, 1000 + 20_000)).toBe(true);
+    expect(recoverFromChunkError(err, win)).toBe(true);
+    clearChunkReloadGuard(win);
+    expect(recoverFromChunkError(err, win)).toBe(true);
     expect(win.location.assign).toHaveBeenCalledTimes(2);
   });
 
   it('falls back to the current pathname when the event URL is empty', () => {
-    const handled = recoverFromChunkError(navError(new Error('ChunkLoadError'), ''), win, 1000);
+    const handled = recoverFromChunkError(navError(new Error('ChunkLoadError'), ''), win);
     expect(handled).toBe(true);
     expect(win.location.assign).toHaveBeenCalledWith('/app');
+  });
+});
+
+describe('clearChunkReloadGuard', () => {
+  it('does not throw when sessionStorage is unavailable', () => {
+    expect(() => clearChunkReloadGuard(fakeWindow({ throwStorage: true }))).not.toThrow();
   });
 });

--- a/src/app/core/router/chunk-error-recovery.spec.ts
+++ b/src/app/core/router/chunk-error-recovery.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NavigationError } from '@angular/router';
+import { isChunkLoadError, recoverFromChunkError } from './chunk-error-recovery';
+
+const navError = (error: unknown, url = '/app/billing'): NavigationError =>
+  new NavigationError(1, url, error);
+
+function fakeWindow() {
+  const store = new Map<string, string>();
+  return {
+    location: { pathname: '/app', assign: vi.fn() },
+    sessionStorage: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    },
+  } as unknown as Window;
+}
+
+describe('isChunkLoadError', () => {
+  it('matches the dynamic-import failures each browser emits', () => {
+    expect(isChunkLoadError({ name: 'ChunkLoadError' })).toBe(true);
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module: /chunk-ABC.js'))).toBe(true);
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true);
+    expect(isChunkLoadError(new Error('Loading chunk 42 failed'))).toBe(true);
+  });
+
+  it('ignores unrelated navigation errors and nullish input', () => {
+    expect(isChunkLoadError(new Error('Cannot match any routes'))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('recoverFromChunkError', () => {
+  let win: Window;
+  beforeEach(() => { win = fakeWindow(); });
+
+  it('reloads the attempted URL on a stale-chunk failure', () => {
+    const handled = recoverFromChunkError(
+      navError(new Error('Failed to fetch dynamically imported module'), '/app/people'),
+      win, 1000,
+    );
+    expect(handled).toBe(true);
+    expect(win.location.assign).toHaveBeenCalledWith('/app/people');
+  });
+
+  it('does not reload for a non-chunk navigation error', () => {
+    const handled = recoverFromChunkError(navError(new Error('Cannot match any routes')), win, 1000);
+    expect(handled).toBe(false);
+    expect(win.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('suppresses a second reload for the same URL within the guard window', () => {
+    const err = navError(new Error('ChunkLoadError'), '/app/location');
+    expect(recoverFromChunkError(err, win, 1000)).toBe(true);
+    // Same URL failing again 3s later → broken deploy, do not loop.
+    expect(recoverFromChunkError(err, win, 4000)).toBe(false);
+    expect(win.location.assign).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers again for the same URL after the guard window elapses (later deploy)', () => {
+    const err = navError(new Error('ChunkLoadError'), '/app/location');
+    expect(recoverFromChunkError(err, win, 1000)).toBe(true);
+    expect(recoverFromChunkError(err, win, 1000 + 20_000)).toBe(true);
+    expect(win.location.assign).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the current pathname when the event URL is empty', () => {
+    const handled = recoverFromChunkError(navError(new Error('ChunkLoadError'), ''), win, 1000);
+    expect(handled).toBe(true);
+    expect(win.location.assign).toHaveBeenCalledWith('/app');
+  });
+});

--- a/src/app/core/router/chunk-error-recovery.ts
+++ b/src/app/core/router/chunk-error-recovery.ts
@@ -10,9 +10,15 @@ import { NavigationError } from '@angular/router';
  * aborts the navigation — the click appears to do nothing.
  *
  * We detect that specific failure and do a full-page load of the attempted URL,
- * which fetches the fresh index.html + chunk map and completes the navigation
- * the user asked for. A short session-scoped guard prevents a genuinely broken
- * deploy from reload-looping.
+ * which fetches the fresh index.html + chunk map and completes the navigation.
+ *
+ * Loop safety is the hard part (a genuinely broken deploy must not reload
+ * forever), so the guard is **count-based, not time-based** — a wall-clock
+ * window can be exceeded by a slow re-bootstrap and defeat itself. The budget
+ * is persisted in sessionStorage (the only state that survives a reload) and
+ * is reset by `clearChunkReloadGuard()` on the first successful navigation
+ * after each load, which proves the tab is healthy. If sessionStorage is
+ * unavailable we cannot prevent a loop, so we fail safe and do NOT reload.
  */
 
 const CHUNK_ERROR_PATTERNS: readonly RegExp[] = [
@@ -23,48 +29,82 @@ const CHUNK_ERROR_PATTERNS: readonly RegExp[] = [
   /Importing a module script failed/i, // Safari
 ];
 
-/** True when the error is a failed lazy-chunk / dynamic-import fetch. */
-export function isChunkLoadError(error: unknown): boolean {
-  if (!error) return false;
+const MAX_CAUSE_DEPTH = 4;
+
+/** True when the error (or a wrapped `cause`) is a failed lazy-chunk fetch. */
+export function isChunkLoadError(error: unknown, depth = 0): boolean {
+  if (!error || depth > MAX_CAUSE_DEPTH) return false;
   if ((error as { name?: string }).name === 'ChunkLoadError') return true;
   const message = (error as { message?: string }).message ?? String(error);
-  return CHUNK_ERROR_PATTERNS.some(re => re.test(message));
+  if (CHUNK_ERROR_PATTERNS.some(re => re.test(message))) return true;
+  // Bundlers/Angular may wrap the underlying fetch failure as `error.cause`.
+  return isChunkLoadError((error as { cause?: unknown }).cause, depth + 1);
 }
 
-const RELOAD_GUARD_PREFIX = 'chunk-reload:';
-/** Suppress a second reload for the same URL within this window (broken deploy). */
-const RELOAD_GUARD_MS = 10_000;
+const GUARD_KEY = 'chunk-reload-guard';
+/** Cap total recovery reloads between healthy navigations (systemic-break backstop). */
+const MAX_RELOADS = 3;
+
+interface ReloadGuard {
+  /** Total recovery reloads since the last healthy navigation. */
+  n: number;
+  /** URLs already reloaded once — never reload the same route twice in a row. */
+  urls: string[];
+}
+
+function readGuard(storage: Storage): ReloadGuard {
+  try {
+    const raw = storage.getItem(GUARD_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<ReloadGuard>;
+      return { n: parsed.n ?? 0, urls: Array.isArray(parsed.urls) ? parsed.urls : [] };
+    }
+  } catch {
+    // fall through
+  }
+  return { n: 0, urls: [] };
+}
 
 /**
  * If the navigation failed on a stale chunk, reload the attempted URL and
- * return true. Otherwise return false and let the error propagate.
+ * return true. Otherwise (or if we can't safely guard against a loop) return
+ * false and let the error propagate.
  *
- * Injectable seams (`win`, `now`) keep it unit-testable and SSR-safe — callers
- * only invoke it in the browser.
+ * `win` is injectable for tests and SSR-safety — callers invoke it in the
+ * browser only.
  */
-export function recoverFromChunkError(
-  event: NavigationError,
-  win: Window = window,
-  now: number = Date.now(),
-): boolean {
+export function recoverFromChunkError(event: NavigationError, win: Window = window): boolean {
   if (!isChunkLoadError(event.error)) return false;
 
   const url = event.url || win.location.pathname;
-  const key = RELOAD_GUARD_PREFIX + url;
+
+  // Persistence is mandatory: without it we can't tell a first attempt from a
+  // loop, so failing safe (no reload) beats reloading forever.
+  let storage: Storage;
   try {
-    const last = Number(win.sessionStorage.getItem(key));
-    if (last && now - last < RELOAD_GUARD_MS) {
-      // Already reloaded for this URL moments ago and it still fails — a truly
-      // broken deploy, not a stale tab. Stop so the error surfaces instead of
-      // looping. Clear the marker so a later, unrelated deploy can recover.
-      win.sessionStorage.removeItem(key);
-      return false;
+    storage = win.sessionStorage;
+    const guard = readGuard(storage);
+    if (guard.n >= MAX_RELOADS || guard.urls.includes(url)) {
+      return false; // budget spent, or already reloaded this route once — stop.
     }
-    win.sessionStorage.setItem(key, String(now));
+    storage.setItem(GUARD_KEY, JSON.stringify({ n: guard.n + 1, urls: [...guard.urls, url] }));
   } catch {
-    // sessionStorage unavailable (private mode) — reload once anyway.
+    return false; // sessionStorage blocked/full — cannot guard a loop, so don't reload.
   }
 
   win.location.assign(url);
   return true;
+}
+
+/**
+ * Reset the reload budget. Call on the first successful navigation after a page
+ * load: reaching it proves the tab is healthy, so any future stale-chunk click
+ * gets a fresh recovery attempt.
+ */
+export function clearChunkReloadGuard(win: Window = window): void {
+  try {
+    win.sessionStorage.removeItem(GUARD_KEY);
+  } catch {
+    // nothing to clear
+  }
 }

--- a/src/app/core/router/chunk-error-recovery.ts
+++ b/src/app/core/router/chunk-error-recovery.ts
@@ -1,0 +1,70 @@
+import { NavigationError } from '@angular/router';
+
+/**
+ * Recovery for stale-tab chunk-load failures after a deploy.
+ *
+ * Domain modules under /app are lazy-loaded as content-hashed chunks. A deploy
+ * replaces those files, so a tab opened before the deploy holds an outdated
+ * chunk map: navigating to a not-yet-visited module requests an old chunk
+ * filename that now 404s, the dynamic import rejects, and the router silently
+ * aborts the navigation — the click appears to do nothing.
+ *
+ * We detect that specific failure and do a full-page load of the attempted URL,
+ * which fetches the fresh index.html + chunk map and completes the navigation
+ * the user asked for. A short session-scoped guard prevents a genuinely broken
+ * deploy from reload-looping.
+ */
+
+const CHUNK_ERROR_PATTERNS: readonly RegExp[] = [
+  /ChunkLoadError/i,
+  /Loading chunk \d+ failed/i,
+  /Failed to fetch dynamically imported module/i, // Chromium
+  /error loading dynamically imported module/i, // Firefox
+  /Importing a module script failed/i, // Safari
+];
+
+/** True when the error is a failed lazy-chunk / dynamic-import fetch. */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  if ((error as { name?: string }).name === 'ChunkLoadError') return true;
+  const message = (error as { message?: string }).message ?? String(error);
+  return CHUNK_ERROR_PATTERNS.some(re => re.test(message));
+}
+
+const RELOAD_GUARD_PREFIX = 'chunk-reload:';
+/** Suppress a second reload for the same URL within this window (broken deploy). */
+const RELOAD_GUARD_MS = 10_000;
+
+/**
+ * If the navigation failed on a stale chunk, reload the attempted URL and
+ * return true. Otherwise return false and let the error propagate.
+ *
+ * Injectable seams (`win`, `now`) keep it unit-testable and SSR-safe — callers
+ * only invoke it in the browser.
+ */
+export function recoverFromChunkError(
+  event: NavigationError,
+  win: Window = window,
+  now: number = Date.now(),
+): boolean {
+  if (!isChunkLoadError(event.error)) return false;
+
+  const url = event.url || win.location.pathname;
+  const key = RELOAD_GUARD_PREFIX + url;
+  try {
+    const last = Number(win.sessionStorage.getItem(key));
+    if (last && now - last < RELOAD_GUARD_MS) {
+      // Already reloaded for this URL moments ago and it still fails — a truly
+      // broken deploy, not a stale tab. Stop so the error surfaces instead of
+      // looping. Clear the marker so a later, unrelated deploy can recover.
+      win.sessionStorage.removeItem(key);
+      return false;
+    }
+    win.sessionStorage.setItem(key, String(now));
+  } catch {
+    // sessionStorage unavailable (private mode) — reload once anyway.
+  }
+
+  win.location.assign(url);
+  return true;
+}


### PR DESCRIPTION
Closes #159.

## Summary

Domain modules under `/app` are lazy-loaded as content-hashed chunks. When a deploy replaces the build, a tab opened *before* the deploy still holds the old chunk map: navigating to a not-yet-visited module requests an old chunk filename that now 404s, the dynamic import rejects, and the router **silently aborts the navigation** — the click appears to do nothing. (This was the "homepage links to billing/people/location are broken" report; a hard refresh fixed it.)

- **`src/app/core/router/chunk-error-recovery.ts`** — `isChunkLoadError()` matches the dynamic-import failure signatures each browser emits (Chromium/Firefox/Safari + webpack-style `ChunkLoadError`) and walks a wrapped `error.cause`. `recoverFromChunkError()` full-page-loads the attempted URL so the tab picks up the fresh `index` + chunk map and completes the navigation.
- **`src/app/app.config.ts`** — wire it via `withNavigationErrorHandler`, guarded by `isPlatformBrowser` so it's a no-op during SSR. A second browser-only app initializer clears the guard on the first successful navigation after each load. Non-chunk navigation errors propagate unchanged.

### Loop safety (hardened after review)

A broken deploy must never reload forever. The guard is:

- **Count-based, not time-based** — each URL is reloaded at most once, with a global cap (`MAX_RELOADS`) as a systemic-shared-chunk backstop. A time window could be exceeded by a slow re-bootstrap and defeat itself, so there is no timing dependency.
- **Fail-safe without storage** — if `sessionStorage` is blocked (private mode), we cannot distinguish a first attempt from a loop, so we do **not** reload (a dead click the user can refresh, never an infinite loop).
- **Self-healing** — the budget resets on the first successful navigation after each load, so a healthy tab always gets fresh recovery while a permanently-broken deploy stops after the cap.

## Validation

- [x] `npm run build` (clean)
- [x] Unit spec — 11 tests: per-browser detection, `error.cause` walking, reload, same-URL loop protection, global cap, sessionStorage-blocked fail-safe, post-clear recovery, empty-URL fallback
- [x] Full suite: 1685 tests pass
- [x] Boot smoke: served the production build and confirmed the app bootstraps and routes render normally with both initializers + the handler installed

## Accessibility Verification (Required for Changed UI)

No UI changes — router error-recovery wiring only; no template, control, or content changes. Accessibility checklist is N/A.

## Notes / Follow-ups

- Recovery is scoped to chunk-load failures; other navigation errors propagate unchanged.
- The guard uses `sessionStorage` (tab-scoped) and is reset on healthy navigation rather than by any time window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJFQPVWHnzg5YFL82jMLkT