### PR TITLE
Attach JWT to tus bulk-upload requests

### DIFF
--- a/src/app/features/bulk-import/services/bulk-import.service.spec.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.spec.ts
@@ -26,7 +26,9 @@ describe('BulkImportService', () => {
   let bulkLoadJobsServiceClass: typeof import('@durion-sdk/bulk-loader').BulkLoadJobsAPIService;
   let columnMappingServiceClass: typeof import('@durion-sdk/bulk-loader').ColumnMappingAPIService;
   let reviewQueueServiceClass: typeof import('@durion-sdk/bulk-loader').ReviewQueueAPIService;
+  let authServiceClass: typeof import('../../../core/services/auth.service').AuthService;
   const apiStub = { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() };
+  const authStub = { accessToken: vi.fn<() => string | null>(() => 'test-jwt') };
   const bulkLoadJobsStub = { createJob: vi.fn(), getJob: vi.fn(), listJobs: vi.fn(), cancelJob: vi.fn(), retryJob: vi.fn() };
   const columnMappingStub = { getMappings: vi.fn(), approveMappings: vi.fn() };
   const reviewQueueStub = { getAuditRecords: vi.fn(), downloadErrorReport: vi.fn(), submitCorrections: vi.fn() };
@@ -53,8 +55,11 @@ describe('BulkImportService', () => {
       },
     }));
 
+    authStub.accessToken.mockReset().mockReturnValue('test-jwt');
+
     ({ BulkImportService: bulkImportServiceClass } = await import('./bulk-import.service'));
     ({ ApiBaseService: apiBaseServiceToken } = await import('../../../core/services/api-base.service'));
+    ({ AuthService: authServiceClass } = await import('../../../core/services/auth.service'));
     ({
       BulkLoadJobsAPIService: bulkLoadJobsServiceClass,
       ColumnMappingAPIService: columnMappingServiceClass,
@@ -65,6 +70,7 @@ describe('BulkImportService', () => {
       providers: [
         bulkImportServiceClass,
         { provide: apiBaseServiceToken, useValue: apiStub },
+        { provide: authServiceClass, useValue: authStub },
         { provide: bulkLoadJobsServiceClass, useValue: bulkLoadJobsStub },
         { provide: columnMappingServiceClass, useValue: columnMappingStub },
         { provide: reviewQueueServiceClass, useValue: reviewQueueStub },
@@ -416,6 +422,36 @@ describe('BulkImportService', () => {
 
       expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: 'https://upload.example/files/abc' });
       expect(tusState.start).toHaveBeenCalled();
+    });
+
+    it('attaches the current JWT to every tus request via onBeforeRequest', () => {
+      const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
+      service.uploadFile('https://upload.example', file).subscribe();
+
+      const onBeforeRequest = tusState.instances[0].options['onBeforeRequest'] as
+        ((req: { setHeader(name: string, value: string): void }) => void);
+      const setHeader = vi.fn();
+      onBeforeRequest({ setHeader });
+
+      expect(setHeader).toHaveBeenCalledWith('Authorization', 'Bearer test-jwt');
+
+      // A refreshed token is picked up on the next request.
+      authStub.accessToken.mockReturnValue('refreshed-jwt');
+      onBeforeRequest({ setHeader });
+      expect(setHeader).toHaveBeenLastCalledWith('Authorization', 'Bearer refreshed-jwt');
+    });
+
+    it('sends no Authorization header when there is no token', () => {
+      authStub.accessToken.mockReturnValue(null);
+      const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
+      service.uploadFile('https://upload.example', file).subscribe();
+
+      const onBeforeRequest = tusState.instances[0].options['onBeforeRequest'] as
+        ((req: { setHeader(name: string, value: string): void }) => void);
+      const setHeader = vi.fn();
+      onBeforeRequest({ setHeader });
+
+      expect(setHeader).not.toHaveBeenCalled();
     });
 
     it('aborts upload on unsubscribe', () => {

--- a/src/app/features/bulk-import/services/bulk-import.service.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@durion-sdk/bulk-loader';
 import type { AuditRecordResponse, BulkLoadJobCreateRequest, BulkLoadJobResponse } from '@durion-sdk/bulk-loader';
 import { ApiBaseService } from '../../../core/services/api-base.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { environment } from '../../../../environments/environment';
 import {
   ACTIVE_JOB_STATUSES,
@@ -72,6 +73,7 @@ const API_TO_FRONTEND_DOMAIN_TYPE: Record<ApiDomainType, DomainType> = {
 @Injectable({ providedIn: 'root' })
 export class BulkImportService {
   private readonly api = inject(ApiBaseService);
+  private readonly auth = inject(AuthService);
   private readonly bulkLoadJobsService = inject(BulkLoadJobsAPIService);
   private readonly columnMappingService = inject(ColumnMappingAPIService);
   private readonly reviewQueueService = inject(ReviewQueueAPIService);
@@ -193,6 +195,15 @@ export class BulkImportService {
         },
         removeFingerprintOnSuccess: true,
         retryDelays: [0, 1000, 3000, 5000],
+        // tus-js-client issues its own XHRs, bypassing authInterceptor, so the
+        // gateway rejects /bulk-loader/** with 401 unless the JWT is attached
+        // here. Read the token per request so retries pick up a refreshed one.
+        onBeforeRequest: req => {
+          const token = this.auth.accessToken();
+          if (token) {
+            req.setHeader('Authorization', `Bearer ${token}`);
+          }
+        },
         onProgress: (bytesSent, bytesTotal) => {
           if (bytesTotal > 0) {
             observer.next(Math.round((bytesSent / bytesTotal) * 100));


### PR DESCRIPTION
tus-js-client issues its own XHRs, so the Angular authInterceptor never runs for TUS uploads and the gateway rejected /bulk-loader/** POSTs with 401 (Missing Authorization header) even for a logged-in admin.

Attach the bearer token in onBeforeRequest, reading it from AuthService on every request so mid-upload retries pick up a silently refreshed token instead of replaying an expired one.


Claude-Session: https://claude.ai/code/session_019mFgTtEZkmAw3Htj8vUskR

## Summary

- Describe what changed and why.

## Validation

- [ ] `npm run build`
- [ ] `npm run test` (or relevant targeted tests)

## Accessibility Verification (Required for Changed UI)

- [ ] Keyboard smoke verified on each changed feature page:
- [ ] All interactive controls reachable using `Tab`/`Shift+Tab`
- [ ] Visible focus indicator present on focused controls
- [ ] No keyboard traps encountered
- [ ] Primary user flow completes without pointer input
- [ ] Screen-reader smoke verified (NVDA or VoiceOver) on each changed feature page:
- [ ] Page heading/structure is announced predictably
- [ ] Form labels and validation errors are announced correctly
- [ ] Status/error updates are announced when state changes

## Notes / Follow-ups

- Link any deferred issues with owner + due date.
