### PR TITLE
Fix tus upload URL resolution and spurious terminate DELETE

### DIFF
--- a/src/app/features/bulk-import/services/bulk-import.service.spec.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.spec.ts
@@ -406,15 +406,49 @@ describe('BulkImportService', () => {
       onSuccess();
 
       expect(instance.file).toBe(file);
-      expect(instance.options['endpoint']).toBe('https://upload.example');
+      expect(instance.options['endpoint']).toBe('https://upload.example/');
       expect(instance.options['metadata']).toEqual({ filename: 'test.csv' });
       expect(tusState.start).toHaveBeenCalled();
       expect(progress).toEqual([50, 100]);
       expect(completed).toBe(true);
     });
 
+    it('absolutizes a path-only endpoint against the page origin', () => {
+      const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
+      service.uploadFile('/api/bulk-loader/v1/bulk-jobs/job-001/tus', file).subscribe();
+
+      expect(tusState.instances[0].options['endpoint'])
+        .toBe(`${window.location.origin}/api/bulk-loader/v1/bulk-jobs/job-001/tus`);
+    });
+
+    it('does not terminate the upload when it completes or errors', () => {
+      const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
+
+      service.uploadFile('https://upload.example', file).subscribe();
+      (tusState.instances[0].options['onSuccess'] as () => void)();
+
+      service.uploadFile('https://upload.example', file).subscribe({ error: () => undefined });
+      (tusState.instances[1].options['onError'] as (error: Error) => void)(new Error('boom'));
+
+      expect(tusState.abort).not.toHaveBeenCalled();
+    });
+
     it('resumes from a previous tus upload when one exists', async () => {
       tusState.findPreviousUploads.mockResolvedValueOnce([{ uploadUrl: 'https://upload.example/files/abc' }]);
+      const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
+
+      service.uploadFile('https://upload.example', file).subscribe();
+      await Promise.resolve();
+
+      expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: 'https://upload.example/files/abc' });
+      expect(tusState.start).toHaveBeenCalled();
+    });
+
+    it('ignores previous uploads whose stored URL is not absolute', async () => {
+      tusState.findPreviousUploads.mockResolvedValueOnce([
+        { uploadUrl: '../../tus/019f4010' },
+        { uploadUrl: 'https://upload.example/files/abc' },
+      ]);
       const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
 
       service.uploadFile('https://upload.example', file).subscribe();

--- a/src/app/features/bulk-import/services/bulk-import.service.spec.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.spec.ts
@@ -433,28 +433,32 @@ describe('BulkImportService', () => {
       expect(tusState.abort).not.toHaveBeenCalled();
     });
 
-    it('resumes from a previous tus upload when one exists', async () => {
-      tusState.findPreviousUploads.mockResolvedValueOnce([{ uploadUrl: 'https://upload.example/files/abc' }]);
+    it('resumes from a previous tus upload stored under the API base', async () => {
+      const storedUrl = `${window.location.origin}/api/bulk-loader/v1/tus/abc`;
+      tusState.findPreviousUploads.mockResolvedValueOnce([{ uploadUrl: storedUrl }]);
       const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
 
-      service.uploadFile('https://upload.example', file).subscribe();
+      service.uploadFile('/api/bulk-loader/v1/bulk-jobs/job-001/tus', file).subscribe();
       await Promise.resolve();
 
-      expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: 'https://upload.example/files/abc' });
+      expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: storedUrl });
       expect(tusState.start).toHaveBeenCalled();
     });
 
-    it('ignores previous uploads whose stored URL is not absolute', async () => {
+    it('ignores previous uploads whose stored URL is relative, foreign, or outside the API base', async () => {
+      const trustedUrl = `${window.location.origin}/api/bulk-loader/v1/tus/abc`;
       tusState.findPreviousUploads.mockResolvedValueOnce([
         { uploadUrl: '../../tus/019f4010' },
-        { uploadUrl: 'https://upload.example/files/abc' },
+        { uploadUrl: 'https://evil.example/api/bulk-loader/v1/tus/abc' },
+        { uploadUrl: `${window.location.origin}/tus/abc` },
+        { uploadUrl: trustedUrl },
       ]);
       const file = new File(['a,b'], 'test.csv', { type: 'text/csv' });
 
-      service.uploadFile('https://upload.example', file).subscribe();
+      service.uploadFile('/api/bulk-loader/v1/bulk-jobs/job-001/tus', file).subscribe();
       await Promise.resolve();
 
-      expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: 'https://upload.example/files/abc' });
+      expect(tusState.resumeFromPreviousUpload).toHaveBeenCalledWith({ uploadUrl: trustedUrl });
       expect(tusState.start).toHaveBeenCalled();
     });
 

--- a/src/app/features/bulk-import/services/bulk-import.service.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.ts
@@ -237,23 +237,9 @@ export class BulkImportService {
             return;
           }
 
-          // Stored upload URLs are replayed verbatim by tus-js-client; skip
-          // entries without an absolute URL (persisted by builds that used a
-          // relative endpoint) or the browser resolves them against the page
-          // URL and the SPA fallback answers instead of the API.
-const endpointUrl = new URL(endpoint);
-const endpointPathPrefix = endpointUrl.pathname.endsWith('/') ? endpointUrl.pathname : `${endpointUrl.pathname}/`;
-const resumable = previousUploads.find(prev => {
-  try {
-    const url = new URL(prev.uploadUrl ?? '');
-    return url.origin === endpointUrl.origin && url.pathname.startsWith(endpointPathPrefix);
-  } catch {
-    return false;
-  }
-});
-if (resumable) {
-  upload.resumeFromPreviousUpload(resumable);
-}
+          const resumable = previousUploads.find(prev => this.isTrustedUploadUrl(prev.uploadUrl));
+          if (resumable) {
+            upload.resumeFromPreviousUpload(resumable);
           }
 
           upload.start();
@@ -333,6 +319,30 @@ if (resumable) {
 
   private buildTusUploadEndpoint(jobId: string): string {
     return `${environment.apiBaseUrl}/bulk-loader/v1/bulk-jobs/${encodeURIComponent(jobId)}/tus`;
+  }
+
+  /**
+   * Accepts only stored tus upload URLs on our API origin under the apiBaseUrl
+   * path. tus-js-client replays stored URLs verbatim and onBeforeRequest
+   * attaches the JWT to whatever URL it targets, so a foreign or relative URL
+   * persisted in localStorage must never be resumed. The check is anchored to
+   * apiBaseUrl (not the creation endpoint's full path) because the backend
+   * issues upload URLs under /bulk-loader/v1/tus/, outside the endpoint path.
+   */
+  private isTrustedUploadUrl(uploadUrl: string | null | undefined): boolean {
+    if (!uploadUrl) {
+      return false;
+    }
+
+    const apiBase = new URL(environment.apiBaseUrl, window.location.origin);
+    const apiPathPrefix = apiBase.pathname.endsWith('/') ? apiBase.pathname : `${apiBase.pathname}/`;
+
+    try {
+      const url = new URL(uploadUrl);
+      return url.origin === apiBase.origin && url.pathname.startsWith(apiPathPrefix);
+    } catch {
+      return false;
+    }
   }
 
   private toJobStatus(status: string): BulkLoadJob['status'] {

--- a/src/app/features/bulk-import/services/bulk-import.service.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.ts
@@ -241,9 +241,19 @@ export class BulkImportService {
           // entries without an absolute URL (persisted by builds that used a
           // relative endpoint) or the browser resolves them against the page
           // URL and the SPA fallback answers instead of the API.
-          const resumable = previousUploads.find(prev => URL.canParse(prev.uploadUrl ?? ''));
-          if (resumable) {
-            upload.resumeFromPreviousUpload(resumable);
+const endpointUrl = new URL(endpoint);
+const endpointPathPrefix = endpointUrl.pathname.endsWith('/') ? endpointUrl.pathname : `${endpointUrl.pathname}/`;
+const resumable = previousUploads.find(prev => {
+  try {
+    const url = new URL(prev.uploadUrl ?? '');
+    return url.origin === endpointUrl.origin && url.pathname.startsWith(endpointPathPrefix);
+  } catch {
+    return false;
+  }
+});
+if (resumable) {
+  upload.resumeFromPreviousUpload(resumable);
+}
           }
 
           upload.start();

--- a/src/app/features/bulk-import/services/bulk-import.service.ts
+++ b/src/app/features/bulk-import/services/bulk-import.service.ts
@@ -188,8 +188,17 @@ export class BulkImportService {
    */
   uploadFile(uploadUrl: string, file: File): Observable<number> {
     return new Observable<number>(observer => {
+      // tus-js-client resolves the creation response's Location header via
+      // `new URL(location, endpoint)`, which throws when the endpoint is a
+      // bare path like `/api/...` and the backend sends a relative Location.
+      const endpoint = new URL(uploadUrl, window.location.origin).toString();
+
+      // Tracks whether the upload reached a terminal state (success/error) so
+      // the teardown below only terminates genuinely cancelled uploads.
+      let isSettled = false;
+
       const upload = new Upload(file, {
-        endpoint: uploadUrl,
+        endpoint,
         metadata: {
           filename: file.name,
         },
@@ -210,10 +219,12 @@ export class BulkImportService {
           }
         },
         onSuccess: () => {
+          isSettled = true;
           observer.next(100);
           observer.complete();
         },
         onError: error => {
+          isSettled = true;
           observer.error(error);
         },
       });
@@ -226,8 +237,13 @@ export class BulkImportService {
             return;
           }
 
-          if (previousUploads.length > 0) {
-            upload.resumeFromPreviousUpload(previousUploads[0]);
+          // Stored upload URLs are replayed verbatim by tus-js-client; skip
+          // entries without an absolute URL (persisted by builds that used a
+          // relative endpoint) or the browser resolves them against the page
+          // URL and the SPA fallback answers instead of the API.
+          const resumable = previousUploads.find(prev => URL.canParse(prev.uploadUrl ?? ''));
+          if (resumable) {
+            upload.resumeFromPreviousUpload(resumable);
           }
 
           upload.start();
@@ -240,7 +256,14 @@ export class BulkImportService {
 
       return () => {
         isDisposed = true;
-        void upload.abort(true);
+        // Teardown also runs after complete/error; only an unsettled upload
+        // is a cancellation that should delete the partial upload server-side.
+        if (!isSettled) {
+          upload.abort(true).catch(() => {
+            // Best-effort cleanup; a failed DELETE must not become an
+            // unhandled rejection.
+          });
+        }
       };
     });
   }


### PR DESCRIPTION
## Summary

Follow-up to #(auth-header fix): once TUS uploads got past gateway auth, they failed right after the creation POST with `tus: unexpected response while terminating upload (method: DELETE, url: ../../tus/<id>, response code: 200, response text: <!doctype html>...)`. Three defects in `BulkImportService.uploadFile()` combined to cause this:

- **Relative endpoint breaks tus URL resolution.** The backend answers the tus creation POST with a relative `Location` header (`../../tus/<id>`), and tus-js-client 4.x resolves it via `new URL(location, endpoint)` — which throws when the endpoint is a bare path (`apiBaseUrl` is `/api`). The endpoint is now absolutized against `window.location.origin`, so `Location` resolves to `https://<host>/api/bulk-loader/v1/tus/<id>` per RFC 3986.
- **Stale resume entries replayed a broken URL.** tus stores upload URLs in localStorage by file fingerprint, and `resumeFromPreviousUpload` replays them verbatim. A relative URL persisted by an earlier broken attempt resolved against the *page* URL, hit the SPA fallback, and got `index.html` with HTTP 200. Stored entries without an absolute URL are now skipped.
- **Finished uploads were being terminated.** The Observable teardown runs on complete/error too, not just cancellation, so `upload.abort(true)` sent a terminate DELETE after every settled upload (on success it could delete the just-uploaded file), and the `void`-ed promise surfaced as an unhandled rejection. Teardown now terminates only genuinely cancelled uploads and swallows cleanup failures.

**To watch after deploy:** PATCH/HEAD requests now go to the correctly resolved `/api/bulk-loader/v1/tus/<id>`. If the gateway only routes `/bulk-loader/v1/bulk-jobs/**`, that's a gateway routing / backend `Location` issue to fix server-side.

## Validation

- [x] `npm run build`
- [x] `npm run test` — bulk-import suite 98/98 passing (3 new specs: endpoint absolutization, skipping non-absolute stored resume URLs, no terminate after complete/error); `tsc --noEmit` clean for app and spec projects

## Accessibility Verification (Required for Changed UI)

- N/A — service-only change (`bulk-import.service.ts` + spec); no UI/template/style changes.

## Notes / Follow-ups

- If gateway logs show 404s on `/bulk-loader/v1/tus/**` after this deploys, the backend should return an absolute (or gateway-routable) `Location` header from the tus creation endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mFgTtEZkmAw3Htj8vUskR

---
_Generated by [Claude Code](https://claude.ai/code/session_019mFgTtEZkmAw3Htj8vUskR)_