### PR TITLE
Remove unused ShopAPIService dependency from AppointmentService

### DIFF
--- a/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.spec.ts
+++ b/src/app/features/shopmgmt/pages/appointment-create-crm/appointment-create-crm-page.component.spec.ts
@@ -42,7 +42,6 @@ const appointmentServiceStub = {
   createAppointment: vi.fn(),
   executeOverride: vi.fn(),
   viewSchedule: vi.fn(),
-  getShopServiceDetails: vi.fn(),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.spec.ts
+++ b/src/app/features/shopmgmt/pages/appointment-edit/appointment-edit-page.component.spec.ts
@@ -72,7 +72,6 @@ const appointmentServiceStub = {
   createAppointment: vi.fn(),
   executeOverride: vi.fn(),
   viewSchedule: vi.fn(),
-  getShopServiceDetails: vi.fn(),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.spec.ts
+++ b/src/app/features/shopmgmt/pages/schedule-view/schedule-view-page.component.spec.ts
@@ -61,7 +61,6 @@ const appointmentServiceStub = {
   createAppointment: vi.fn(),
   executeOverride: vi.fn(),
   viewSchedule: vi.fn(),
-  getShopServiceDetails: vi.fn(),
 };
 
 // ---------------------------------------------------------------------------

--- a/src/app/features/shopmgmt/services/appointment.service.spec.ts
+++ b/src/app/features/shopmgmt/services/appointment.service.spec.ts
@@ -10,7 +10,6 @@ import {
   AppointmentAssignmentsService,
   ConflictOverrideAPIService,
   ScheduleAPIService,
-  ShopAPIService,
   ShopAuditService,
 } from '@durion-sdk/shop-manager';
 
@@ -57,7 +56,6 @@ const appointmentsStub = {
 const assignmentStub = { listAssignments: vi.fn(), createAssignment: vi.fn() };
 const conflictOverrideStub = { executeOverride: vi.fn() };
 const scheduleStub = { viewSchedule: vi.fn() };
-const shopStub = { getShopServiceDetails: vi.fn() };
 const shopAuditStub = { searchShopAudit: vi.fn() };
 
 // ---------------------------------------------------------------------------
@@ -85,7 +83,6 @@ describe('AppointmentService [CAP-249]', () => {
         { provide: AppointmentAssignmentsService, useValue: assignmentStub },
         { provide: ConflictOverrideAPIService, useValue: conflictOverrideStub },
         { provide: ScheduleAPIService, useValue: scheduleStub },
-        { provide: ShopAPIService, useValue: shopStub },
         { provide: ShopAuditService, useValue: shopAuditStub },
       ],
     });

--- a/src/app/features/shopmgmt/services/appointment.service.ts
+++ b/src/app/features/shopmgmt/services/appointment.service.ts
@@ -7,7 +7,6 @@ import {
   ConflictOverrideAPIService,
   MechanicAssignmentItemRoleEnum,
   ScheduleAPIService,
-  ShopAPIService,
   ShopAuditService,
 } from '@durion-sdk/shop-manager';
 import type {
@@ -32,7 +31,6 @@ export class AppointmentService {
   private readonly assignment = inject(AppointmentAssignmentsService);
   private readonly conflictOverride = inject(ConflictOverrideAPIService);
   private readonly schedule = inject(ScheduleAPIService);
-  private readonly shop = inject(ShopAPIService);
   private readonly shopAudit = inject(ShopAuditService);
 
   getAppointment(appointmentId: string): Observable<AppointmentDetail> {
@@ -111,10 +109,6 @@ export class AppointmentService {
       notes: body.notes,
     };
     return this.appointments.cancelAppointment(appointmentId, sdkRequest) as unknown as Observable<AppointmentDetail>;
-  }
-
-  getShopServiceDetails(locationId: string, serviceId: string): Observable<unknown> {
-    return this.shop.getShopServiceDetails(locationId, serviceId) as Observable<unknown>;
   }
 
   viewSchedule(locationId: string, date: string, resourceType?: string, resourceId?: string): Observable<unknown> {


### PR DESCRIPTION
## Summary

Removed the unused `ShopAPIService` dependency and its associated `getShopServiceDetails()` method from `AppointmentService`. This method was injected but never called anywhere in the codebase, making it safe to remove as dead code.

**Changes:**
- Removed `ShopAPIService` import from `appointment.service.ts`
- Removed `shop` service injection from `AppointmentService`
- Removed unused `getShopServiceDetails(locationId, serviceId)` method
- Updated test stubs in `appointment.service.spec.ts` and three component spec files to remove references to the deleted method

## Validation

- [ ] `npm run build`
- [ ] `npm run test` (or relevant targeted tests)

## Notes

This is a straightforward cleanup of dead code with no functional impact. All references to the removed method have been cleaned up from test files.

https://claude.ai/code/session_01NjK8AxWffAgUxFRn2pWmn1